### PR TITLE
Multiple language support for quests

### DIFF
--- a/config/ftbquests/quests/chapters/adventurer.snbt
+++ b/config/ftbquests/quests/chapters/adventurer.snbt
@@ -1,36 +1,37 @@
 {
-	id: "4F80AA2EB0DCC10C"
-	group: "1039AC171AB01709"
-	order_index: 4
-	filename: "adventurer"
-	title: "Adventurer"
-	icon: "twilightforest:twilight_portal_miniature_structure"
-	default_quest_shape: ""
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "1039AC171AB01709"
+	id: "4F80AA2EB0DCC10C"
+	filename: "adventurer"
+	default_quest_shape: ""
+	icon: "twilightforest:twilight_portal_miniature_structure"
+	title: "Adventurer"
+	order_index: 4
 	quests: [
 		{
-			title: "Adventures and Mysteries"
-			x: -0.5d
-			y: -0.5d
-			subtitle: "If we were meant to stay in one place, we’d have roots instead of feet."
-			id: "6EC4700B21DB617B"
 			tasks: [{
 				id: "40FC0E99020D1BB4"
 				type: "checkmark"
 			}]
+			subtitle: "If we were meant to stay in one place, we’d have roots instead of feet."
+			id: "6EC4700B21DB617B"
+			y: -0.5d
+			x: -0.5d
+			title: "Adventures and Mysteries"
 		}
 		{
-			title: "Fishes and Crates!"
-			icon: {
-				id: "gofish:celestial_rod"
-				Count: 1b
-				tag: {
-					Damage: 0
+			tasks: [{
+				id: "52BEAE23DF485E51"
+				type: "item"
+				item: {
+					id: "itemfilters:mod"
+					Count: 1b
+					tag: {
+						value: "gofish"
+					}
 				}
-			}
-			x: -1.5d
-			y: 0.5d
-			subtitle: "Fishing should be fun."
+			}]
 			description: [
 				"Go Fish adds in general Fish, which are obtainable globally in any area for each dimension, and biome-specific Fish, which are only obtainable in certain areas (See below)."
 				""
@@ -68,53 +69,54 @@
 				"The End:"
 				"- Baked Endfish"
 			]
-			dependencies: ["6EC4700B21DB617B"]
 			id: "1941554F8883F5BE"
-			tasks: [{
-				id: "52BEAE23DF485E51"
-				type: "item"
-				item: {
-					id: "itemfilters:mod"
-					Count: 1b
-					tag: {
-						value: "gofish"
-					}
+			icon: {
+				id: "gofish:celestial_rod"
+				Count: 1b
+				tag: {
+					Damage: 0
 				}
-			}]
+			}
+			x: -1.5d
+			y: 0.5d
+			title: "Fishes and Crates!"
 			rewards: [{
 				id: "69D9C7A4DDC5D916"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Fishing should be fun."
+			dependencies: ["6EC4700B21DB617B"]
 		}
 		{
-			title: "Waystones"
-			x: 0.5d
-			y: 0.5d
-			subtitle: "Craft your first Waystone!"
-			description: ["You can use them for interdimensional teleportation between Waystones. Costs 1 XP Level to teleport."]
-			dependencies: ["6EC4700B21DB617B"]
-			id: "23C3589FAFB40AD5"
 			tasks: [{
-				id: "73C759A163CEAEE8"
 				type: "observation"
-				icon: "fwaystones:waystone"
 				timer: 0L
 				observe_type: 0
+				id: "73C759A163CEAEE8"
+				icon: "fwaystones:waystone"
 				to_observe: "fwaystones:waystone"
 			}]
+			description: ["You can use them for interdimensional teleportation between Waystones. Costs 1 XP Level to teleport."]
+			id: "23C3589FAFB40AD5"
+			x: 0.5d
+			y: 0.5d
+			title: "Waystones"
 			rewards: [{
 				id: "7E79E623D0CD9F54"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Craft your first Waystone!"
+			dependencies: ["6EC4700B21DB617B"]
 		}
 		{
-			title: "The Twilight Forest"
-			icon: "twilightforest:twilight_portal_miniature_structure"
-			x: -0.5d
-			y: -2.5d
-			subtitle: "Step into the Twilight Realm!"
+			tasks: [{
+				id: "64630338E7F2207F"
+				type: "dimension"
+				icon: "twilightforest:twilight_portal_miniature_structure"
+				dimension: "twilightforest:twilight_forest"
+			}]
 			description: [
 				"To make a portal from the Eden Ring to the Twilight Forest, build a 2x2 pool of water and souround it with flowers. To ignit it, drop a diamond in the pool."
 				""
@@ -122,71 +124,72 @@
 				""
 				"Twilight Forest is a dimension exploration mod focused on adventure that will take you on a journey to meet strange creatures, exploring dungeons, and much more."
 			]
-			dependencies: ["07C43FD476A6AB1C"]
 			id: "36D37A1AFFC1B369"
-			tasks: [{
-				id: "64630338E7F2207F"
-				type: "dimension"
-				icon: "twilightforest:twilight_portal_miniature_structure"
-				dimension: "twilightforest:twilight_forest"
-			}]
+			icon: "twilightforest:twilight_portal_miniature_structure"
+			x: -0.5d
+			y: -2.5d
+			title: "The Twilight Forest"
 			rewards: [{
 				id: "0C0869CB6A2C4E9F"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Step into the Twilight Realm!"
+			dependencies: ["07C43FD476A6AB1C"]
 		}
 		{
-			title: "Eden Ring"
-			icon: "edenring:guide_book"
-			x: -0.5d
-			y: -1.5d
-			description: [
-				"To build portal you need 12 waxed copper blocks, 12 waxed cut copper stairs, 4 block of amethyst, 4 amethyst clusters, 1 gold block and 1 flint and steel. To make portal you need to recreate structure from picture below, and to activate it you need to fire central gold block with flint and steel."
-				"{image:kubejs:textures/item/eden_portal.png width:100 height:100 align:1}"
-			]
-			dependencies: ["6EC4700B21DB617B"]
-			id: "07C43FD476A6AB1C"
 			tasks: [{
 				id: "62E94367F808EC8B"
 				type: "dimension"
 				icon: "edenring:guide_book"
 				dimension: "edenring:edenring"
 			}]
+			description: [
+				"To build portal you need 12 waxed copper blocks, 12 waxed cut copper stairs, 4 block of amethyst, 4 amethyst clusters, 1 gold block and 1 flint and steel. To make portal you need to recreate structure from picture below, and to activate it you need to fire central gold block with flint and steel."
+				"{image:kubejs:textures/item/eden_portal.png width:100 height:100 align:1}"
+			]
+			icon: "edenring:guide_book"
+			id: "07C43FD476A6AB1C"
+			x: -0.5d
+			y: -1.5d
+			title: "Eden Ring"
 			rewards: [{
 				id: "27B7DB469610DA03"
 				type: "item"
 				item: "edenring:guide_book"
 			}]
+			dependencies: ["6EC4700B21DB617B"]
 		}
 		{
-			title: "Sky Islands Dimension?"
-			x: -0.5d
-			y: -3.5d
-			description: [
-				"Build the Portal Frame with Gravilite Blocks, and ignite the portal with a Maze Map Focus!"
-				""
-				"In this dimension you can discover many Biomes and Strucutres."
-			]
-			dependencies: ["36D37A1AFFC1B369"]
-			id: "43709A95E106563B"
 			tasks: [{
 				id: "5B4FF07511C0CD65"
 				type: "dimension"
 				icon: "soaringstructures2:soaring_island_pixels"
 				dimension: "sf3:void"
 			}]
+			description: [
+				"Build the Portal Frame with Gravilite Blocks, and ignite the portal with a Maze Map Focus!"
+				""
+				"In this dimension you can discover many Biomes and Strucutres."
+			]
+			id: "43709A95E106563B"
+			x: -0.5d
+			y: -3.5d
+			title: "Sky Islands Dimension?"
 			rewards: [{
 				id: "5D34D1245BE18BBB"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["36D37A1AFFC1B369"]
 		}
 		{
-			title: "The End, but not really!"
-			icon: "minecraft:end_portal_frame"
-			x: -0.5d
-			y: -4.5d
+			tasks: [{
+				id: "56BA1F2EB64D3CC4"
+				type: "dimension"
+				icon: "minecraft:end_portal_frame"
+				dimension: "minecraft:the_end"
+			}]
 			description: [
 				"Try to find the Stronghold in the Sky-Islands Dimension."
 				""
@@ -195,41 +198,34 @@
 				"Use REI to check which loot tables or mob drops contain the Eyes."
 				"You can craft some. But most Eyes are obtainable by looting some chests in the Sky Islands Dimension."
 			]
-			dependencies: ["43709A95E106563B"]
+			icon: "minecraft:end_portal_frame"
 			id: "3D5E0F53E4BAAA72"
-			tasks: [{
-				id: "56BA1F2EB64D3CC4"
-				type: "dimension"
-				icon: "minecraft:end_portal_frame"
-				dimension: "minecraft:the_end"
-			}]
+			x: -0.5d
+			y: -4.5d
+			title: "The End, but not really!"
 			rewards: [{
 				id: "7FA8A6CFD1E3BAD2"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["43709A95E106563B"]
 		}
 		{
-			x: 0.5d
-			y: -2.5d
+			tasks: [{
+				id: "51E544D7CF41D801"
+				type: "checkmark"
+				title: "Where is the Loot?"
+			}]
 			description: [
 				"Most Twilight Bosses spawn a chest after defeating them."
 				"If there is no floor under the boss, make sure to fly down to the bottom of the world, maybe you can find the chest there."
 			]
 			dependencies: ["36D37A1AFFC1B369"]
 			id: "6FA54248C69DFAB2"
-			tasks: [{
-				id: "51E544D7CF41D801"
-				type: "checkmark"
-				title: "Where is the Loot?"
-			}]
+			y: -2.5d
+			x: 0.5d
 		}
 		{
-			title: "Twilight Trophies"
-			x: -1.5d
-			y: -2.5d
-			dependencies: ["36D37A1AFFC1B369"]
-			id: "3687E7A9DCCB297C"
 			tasks: [
 				{
 					id: "75384D2AEA6EF3AD"
@@ -277,6 +273,10 @@
 					item: "twilightforest:quest_ram_trophy"
 				}
 			]
+			id: "3687E7A9DCCB297C"
+			x: -1.5d
+			y: -2.5d
+			title: "Twilight Trophies"
 			rewards: [
 				{
 					id: "1C8920CB87793372"
@@ -345,7 +345,7 @@
 					}
 				}
 			]
+			dependencies: ["36D37A1AFFC1B369"]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/agriculture.snbt
+++ b/config/ftbquests/quests/chapters/agriculture.snbt
@@ -1,24 +1,19 @@
 {
-	id: "5D25557A809CB5D3"
-	group: "76C22988F9A7C9CE"
-	order_index: 3
-	filename: "agriculture"
-	title: "Agriculture"
-	icon: "farmersdelight:cooking_pot"
-	default_quest_shape: ""
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "76C22988F9A7C9CE"
+	id: "5D25557A809CB5D3"
+	filename: "agriculture"
+	default_quest_shape: ""
+	icon: "farmersdelight:cooking_pot"
+	title: "Agriculture"
+	order_index: 3
 	quests: [
 		{
-			x: 3.0000000000000133d
-			y: -5.5d
-			hide: true
 			size: 1.5d
 			id: "79FAB4514365A883"
-			tasks: [{
-				id: "4842C735B5514CC6"
-				type: "item"
-				item: "croptopia:cooking_pot"
-			}]
+			x: 3.0000000000000133d
+			y: -5.5d
 			rewards: [
 				{
 					id: "6A49FC56516A31B5"
@@ -32,31 +27,32 @@
 					table_id: 13756307348121783L
 				}
 			]
+			hide: true
+			tasks: [{
+				id: "4842C735B5514CC6"
+				type: "item"
+				item: "croptopia:cooking_pot"
+			}]
 		}
 		{
-			x: 6.000000000000018d
-			y: -5.5d
-			hide: true
 			size: 1.5d
 			id: "5909DA5B9FAA0986"
-			tasks: [{
-				id: "77836333547427D0"
-				type: "item"
-				item: "croptopia:frying_pan"
-			}]
+			x: 6.000000000000018d
+			y: -5.5d
 			rewards: [{
 				id: "765D21FA414BCF8F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			hide: true
+			tasks: [{
+				id: "77836333547427D0"
+				type: "item"
+				item: "croptopia:frying_pan"
+			}]
 		}
 		{
-			title: "Burgers"
-			x: 6.500000000000018d
-			y: -7.0d
-			dependencies: ["5909DA5B9FAA0986"]
-			id: "2355C13D1A9CE59B"
 			tasks: [
 				{
 					id: "42C8C963FD5DE4DE"
@@ -74,22 +70,19 @@
 					item: "croptopia:tofuburger"
 				}
 			]
+			id: "2355C13D1A9CE59B"
+			x: 6.500000000000018d
+			y: -7.0d
+			title: "Burgers"
 			rewards: [{
 				id: "195CE818F45516DD"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["5909DA5B9FAA0986"]
 		}
 		{
-			title: "Pizzas"
-			x: 4.500000000000018d
-			y: -5.0d
-			dependencies: [
-				"5909DA5B9FAA0986"
-				"79FAB4514365A883"
-			]
-			id: "79B9AECC3CF1C907"
 			tasks: [
 				{
 					id: "3392738036037CF1"
@@ -112,22 +105,22 @@
 					item: "croptopia:pineapple_pepperoni_pizza"
 				}
 			]
+			id: "79B9AECC3CF1C907"
+			x: 4.500000000000018d
+			y: -5.0d
+			title: "Pizzas"
 			rewards: [{
 				id: "0C97C8B42FBC1266"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			title: "Pies"
-			x: 4.500000000000018d
-			y: -6.0d
 			dependencies: [
 				"5909DA5B9FAA0986"
 				"79FAB4514365A883"
 			]
-			id: "19ACDCCA81925E53"
+		}
+		{
 			tasks: [
 				{
 					id: "235DF45EFB137D11"
@@ -150,23 +143,31 @@
 					item: "croptopia:pecan_pie"
 				}
 			]
+			id: "19ACDCCA81925E53"
+			x: 4.500000000000018d
+			y: -6.0d
+			title: "Pies"
 			rewards: [{
 				id: "0471B88018BDCC80"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: [
+				"5909DA5B9FAA0986"
+				"79FAB4514365A883"
+			]
 		}
 		{
-			x: 7.500000000000018d
-			y: -5.0d
-			dependencies: ["5909DA5B9FAA0986"]
-			id: "5A0CC89B5976889C"
 			tasks: [{
 				id: "26E8C832524AF2F1"
 				type: "item"
 				item: "croptopia:tortilla"
 			}]
+			dependencies: ["5909DA5B9FAA0986"]
+			id: "5A0CC89B5976889C"
+			y: -5.0d
+			x: 7.500000000000018d
 			rewards: [{
 				id: "5BFBC0359D5C98BC"
 				type: "random"
@@ -175,10 +176,6 @@
 			}]
 		}
 		{
-			x: 6.000000000000018d
-			y: -4.0d
-			dependencies: ["5A0CC89B5976889C"]
-			id: "34FB2C66AF63E9A8"
 			tasks: [
 				{
 					id: "2017396D04E51076"
@@ -211,6 +208,10 @@
 					item: "croptopia:carnitas"
 				}
 			]
+			dependencies: ["5A0CC89B5976889C"]
+			id: "34FB2C66AF63E9A8"
+			y: -4.0d
+			x: 6.000000000000018d
 			rewards: [{
 				id: "2FA7D8FEFF227C92"
 				type: "random"
@@ -219,11 +220,6 @@
 			}]
 		}
 		{
-			title: "That's a healthy meal"
-			x: 7.500000000000018d
-			y: -6.0d
-			dependencies: ["5909DA5B9FAA0986"]
-			id: "70A9691AD95CF1F8"
 			tasks: [
 				{
 					id: "75E2F578D7D1C05B"
@@ -246,19 +242,19 @@
 					item: "croptopia:beef_wellington"
 				}
 			]
+			id: "70A9691AD95CF1F8"
+			x: 7.500000000000018d
+			y: -6.0d
+			title: "That's a healthy meal"
 			rewards: [{
 				id: "7CFFA84FBEB2799A"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["5909DA5B9FAA0986"]
 		}
 		{
-			title: "Roasted"
-			x: 5.500000000000018d
-			y: -7.0d
-			dependencies: ["5909DA5B9FAA0986"]
-			id: "71A3B30B0E630195"
 			tasks: [
 				{
 					id: "658E1327DFF63D19"
@@ -286,19 +282,19 @@
 					item: "croptopia:roasted_turnips"
 				}
 			]
+			id: "71A3B30B0E630195"
+			x: 5.500000000000018d
+			y: -7.0d
+			title: "Roasted"
 			rewards: [{
 				id: "4618D9D219FF398B"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["5909DA5B9FAA0986"]
 		}
 		{
-			title: "Ice Crime"
-			x: 3.5000000000000155d
-			y: -7.0d
-			dependencies: ["79FAB4514365A883"]
-			id: "67A10E02751BDEF3"
 			tasks: [
 				{
 					id: "52015737E2500F39"
@@ -331,19 +327,19 @@
 					item: "croptopia:pecan_ice_cream"
 				}
 			]
+			id: "67A10E02751BDEF3"
+			x: 3.5000000000000155d
+			y: -7.0d
+			title: "Ice Crime"
 			rewards: [{
 				id: "4D7DE629FFB4D70B"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["79FAB4514365A883"]
 		}
 		{
-			title: "That's my jam"
-			x: 2.500000000000011d
-			y: -7.0d
-			dependencies: ["79FAB4514365A883"]
-			id: "4B2932294F40EA83"
 			tasks: [
 				{
 					id: "38B3D880BE0704CD"
@@ -391,19 +387,19 @@
 					item: "croptopia:raspberry_jam"
 				}
 			]
+			id: "4B2932294F40EA83"
+			x: 2.500000000000011d
+			y: -7.0d
+			title: "That's my jam"
 			rewards: [{
 				id: "20A556E2DBA68A75"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["79FAB4514365A883"]
 		}
 		{
-			title: "Fries"
-			x: 1.5000000000000067d
-			y: -6.0d
-			dependencies: ["79FAB4514365A883"]
-			id: "20DC6E2C6131058F"
 			tasks: [
 				{
 					id: "4EDC362DACEA42AF"
@@ -416,23 +412,28 @@
 					item: "croptopia:sweet_potato_fries"
 				}
 			]
+			id: "20DC6E2C6131058F"
+			x: 1.5000000000000067d
+			y: -6.0d
+			title: "Fries"
 			rewards: [{
 				id: "15628D46A7BF7F85"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["79FAB4514365A883"]
 		}
 		{
-			x: 1.5000000000000067d
-			y: -5.0d
-			dependencies: ["79FAB4514365A883"]
-			id: "0F2777199D918181"
 			tasks: [{
 				id: "3ABA57E2E1463278"
 				type: "item"
 				item: "croptopia:butter"
 			}]
+			dependencies: ["79FAB4514365A883"]
+			id: "0F2777199D918181"
+			y: -5.0d
+			x: 1.5000000000000067d
 			rewards: [{
 				id: "499B7714083F2EC2"
 				type: "random"
@@ -441,11 +442,6 @@
 			}]
 		}
 		{
-			title: "Fatty, sweet desserts..."
-			x: 3.0000000000000067d
-			y: -4.0d
-			dependencies: ["0F2777199D918181"]
-			id: "1A6570EEFD2716C6"
 			tasks: [
 				{
 					id: "6D6E110F591E9F71"
@@ -468,18 +464,19 @@
 					item: "croptopia:lemon_coconut_bar"
 				}
 			]
+			id: "1A6570EEFD2716C6"
+			x: 3.0000000000000067d
+			y: -4.0d
+			title: "Fatty, sweet desserts..."
 			rewards: [{
 				id: "1669A05DE73AB27E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["0F2777199D918181"]
 		}
 		{
-			x: 1.5d
-			y: -1.7999999999999998d
-			hide: true
-			id: "1BBC7A6ADE8382B0"
 			tasks: [{
 				id: "56A3C980E541F0EF"
 				type: "item"
@@ -491,13 +488,12 @@
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			id: "1BBC7A6ADE8382B0"
+			y: -1.7999999999999998d
+			x: 1.5d
+			hide: true
 		}
 		{
-			title: "Cool Fertilizers"
-			x: 3.5d
-			y: -1.7999999999999998d
-			hide: true
-			id: "7B778677FF3566C9"
 			tasks: [
 				{
 					id: "52E1610BEBD5EC28"
@@ -515,18 +511,19 @@
 					item: "farmingforblockheads:yellow_fertilizer"
 				}
 			]
+			id: "7B778677FF3566C9"
+			x: 3.5d
+			y: -1.7999999999999998d
+			title: "Cool Fertilizers"
 			rewards: [{
 				id: "21B43C22AA9BBB64"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			hide: true
 		}
 		{
-			x: 0.5d
-			y: -12.0d
-			hide: true
-			id: "097E44CE2A686D2B"
 			tasks: [{
 				id: "44227CC75D99CEC9"
 				type: "item"
@@ -544,30 +541,30 @@
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			id: "097E44CE2A686D2B"
+			y: -12.0d
+			x: 0.5d
+			hide: true
 		}
 		{
-			x: 1.0d
-			y: -10.5d
-			dependencies: ["097E44CE2A686D2B"]
 			size: 1.5d
 			id: "7D916BB04FC8C26F"
-			tasks: [{
-				id: "63B5888B7CFDFF7A"
-				type: "item"
-				item: "farmersdelight:cutting_board"
-			}]
+			x: 1.0d
+			y: -10.5d
 			rewards: [{
 				id: "0C39D436D58127DF"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["097E44CE2A686D2B"]
+			tasks: [{
+				id: "63B5888B7CFDFF7A"
+				type: "item"
+				item: "farmersdelight:cutting_board"
+			}]
 		}
 		{
-			x: 7.5d
-			y: -12.0d
-			hide: true
-			id: "7A9E16E2C76A9705"
 			tasks: [{
 				id: "4778B37EFC07E091"
 				type: "item"
@@ -579,17 +576,21 @@
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			id: "7A9E16E2C76A9705"
+			y: -12.0d
+			x: 7.5d
+			hide: true
 		}
 		{
-			x: 8.0d
-			y: -10.5d
-			dependencies: ["7A9E16E2C76A9705"]
-			id: "5F3D03AFC18EE72F"
 			tasks: [{
 				id: "6904B73DF51A1AD1"
 				type: "item"
 				item: "farmersdelight:cooking_pot"
 			}]
+			dependencies: ["7A9E16E2C76A9705"]
+			id: "5F3D03AFC18EE72F"
+			y: -10.5d
+			x: 8.0d
 			rewards: [{
 				id: "052E1A5741B635FF"
 				type: "random"
@@ -598,10 +599,6 @@
 			}]
 		}
 		{
-			x: 9.0d
-			y: -12.0d
-			hide: true
-			id: "627A59E7F847BB40"
 			tasks: [{
 				id: "4FCB12F624D50A82"
 				type: "item"
@@ -613,17 +610,21 @@
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			id: "627A59E7F847BB40"
+			y: -12.0d
+			x: 9.0d
+			hide: true
 		}
 		{
-			x: 10.0d
-			y: -12.0d
-			dependencies: ["627A59E7F847BB40"]
-			id: "773CAC5A8E850DAD"
 			tasks: [{
 				id: "660EDDC8AA6A3A2C"
 				type: "item"
 				item: "farmersdelight:rich_soil"
 			}]
+			dependencies: ["627A59E7F847BB40"]
+			id: "773CAC5A8E850DAD"
+			y: -12.0d
+			x: 10.0d
 			rewards: [{
 				id: "392F534E5ADBC8EB"
 				type: "random"
@@ -632,11 +633,6 @@
 			}]
 		}
 		{
-			title: "Mushroom Colonies"
-			x: 10.5d
-			y: -10.5d
-			dependencies: ["773CAC5A8E850DAD"]
-			id: "4B705991EFCC0EDD"
 			tasks: [
 				{
 					id: "7B5800C80EC62B07"
@@ -649,19 +645,19 @@
 					item: "farmersdelight:brown_mushroom_colony"
 				}
 			]
+			id: "4B705991EFCC0EDD"
+			x: 10.5d
+			y: -10.5d
+			title: "Mushroom Colonies"
 			rewards: [{
 				id: "4EF253124F37FB61"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["773CAC5A8E850DAD"]
 		}
 		{
-			title: "Huge meals"
-			x: 5.5d
-			y: -12.0d
-			hide: true
-			id: "083334CD2B300860"
 			tasks: [
 				{
 					id: "68D379D96F07B76A"
@@ -679,26 +675,31 @@
 					item: "farmersdelight:shepherds_pie_block"
 				}
 			]
+			id: "083334CD2B300860"
+			x: 5.5d
+			y: -12.0d
+			title: "Huge meals"
 			rewards: [{
 				id: "315A63FFEB27E438"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			hide: true
 		}
 		{
-			x: 9.5d
-			y: -10.5d
-			dependencies: [
-				"4B705991EFCC0EDD"
-				"5F3D03AFC18EE72F"
-			]
-			id: "0C7C5867373C0CC6"
 			tasks: [{
 				id: "4F6C5F404DBE1A78"
 				type: "item"
 				item: "farmersdelight:stuffed_pumpkin_block"
 			}]
+			dependencies: [
+				"4B705991EFCC0EDD"
+				"5F3D03AFC18EE72F"
+			]
+			id: "0C7C5867373C0CC6"
+			y: -10.5d
+			x: 9.5d
 			rewards: [{
 				id: "6FB2133EB6F05358"
 				type: "random"
@@ -707,14 +708,6 @@
 			}]
 		}
 		{
-			title: "Pie slices"
-			x: 2.5d
-			y: -10.5d
-			dependencies: [
-				"7D916BB04FC8C26F"
-				"625DEA3AF13B6552"
-			]
-			id: "23437C7E33C71D1E"
 			tasks: [
 				{
 					id: "57F31E70CEBBD6F5"
@@ -737,19 +730,22 @@
 					item: "farmersdelight:cake_slice"
 				}
 			]
+			id: "23437C7E33C71D1E"
+			x: 2.5d
+			y: -10.5d
+			title: "Pie slices"
 			rewards: [{
 				id: "2C7063280AB31461"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: [
+				"7D916BB04FC8C26F"
+				"625DEA3AF13B6552"
+			]
 		}
 		{
-			title: "Pies"
-			x: 4.0d
-			y: -10.5d
-			dependencies: ["0F746C6F14897204"]
-			id: "625DEA3AF13B6552"
 			tasks: [
 				{
 					id: "12A1435D560D5AD7"
@@ -767,18 +763,19 @@
 					item: "farmersdelight:chocolate_pie"
 				}
 			]
+			id: "625DEA3AF13B6552"
+			x: 4.0d
+			y: -10.5d
+			title: "Pies"
 			rewards: [{
 				id: "69419D1DB480C1F3"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["0F746C6F14897204"]
 		}
 		{
-			x: 5.0d
-			y: -10.5d
-			hide: true
-			id: "1BBC001FB267B394"
 			tasks: [{
 				id: "41A41C448404833E"
 				type: "item"
@@ -790,16 +787,12 @@
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			id: "1BBC001FB267B394"
+			y: -10.5d
+			x: 5.0d
+			hide: true
 		}
 		{
-			title: "Pasta are delicious"
-			x: 6.5d
-			y: -10.5d
-			dependencies: [
-				"1BBC001FB267B394"
-				"5F3D03AFC18EE72F"
-			]
-			id: "74650181597F1AB9"
 			tasks: [
 				{
 					id: "67DEF8453274E3C4"
@@ -822,19 +815,22 @@
 					item: "farmersdelight:squid_ink_pasta"
 				}
 			]
+			id: "74650181597F1AB9"
+			x: 6.5d
+			y: -10.5d
+			title: "Pasta are delicious"
 			rewards: [{
 				id: "6FC6704DF329F6B4"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: [
+				"1BBC001FB267B394"
+				"5F3D03AFC18EE72F"
+			]
 		}
 		{
-			title: "Sandwiches'n Burgers"
-			x: 5.5d
-			y: -9.0d
-			hide: true
-			id: "62C64252FB7FBBA8"
 			tasks: [
 				{
 					id: "643BDCA1B42AA5A5"
@@ -857,19 +853,19 @@
 					item: "farmersdelight:bacon_sandwich"
 				}
 			]
+			id: "62C64252FB7FBBA8"
+			x: 5.5d
+			y: -9.0d
+			title: "Sandwiches'n Burgers"
 			rewards: [{
 				id: "7F697198B06615C2"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			hide: true
 		}
 		{
-			title: "Slicy"
-			x: 1.5d
-			y: -9.0d
-			dependencies: ["7D916BB04FC8C26F"]
-			id: "76EF45960A8BFACD"
 			tasks: [
 				{
 					id: "1BD47ACD27B6134F"
@@ -897,18 +893,19 @@
 					item: "farmersdelight:beef_patty"
 				}
 			]
+			id: "76EF45960A8BFACD"
+			x: 1.5d
+			y: -9.0d
+			title: "Slicy"
 			rewards: [{
 				id: "2F155520EFD72B77"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D916BB04FC8C26F"]
 		}
 		{
-			x: 3.5d
-			y: -12.0d
-			hide: true
-			id: "0F746C6F14897204"
 			tasks: [{
 				id: "1134769F3C1CFA6A"
 				type: "item"
@@ -920,13 +917,12 @@
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			id: "0F746C6F14897204"
+			y: -12.0d
+			x: 3.5d
+			hide: true
 		}
 		{
-			title: "Cabbages are awesome"
-			x: 8.5d
-			y: -9.0d
-			dependencies: ["5F3D03AFC18EE72F"]
-			id: "403AD739A10E62B4"
 			tasks: [
 				{
 					id: "29156A6A756A6E4D"
@@ -939,19 +935,19 @@
 					item: "farmersdelight:cabbage_rolls"
 				}
 			]
+			id: "403AD739A10E62B4"
+			x: 8.5d
+			y: -9.0d
+			title: "Cabbages are awesome"
 			rewards: [{
 				id: "2B48C1886C9DB211"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["5F3D03AFC18EE72F"]
 		}
 		{
-			title: "Salads"
-			x: 3.5d
-			y: -9.0d
-			hide: true
-			id: "54C34E3C38194EE4"
 			tasks: [
 				{
 					id: "2C47F0DB823A4C33"
@@ -984,19 +980,19 @@
 					item: "farmersdelight:nether_salad"
 				}
 			]
+			id: "54C34E3C38194EE4"
+			x: 3.5d
+			y: -9.0d
+			title: "Salads"
 			rewards: [{
 				id: "20648A8264380F3B"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			hide: true
 		}
 		{
-			title: "Animal Food"
-			x: 0.5d
-			y: -9.0d
-			hide: true
-			id: "49A785AC8B9A666F"
 			tasks: [
 				{
 					id: "0EEABC397BC4B249"
@@ -1009,19 +1005,19 @@
 					item: "farmersdelight:horse_feed"
 				}
 			]
+			id: "49A785AC8B9A666F"
+			x: 0.5d
+			y: -9.0d
+			title: "Animal Food"
 			rewards: [{
 				id: "0586801F68189847"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			hide: true
 		}
 		{
-			title: "Stews'n Soups"
-			x: 7.5d
-			y: -9.0d
-			dependencies: ["5F3D03AFC18EE72F"]
-			id: "1FAEA6633C3C396F"
 			tasks: [
 				{
 					id: "6E34FA882DD463A9"
@@ -1059,18 +1055,19 @@
 					item: "farmersdelight:baked_cod_stew"
 				}
 			]
+			id: "1FAEA6633C3C396F"
+			x: 7.5d
+			y: -9.0d
+			title: "Stews'n Soups"
 			rewards: [{
 				id: "30E7AD91D67AE468"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["5F3D03AFC18EE72F"]
 		}
 		{
-			x: 2.5d
-			y: -1.7999999999999998d
-			hide: true
-			id: "2AE3EBC84E212473"
 			tasks: [{
 				id: "5B46A1BC6E136C54"
 				type: "item"
@@ -1082,12 +1079,12 @@
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			id: "2AE3EBC84E212473"
+			y: -1.7999999999999998d
+			x: 2.5d
+			hide: true
 		}
 		{
-			x: 6.5d
-			y: -1.7999999999999998d
-			hide: true
-			id: "0DC385FAC6B8F5B0"
 			tasks: [{
 				id: "728BFFBE8B4B23E5"
 				type: "item"
@@ -1099,12 +1096,12 @@
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			id: "0DC385FAC6B8F5B0"
+			y: -1.7999999999999998d
+			x: 6.5d
+			hide: true
 		}
 		{
-			x: 7.5d
-			y: -1.7999999999999998d
-			hide: true
-			id: "6F7798F6D4D94BE8"
 			tasks: [{
 				id: "0B8009A06ECBFB69"
 				type: "item"
@@ -1116,12 +1113,12 @@
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			id: "6F7798F6D4D94BE8"
+			y: -1.7999999999999998d
+			x: 7.5d
+			hide: true
 		}
 		{
-			x: 5.5d
-			y: -1.7999999999999998d
-			hide: true
-			id: "2695E596732FC2A4"
 			tasks: [{
 				id: "05BC5CBA1DBA80CD"
 				type: "item"
@@ -1133,12 +1130,12 @@
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			id: "2695E596732FC2A4"
+			y: -1.7999999999999998d
+			x: 5.5d
+			hide: true
 		}
 		{
-			x: 10.999999999999996d
-			y: -6.0d
-			hide: true
-			id: "17E6C123D3D65800"
 			tasks: [{
 				id: "6B58E7B5727C7474"
 				type: "item"
@@ -1150,17 +1147,21 @@
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			id: "17E6C123D3D65800"
+			y: -6.0d
+			x: 10.999999999999996d
+			hide: true
 		}
 		{
-			x: 10.5d
-			y: -7.5d
-			dependencies: ["17E6C123D3D65800"]
-			id: "4A772B99CD435285"
 			tasks: [{
 				id: "1B1D1DA9554C9268"
 				type: "item"
 				item: "croptosis:gold_watering_can"
 			}]
+			dependencies: ["17E6C123D3D65800"]
+			id: "4A772B99CD435285"
+			y: -7.5d
+			x: 10.5d
 			rewards: [{
 				id: "4E8FF35EEFD86AB9"
 				type: "random"
@@ -1169,15 +1170,15 @@
 			}]
 		}
 		{
-			x: 10.0d
-			y: -6.0d
-			dependencies: ["4A772B99CD435285"]
-			id: "2BF9CB319CF8BF36"
 			tasks: [{
 				id: "082F5B0CAE531489"
 				type: "item"
 				item: "croptosis:diamond_watering_can"
 			}]
+			dependencies: ["4A772B99CD435285"]
+			id: "2BF9CB319CF8BF36"
+			y: -6.0d
+			x: 10.0d
 			rewards: [{
 				id: "234A449889391FBC"
 				type: "random"
@@ -1186,15 +1187,15 @@
 			}]
 		}
 		{
-			x: 9.5d
-			y: -7.5d
-			dependencies: ["2BF9CB319CF8BF36"]
-			id: "25B54342BD246BAE"
 			tasks: [{
 				id: "2026A4E3B185A04B"
 				type: "item"
 				item: "croptosis:netherite_watering_can"
 			}]
+			dependencies: ["2BF9CB319CF8BF36"]
+			id: "25B54342BD246BAE"
+			y: -7.5d
+			x: 9.5d
 			rewards: [{
 				id: "7CD707DBD45849C2"
 				type: "random"
@@ -1203,5 +1204,4 @@
 			}]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/applied_energistics.snbt
+++ b/config/ftbquests/quests/chapters/applied_energistics.snbt
@@ -1,125 +1,129 @@
 {
-	id: "1C4A7D73409E23C9"
-	group: "33A417364C0A17FE"
-	order_index: 2
-	filename: "applied_energistics"
-	title: "Applied Energistics 2"
-	icon: "ae2:singularity"
-	default_quest_shape: "square"
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "33A417364C0A17FE"
+	id: "1C4A7D73409E23C9"
+	filename: "applied_energistics"
+	default_quest_shape: "square"
+	icon: "ae2:singularity"
+	title: "Applied Energistics 2"
+	order_index: 2
 	quests: [
 		{
-			title: "Crystals are the way"
+			tasks: [{
+				id: "057AFA385B6AD0B6"
+				type: "checkmark"
+			}]
+			description: ["Certus Quartz is required for most AE2 Components."]
+			id: "409FDC9E0FBF40CB"
 			x: -5.0d
 			y: -6.0d
-			description: ["Certus Quartz is required for most AE2 Components."]
+			title: "Crystals are the way"
 			dependencies: [
 				"43709A95E106563B"
 				"7CE18D246F01445D"
 			]
 			dependency_requirement: "one_completed"
-			id: "409FDC9E0FBF40CB"
-			tasks: [{
-				id: "057AFA385B6AD0B6"
-				type: "checkmark"
-			}]
 		}
 		{
-			x: -3.5d
-			y: -7.0d
-			subtitle: "To charge your Certus Quartz Crystals, you can use either an AE2 Charger, MI Industrial Electrolyzer or a Create: Crafts and Additions Tesla Coil."
-			dependencies: ["409FDC9E0FBF40CB"]
-			id: "4ACC10C8890C306E"
 			tasks: [{
 				id: "2BCC42993452589F"
 				type: "item"
 				item: "ae2:charged_certus_quartz_crystal"
 			}]
+			id: "4ACC10C8890C306E"
+			x: -3.5d
+			y: -7.0d
 			rewards: [{
 				id: "1D81FAFB7CD11D6B"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "To charge your Certus Quartz Crystals, you can use either an AE2 Charger, MI Industrial Electrolyzer or a Create: Crafts and Additions Tesla Coil."
+			dependencies: ["409FDC9E0FBF40CB"]
 		}
 		{
-			x: -3.5d
-			y: -8.5d
-			subtitle: "Throw Charged Certus Quartz, Nether Quartz and Redstone Dust into the water."
-			dependencies: ["4ACC10C8890C306E"]
-			id: "033814C6CFAF56E6"
 			tasks: [{
 				id: "58065B40437B33DA"
 				type: "item"
 				item: "ae2:fluix_crystal"
 				count: 16L
 			}]
+			id: "033814C6CFAF56E6"
+			x: -3.5d
+			y: -8.5d
 			rewards: [{
 				id: "3545563E6E32AC3D"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Throw Charged Certus Quartz, Nether Quartz and Redstone Dust into the water."
+			dependencies: ["4ACC10C8890C306E"]
 		}
 		{
-			x: -3.5d
-			y: -5.5d
-			subtitle: "Used to press items using various Inscriber Plates."
-			description: ["It can accept 3 Acceleration Cards to speed up processing."]
-			dependencies: ["4ACC10C8890C306E"]
-			id: "42721BC1F7734286"
 			tasks: [{
 				id: "2BDA459026191334"
 				type: "item"
 				item: "ae2:inscriber"
 			}]
+			description: ["It can accept 3 Acceleration Cards to speed up processing."]
+			id: "42721BC1F7734286"
+			x: -3.5d
+			y: -5.5d
 			rewards: [{
 				id: "2B2E12989BCC4DF6"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Used to press items using various Inscriber Plates."
+			dependencies: ["4ACC10C8890C306E"]
 		}
 		{
-			x: -5.0d
-			y: -4.5d
-			subtitle: "Provides a way to charge supported tools through the ME Network."
-			description: [
-				"Power can be provided via the top or bottom, via either Fluix ME Glass Cable or other Cables, or other mod power cables. Items can be inserted or removed from any side."
-				""
-				"Can also be used to create Charged Certus Quartz Crystal from Certus Quartz Crystal."
-			]
-			dependencies: ["409FDC9E0FBF40CB"]
-			id: "4AC1C083537E8706"
 			tasks: [{
 				id: "283357E45102D87C"
 				type: "item"
 				item: "ae2:charger"
 			}]
+			description: [
+				"Power can be provided via the top or bottom, via either Fluix ME Glass Cable or other Cables, or other mod power cables. Items can be inserted or removed from any side."
+				""
+				"Can also be used to create Charged Certus Quartz Crystal from Certus Quartz Crystal."
+			]
+			id: "4AC1C083537E8706"
+			x: -5.0d
+			y: -4.5d
 			rewards: [{
 				id: "2667CE60FB687E04"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Provides a way to charge supported tools through the ME Network."
+			dependencies: ["409FDC9E0FBF40CB"]
 		}
 		{
-			x: -5.0d
-			y: -8.5d
-			subtitle: "Converts energy from external systems into AE and stores it in the network."
-			description: ["Alternatively, you can power your AE2 Network by plugging any Energy-compatible cable to the ME Controller."]
-			id: "44B22A645FC94C64"
 			tasks: [{
 				id: "7C8924F839D8D61E"
 				type: "item"
 				item: "ae2:energy_acceptor"
 			}]
+			description: ["Alternatively, you can power your AE2 Network by plugging any Energy-compatible cable to the ME Controller."]
+			id: "44B22A645FC94C64"
+			x: -5.0d
+			y: -8.5d
 			rewards: [{
 				id: "1646033242B799C1"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Converts energy from external systems into AE and stores it in the network."
 		}
 		{
-			x: -3.5d
-			y: -10.0d
-			subtitle: "The simplest cable to make, transfers power and channels."
+			tasks: [{
+				id: "1582C3D80B414E43"
+				type: "item"
+				item: "ae2:fluix_glass_cable"
+				count: 6L
+			}]
 			description: [
 				"To craft colored cables surround a dye of any type with 8 cables of the same type (color of the cables dosn't matter, but they must be the same type, glass, smart, etc)."
 				""
@@ -129,46 +133,45 @@
 				""
 				"You can cover the cable with wool to create Fluix ME Covered Cable, and craft Fluix ME Smart Cable to get a better idea of what is going on with your Channels."
 			]
-			dependencies: [
-				"033814C6CFAF56E6"
-				"00259AC734AF1B4D"
-			]
 			id: "3C12FD23932C3522"
-			tasks: [{
-				id: "1582C3D80B414E43"
-				type: "item"
-				item: "ae2:fluix_glass_cable"
-				count: 6L
-			}]
+			x: -3.5d
+			y: -10.0d
 			rewards: [{
 				id: "4EF17501CBFF2087"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The simplest cable to make, transfers power and channels."
+			dependencies: [
+				"033814C6CFAF56E6"
+				"00259AC734AF1B4D"
+			]
 		}
 		{
-			x: -2.0d
-			y: -10.0d
-			subtitle: "Used to accelerate crystal growth, which allows you to create Certus Quartz Crystal and Fluix Crystal from crystal dust."
-			description: ["Place them around the Water to speed up in-world crystal growth."]
-			dependencies: ["3C12FD23932C3522"]
-			id: "7B3F4A3D79F2988B"
 			tasks: [{
 				id: "7AA503B6ABF481D7"
 				type: "item"
 				item: "ae2:quartz_growth_accelerator"
 				count: 4L
 			}]
+			description: ["Place them around the Water to speed up in-world crystal growth."]
+			id: "7B3F4A3D79F2988B"
+			x: -2.0d
+			y: -10.0d
 			rewards: [{
 				id: "065802CBACCBE341"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Used to accelerate crystal growth, which allows you to create Certus Quartz Crystal and Fluix Crystal from crystal dust."
+			dependencies: ["3C12FD23932C3522"]
 		}
 		{
-			x: -0.5d
-			y: -10.0d
-			subtitle: "Throw em in water!"
+			tasks: [{
+				id: "02C1F3E82404AE7E"
+				type: "item"
+				item: "ae2:fluix_crystal_seed"
+			}]
 			description: [
 				"The Certus Quartz Dust you find can be grown into a Certus Quartz Crystal."
 				""
@@ -176,23 +179,23 @@
 				""
 				"This process is very slow without the help of the Crystal Growth Accelerator."
 			]
-			dependencies: ["7B3F4A3D79F2988B"]
 			id: "7595957E9616FC92"
-			tasks: [{
-				id: "02C1F3E82404AE7E"
-				type: "item"
-				item: "ae2:fluix_crystal_seed"
-			}]
+			x: -0.5d
+			y: -10.0d
 			rewards: [{
 				id: "262447B4477C4C26"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Throw em in water!"
+			dependencies: ["7B3F4A3D79F2988B"]
 		}
 		{
-			x: -11.0d
-			y: -3.0d
-			subtitle: "A Network Switchboard!"
+			tasks: [{
+				id: "6CB5F66C1E628B0E"
+				type: "item"
+				item: "ae2:controller"
+			}]
 			description: [
 				"ME Networks require power to function."
 				""
@@ -209,23 +212,23 @@
 				""
 				"You can right-click an active ME Controller to see amount of installed parts and network's energy consumption - no need for the Network Tool!"
 			]
-			dependencies: ["5683C69200EBC4CD"]
 			id: "696536A55ED81D6B"
-			tasks: [{
-				id: "6CB5F66C1E628B0E"
-				type: "item"
-				item: "ae2:controller"
-			}]
+			x: -11.0d
+			y: -3.0d
 			rewards: [{
 				id: "3263CC53B6C24CDB"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A Network Switchboard!"
+			dependencies: ["5683C69200EBC4CD"]
 		}
 		{
-			x: -12.5d
-			y: -4.5d
-			subtitle: "A smarter cable?"
+			tasks: [{
+				id: "733C8308DEA8FB07"
+				type: "item"
+				item: "ae2:fluix_smart_cable"
+			}]
 			description: [
 				"While bearing some similarity to Fluix ME Covered Cable in appearance, they provide diagnostic function by visualizing the channel usage on the cables, the channels appear as lit colored lines that run along the black stripe on the cables giving you an understanding of how your channels are being used on your network."
 				""
@@ -233,23 +236,23 @@
 				""
 				"You can also read out the amount of channels via The One Probe."
 			]
-			dependencies: ["5683C69200EBC4CD"]
 			id: "2B641E7A30686BCF"
-			tasks: [{
-				id: "733C8308DEA8FB07"
-				type: "item"
-				item: "ae2:fluix_smart_cable"
-			}]
+			x: -12.5d
+			y: -4.5d
 			rewards: [{
 				id: "7F665B7979BA2C8A"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A smarter cable?"
+			dependencies: ["5683C69200EBC4CD"]
 		}
 		{
-			x: -11.0d
-			y: -7.0d
-			subtitle: "A block designed to do one thing, store Storage Cells."
+			tasks: [{
+				id: "04A70F331336A1D5"
+				type: "item"
+				item: "ae2:drive"
+			}]
 			description: [
 				"This block holds 10 storage cells so you can tightly pack your storage into a very small space."
 				""
@@ -265,40 +268,40 @@
 				""
 				"Its important to note, that without a ME Network this block does nothing. Its only useful when combined with a way to input, and output items, and requires 2 AE/t power to function, and additional power for each Storage Cell stored inside it."
 			]
-			dependencies: ["5683C69200EBC4CD"]
 			id: "19FBAF9A70549BF5"
-			tasks: [{
-				id: "04A70F331336A1D5"
-				type: "item"
-				item: "ae2:drive"
-			}]
+			x: -11.0d
+			y: -7.0d
 			rewards: [{
 				id: "5751269980EAF0AF"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A block designed to do one thing, store Storage Cells."
+			dependencies: ["5683C69200EBC4CD"]
 		}
 		{
-			x: -9.5d
-			y: -6.5d
-			subtitle: "Upgraded version of the ME Terminal which has an integrated crafting grid with access to a ME Network's Networked Storage."
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "3988E16DAA388261"
 			tasks: [{
 				id: "0FCC6C4E3FB97D07"
 				type: "item"
 				item: "ae2:crafting_terminal"
 			}]
+			id: "3988E16DAA388261"
+			x: -9.5d
+			y: -6.5d
 			rewards: [{
 				id: "6E68A01114D103E1"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Upgraded version of the ME Terminal which has an integrated crafting grid with access to a ME Network's Networked Storage."
+			dependencies: ["19FBAF9A70549BF5"]
 		}
 		{
-			x: -11.0d
-			y: -1.5d
-			subtitle: "A versatile configurable system to move items / redstone / power / and fluids from one location to another though an existing ME Network without storage."
+			tasks: [{
+				id: "5723EBB3D22A39E7"
+				type: "item"
+				item: "ae2:me_p2p_tunnel"
+			}]
 			description: [
 				"Tunnels are 1 input to N outputs. This means you can output to as many points as you want, but only input at a single point per tunnel."
 				""
@@ -310,32 +313,18 @@
 				""
 				"Be aware, that the Energy P2P Tunnel will draw a 5% tax on the transfered energy from the network."
 			]
-			dependencies: ["696536A55ED81D6B"]
 			id: "1286F9F4255B9A38"
-			tasks: [{
-				id: "5723EBB3D22A39E7"
-				type: "item"
-				item: "ae2:me_p2p_tunnel"
-			}]
+			x: -11.0d
+			y: -1.5d
 			rewards: [{
 				id: "1E6BDDAEB6D3E641"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A versatile configurable system to move items / redstone / power / and fluids from one location to another though an existing ME Network without storage."
+			dependencies: ["696536A55ED81D6B"]
 		}
 		{
-			x: -11.0d
-			y: 0.0d
-			subtitle: "Used mainly to configure P2P Tunnels."
-			description: [
-				"To configure a ME P2P Tunnel you must first attune the tunnel to carry what you want it to, then you need to configure the outputs to their input."
-				""
-				"You can configure the connections by using the Memory Card; First Shift+Right Click the input to save it on your memory card, then simply right-click the different outputs to store the input onto the outputs."
-				""
-				"Memory Cards can also copy device configurations, in case you want to set up mutliple devices with the same configuration."
-			]
-			dependencies: ["1286F9F4255B9A38"]
-			id: "5DD87AC2BC5F87F2"
 			tasks: [{
 				id: "07906B740B4ADB80"
 				type: "item"
@@ -345,43 +334,43 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"To configure a ME P2P Tunnel you must first attune the tunnel to carry what you want it to, then you need to configure the outputs to their input."
+				""
+				"You can configure the connections by using the Memory Card; First Shift+Right Click the input to save it on your memory card, then simply right-click the different outputs to store the input onto the outputs."
+				""
+				"Memory Cards can also copy device configurations, in case you want to set up mutliple devices with the same configuration."
+			]
+			id: "5DD87AC2BC5F87F2"
+			x: -11.0d
+			y: 0.0d
 			rewards: [{
 				id: "6A0D087F9939DEF6"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Used mainly to configure P2P Tunnels."
+			dependencies: ["1286F9F4255B9A38"]
 		}
 		{
-			x: -14.0d
-			y: -4.5d
-			subtitle: "Higher Capacity cable, can carry 32 channels unlike standard cable which can only carry 8."
-			description: ["However it doesn't support buses so you must first step down from dense to a smaller cable (such as Fluix ME Glass Cable or Fluix ME Smart Cable) before using buses or panels. Shows load similarly to Fluix ME Smart Cable, with each line lit representing four channels in use."]
-			dependencies: ["2B641E7A30686BCF"]
-			id: "1E435A4C1547934D"
 			tasks: [{
 				id: "4D657D4CBB6A2016"
 				type: "item"
 				item: "ae2:fluix_smart_dense_cable"
 			}]
+			description: ["However it doesn't support buses so you must first step down from dense to a smaller cable (such as Fluix ME Glass Cable or Fluix ME Smart Cable) before using buses or panels. Shows load similarly to Fluix ME Smart Cable, with each line lit representing four channels in use."]
+			id: "1E435A4C1547934D"
+			x: -14.0d
+			y: -4.5d
 			rewards: [{
 				id: "4330B05B53533D6C"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Higher Capacity cable, can carry 32 channels unlike standard cable which can only carry 8."
+			dependencies: ["2B641E7A30686BCF"]
 		}
 		{
-			x: -12.0d
-			y: -9.0d
-			subtitle: "Lowest Tier Storage Cell, which can contain 1,024 bytes of storage."
-			description: [
-				"1,024 bytes of storage can hold 127 Stacks of a single item. or 65 Stacks, while holding 63 Different items."
-				""
-				"The 1k Storage Cell uses 8 bytes of data to store a single type."
-				""
-				"8 Items take up 1 byte."
-			]
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "215EF29F7DD6B37C"
 			tasks: [{
 				id: "3FDDED57431181C3"
 				type: "item"
@@ -391,26 +380,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"1,024 bytes of storage can hold 127 Stacks of a single item. or 65 Stacks, while holding 63 Different items."
+				""
+				"The 1k Storage Cell uses 8 bytes of data to store a single type."
+				""
+				"8 Items take up 1 byte."
+			]
+			id: "215EF29F7DD6B37C"
+			x: -12.0d
+			y: -9.0d
 			rewards: [{
 				id: "649B9989A24F85A0"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Lowest Tier Storage Cell, which can contain 1,024 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
 		}
 		{
-			x: -12.0d
-			y: -10.0d
-			subtitle: "Low Tier Storage Cell, which can contain 4,096 bytes of storage."
-			description: [
-				"4,096 bytes of storage can hold 508 Stacks of a single item. or 260 Stacks, while holding 63 Different items."
-				""
-				"The 4k Storage Cell uses 32 bytes of data to store a single type."
-				""
-				"8 Items take up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "5AB8DB04F4DA2F40"
 			tasks: [{
 				id: "2E155470D8151510"
 				type: "item"
@@ -420,26 +408,26 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"4,096 bytes of storage can hold 508 Stacks of a single item. or 260 Stacks, while holding 63 Different items."
+				""
+				"The 4k Storage Cell uses 32 bytes of data to store a single type."
+				""
+				"8 Items take up 1 byte."
+			]
+			id: "5AB8DB04F4DA2F40"
+			x: -12.0d
+			y: -10.0d
 			rewards: [{
 				id: "0E07A03963E49881"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Low Tier Storage Cell, which can contain 4,096 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -12.0d
-			y: -11.0d
-			subtitle: "Middle Tier Storage Cell, which can contain 16,384 bytes of storage."
-			description: [
-				"16,384 bytes of storage can hold 2,032 Stacks of a single item. or 1,040 Stacks, while holding 63 Different items."
-				""
-				"The 16k Storage Cell uses 128 bytes of data to store a single type."
-				""
-				"8 Items take up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "2A358437484E61CF"
 			tasks: [{
 				id: "0950907AA16E55FA"
 				type: "item"
@@ -449,26 +437,26 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"16,384 bytes of storage can hold 2,032 Stacks of a single item. or 1,040 Stacks, while holding 63 Different items."
+				""
+				"The 16k Storage Cell uses 128 bytes of data to store a single type."
+				""
+				"8 Items take up 1 byte."
+			]
+			id: "2A358437484E61CF"
+			x: -12.0d
+			y: -11.0d
 			rewards: [{
 				id: "5431849B646D74A7"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Middle Tier Storage Cell, which can contain 16,384 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -12.0d
-			y: -12.0d
-			subtitle: "High Tier Storage Cell, which can contain 65,536 bytes of storage."
-			description: [
-				"65,536 bytes of storage can hold 8,128 Stacks of a single item. or 4,160 Stacks, while holding 63 Different items."
-				""
-				"The 64k Storage Cell uses 512 bytes of data to store a single type."
-				""
-				"8 Items take up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "451C8D5D92F1BAED"
 			tasks: [{
 				id: "7FAF15C54C21DDF8"
 				type: "item"
@@ -478,16 +466,31 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"65,536 bytes of storage can hold 8,128 Stacks of a single item. or 4,160 Stacks, while holding 63 Different items."
+				""
+				"The 64k Storage Cell uses 512 bytes of data to store a single type."
+				""
+				"8 Items take up 1 byte."
+			]
+			id: "451C8D5D92F1BAED"
+			x: -12.0d
+			y: -12.0d
 			rewards: [{
 				id: "2E7996FFCCA4BEDB"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "High Tier Storage Cell, which can contain 65,536 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -8.0d
-			y: -7.0d
-			subtitle: "A specialized version of the ME Crafting Terminal designed to encode Blank Pattern into Crafting, Processing, Stonecutting or Smithing Patterns."
+			tasks: [{
+				id: "2A1935843BEBBF9F"
+				type: "item"
+				item: "ae2:pattern_encoding_terminal"
+			}]
 			description: [
 				"Lets you browse the contents of your network like other terminals, but also contains an area for designing patterns."
 				""
@@ -500,49 +503,49 @@
 				""
 				"To select between modes, click the tabs to the right of the interface."
 			]
-			dependencies: [
-				"3988E16DAA388261"
-				"4555AD508D9C6CEB"
-			]
-			min_width: 300
 			id: "34550EB511DF1DBC"
-			tasks: [{
-				id: "2A1935843BEBBF9F"
-				type: "item"
-				item: "ae2:pattern_encoding_terminal"
-			}]
+			x: -8.0d
+			y: -7.0d
 			rewards: [{
 				id: "029183DD4EFACEE5"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			min_width: 300
+			subtitle: "A specialized version of the ME Crafting Terminal designed to encode Blank Pattern into Crafting, Processing, Stonecutting or Smithing Patterns."
+			dependencies: [
+				"3988E16DAA388261"
+				"4555AD508D9C6CEB"
+			]
 		}
 		{
-			x: -9.5d
-			y: -7.5d
-			subtitle: "A HID which gives you access to items stored in your ME Network. This will also include items accessible through ME Storage Bus."
-			description: [
-				"It has the ability to sort and search, as well as filter by using View Cell. It requires a channel to function."
-				""
-				"Can be upgraded into a ME Crafting Terminal."
-			]
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "4555AD508D9C6CEB"
 			tasks: [{
 				id: "2FEE9FBD8CE4FE03"
 				type: "item"
 				item: "ae2:terminal"
 			}]
+			description: [
+				"It has the ability to sort and search, as well as filter by using View Cell. It requires a channel to function."
+				""
+				"Can be upgraded into a ME Crafting Terminal."
+			]
+			id: "4555AD508D9C6CEB"
+			x: -9.5d
+			y: -7.5d
 			rewards: [{
 				id: "7CDA5584E969893A"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A HID which gives you access to items stored in your ME Network. This will also include items accessible through ME Storage Bus."
+			dependencies: ["19FBAF9A70549BF5"]
 		}
 		{
-			x: 2.0d
-			y: -5.5d
-			subtitle: "Exports and imports items and fluids from/to the network."
+			tasks: [{
+				id: "5F3D81B7D3F27CA2"
+				type: "item"
+				item: "ae2:interface"
+			}]
 			description: [
 				"It has a special interaction when ME Storage Bus or ME Pattern Provider is placed on this block."
 				""
@@ -557,46 +560,46 @@
 				"> Crafting Card - automatically requests crafting to keep items in stock. (not recommended as excessive requesting can lead to TPS lag.)"
 				"Always exports items already in stock first."
 			]
-			dependencies: ["2BE8127E1180DA21"]
-			min_width: 300
 			id: "115B865B26BE47E5"
-			tasks: [{
-				id: "5F3D81B7D3F27CA2"
-				type: "item"
-				item: "ae2:interface"
-			}]
+			x: 2.0d
+			y: -5.5d
 			rewards: [{
 				id: "75BCEA59308257CA"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			min_width: 300
+			subtitle: "Exports and imports items and fluids from/to the network."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: 4.0d
-			y: -5.5d
-			subtitle: "This particular block provides the CPU with no additional features, but can be used as a \"filler\" block."
-			description: [
-				"It is the base for crafting the other functional components of a crafting CPU."
-				""
-				"A Crafting CPU Multiblock must be a cuboid, else it will not form."
-			]
-			dependencies: ["2BE8127E1180DA21"]
-			id: "159C31FE32578AD2"
 			tasks: [{
 				id: "2641A595A151CEC8"
 				type: "item"
 				item: "ae2:crafting_unit"
 			}]
+			description: [
+				"It is the base for crafting the other functional components of a crafting CPU."
+				""
+				"A Crafting CPU Multiblock must be a cuboid, else it will not form."
+			]
+			id: "159C31FE32578AD2"
+			x: 4.0d
+			y: -5.5d
 			rewards: [{
 				id: "35560ED76E3DEE07"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "This particular block provides the CPU with no additional features, but can be used as a \"filler\" block."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: 3.0d
-			y: -5.5d
-			subtitle: "Automatically crafts Crafting Table, Stonecutter and Smithing Table recipes."
+			tasks: [{
+				id: "1E101186DD63E8A3"
+				type: "item"
+				item: "ae2:molecular_assembler"
+			}]
 			description: [
 				"It has two modes of operation."
 				""
@@ -606,113 +609,113 @@
 				""
 				"After crafting, the Molecular Assembler will try to push its output item into an adjacent inventory, Interface or Pattern Provider."
 			]
-			dependencies: ["2BE8127E1180DA21"]
 			id: "63DF8DED795008EA"
-			tasks: [{
-				id: "1E101186DD63E8A3"
-				type: "item"
-				item: "ae2:molecular_assembler"
-			}]
+			x: 3.0d
+			y: -5.5d
 			rewards: [{
 				id: "36274E786964367A"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Automatically crafts Crafting Table, Stonecutter and Smithing Table recipes."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: 0.5d
-			y: -1.5d
-			subtitle: "Provides 1024 bytes of storage for crafting."
-			dependencies: ["2BE8127E1180DA21"]
-			id: "719707385946F7F4"
 			tasks: [{
 				id: "00690EE1F30F9B99"
 				type: "item"
 				item: "ae2:1k_crafting_storage"
 			}]
+			id: "719707385946F7F4"
+			x: 0.5d
+			y: -1.5d
 			rewards: [{
 				id: "60B2624F883FD72F"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Provides 1024 bytes of storage for crafting."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: 1.5d
-			y: -1.5d
-			subtitle: "Provides 4,096 bytes of storage for crafting."
-			dependencies: ["2BE8127E1180DA21"]
-			id: "2C7ABB61B3B1AD85"
 			tasks: [{
 				id: "640B719C25B50B4B"
 				type: "item"
 				item: "ae2:4k_crafting_storage"
 			}]
+			id: "2C7ABB61B3B1AD85"
+			x: 1.5d
+			y: -1.5d
 			rewards: [{
 				id: "6F58CE36BA02724F"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Provides 4,096 bytes of storage for crafting."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: 2.5d
-			y: -1.5d
-			subtitle: "Provides 16,384 bytes of storage for crafting."
-			dependencies: ["2BE8127E1180DA21"]
-			id: "1C9473DDA8CA1AC1"
 			tasks: [{
 				id: "3B28508C9447ACAC"
 				type: "item"
 				item: "ae2:16k_crafting_storage"
 			}]
+			id: "1C9473DDA8CA1AC1"
+			x: 2.5d
+			y: -1.5d
 			rewards: [{
 				id: "3CAC6A77BD991766"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Provides 16,384 bytes of storage for crafting."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: 3.5d
-			y: -1.5d
-			subtitle: "Provides 65,536 bytes of storage for crafting."
-			dependencies: ["2BE8127E1180DA21"]
-			id: "6862A2B7639A470E"
 			tasks: [{
 				id: "0505C3A757A97D86"
 				type: "item"
 				item: "ae2:64k_crafting_storage"
 			}]
+			id: "6862A2B7639A470E"
+			x: 3.5d
+			y: -1.5d
 			rewards: [{
 				id: "663D11734F2B827E"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Provides 65,536 bytes of storage for crafting."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: 2.0d
-			y: -7.0d
-			subtitle: "Exposes an external inventory as a storage for the ME Network."
-			description: [
-				"If placed on the ME Interface of another network, it exposes items of that network instead."
-				""
-				"Useful for making mass storage while using only 1 channel on main ME Network."
-			]
-			dependencies: ["115B865B26BE47E5"]
-			id: "5386766A061332CA"
 			tasks: [{
 				id: "6DD06942CEC418CB"
 				type: "item"
 				item: "ae2:storage_bus"
 			}]
+			description: [
+				"If placed on the ME Interface of another network, it exposes items of that network instead."
+				""
+				"Useful for making mass storage while using only 1 channel on main ME Network."
+			]
+			id: "5386766A061332CA"
+			x: 2.0d
+			y: -7.0d
 			rewards: [{
 				id: "50BDA7486CD5F797"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Exposes an external inventory as a storage for the ME Network."
+			dependencies: ["115B865B26BE47E5"]
 		}
 		{
-			x: 0.0d
-			y: -3.5d
-			subtitle: "Pulls items/fluids from external inventory/tank into the ME Network."
+			tasks: [{
+				id: "006B723E69E57816"
+				type: "item"
+				item: "ae2:import_bus"
+			}]
 			description: [
 				"It can accept upgrades:"
 				"> Capacity Card (max: 2) - adds 4 additional filter slots for importing per card."
@@ -726,23 +729,23 @@
 				"3 cards - 64 items at once,"
 				"4 cards - 96 items at once."
 			]
-			dependencies: ["2BE8127E1180DA21"]
 			id: "05F88D164E0A2988"
-			tasks: [{
-				id: "006B723E69E57816"
-				type: "item"
-				item: "ae2:import_bus"
-			}]
+			x: 0.0d
+			y: -3.5d
 			rewards: [{
 				id: "5FE40F90038D950F"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Pulls items/fluids from external inventory/tank into the ME Network."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: 0.0d
-			y: -2.5d
-			subtitle: "Pushes items/fluids from ME Network into the external inventory/tank."
+			tasks: [{
+				id: "3D82F453CBD0740A"
+				type: "item"
+				item: "ae2:export_bus"
+			}]
 			description: [
 				"It can accept upgrades:"
 				"> Capacity Card (max: 2) - adds 4 additional filter slots for exporting per card."
@@ -760,24 +763,24 @@
 				"4 cards - 96 items at once."
 				"> Crafting Card - the Export Bus will automatically request crafting until the container is filled. You can choose whether you want to extract items already in stock first or not."
 			]
-			dependencies: ["2BE8127E1180DA21"]
-			min_width: 300
 			id: "578F8DD2ACBA9C6C"
-			tasks: [{
-				id: "3D82F453CBD0740A"
-				type: "item"
-				item: "ae2:export_bus"
-			}]
+			x: 0.0d
+			y: -2.5d
 			rewards: [{
 				id: "015E6C5EDA60D2A8"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			min_width: 300
+			subtitle: "Pushes items/fluids from ME Network into the external inventory/tank."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: -6.5d
-			y: -1.5d
-			subtitle: "Allows you to configure which users, and what permissions the users have with the ME System."
+			tasks: [{
+				id: "6FDD185D41E3E494"
+				type: "item"
+				item: "ae2:security_station"
+			}]
 			description: [
 				"By existing it enforces permissions on the usage of the system."
 				""
@@ -791,44 +794,44 @@
 				""
 				"Other than adding security on software layer, you can link up your Wireless Terminal with the network and access it wirelessly."
 			]
-			dependencies: ["679955AA48F79365"]
 			id: "57507836248CB116"
-			tasks: [{
-				id: "6FDD185D41E3E494"
-				type: "item"
-				item: "ae2:security_station"
-			}]
+			x: -6.5d
+			y: -1.5d
 			rewards: [{
 				id: "71278AA6D7386AED"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Allows you to configure which users, and what permissions the users have with the ME System."
+			dependencies: ["679955AA48F79365"]
 		}
 		{
-			x: -5.0d
-			y: -1.5d
-			description: [
-				"Allows you to specify permissions for different players."
-				""
-				"Useful in Multiplayer."
-			]
-			dependencies: ["57507836248CB116"]
-			id: "563432F2BB1EE1AF"
 			tasks: [{
 				id: "21C4930537157E49"
 				type: "item"
 				item: "ae2:biometric_card"
 			}]
+			description: [
+				"Allows you to specify permissions for different players."
+				""
+				"Useful in Multiplayer."
+			]
+			id: "563432F2BB1EE1AF"
+			x: -5.0d
+			y: -1.5d
 			rewards: [{
 				id: "42A223A49CCD5F52"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["57507836248CB116"]
 		}
 		{
-			x: -6.5d
-			y: 0.0d
-			subtitle: "Allows wireless access via a Wireless Terminal."
+			tasks: [{
+				id: "4E38E22FE7B37FE6"
+				type: "item"
+				item: "ae2:wireless_access_point"
+			}]
 			description: [
 				"Range and power usage is determined based on the number of Wireless Booster installed into the ME Wireless Access Point."
 				""
@@ -836,26 +839,18 @@
 				""
 				"Requires a channel to be operational."
 			]
-			dependencies: ["57507836248CB116"]
 			id: "69597F2A6D80AE29"
-			tasks: [{
-				id: "4E38E22FE7B37FE6"
-				type: "item"
-				item: "ae2:wireless_access_point"
-			}]
+			x: -6.5d
+			y: 0.0d
 			rewards: [{
 				id: "4E65ABF8921A048C"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Allows wireless access via a Wireless Terminal."
+			dependencies: ["57507836248CB116"]
 		}
 		{
-			title: "Wireless Terminal"
-			x: -6.5d
-			y: 1.5d
-			subtitle: "Put it in the designated slot in ME Security Terminal to link it to the network."
-			dependencies: ["69597F2A6D80AE29"]
-			id: "0B27217B40C19911"
 			tasks: [{
 				id: "1CFC818DEC3E5B6C"
 				type: "item"
@@ -891,33 +886,41 @@
 					}
 				}
 			}]
+			id: "0B27217B40C19911"
+			x: -6.5d
+			y: 1.5d
+			title: "Wireless Terminal"
 			rewards: [{
 				id: "51F75DBF6855EF97"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Put it in the designated slot in ME Security Terminal to link it to the network."
+			dependencies: ["69597F2A6D80AE29"]
 		}
 		{
-			x: -6.5d
-			y: 3.0d
-			subtitle: "Used to increase the range of the ME Wireless Access Point."
-			dependencies: ["0B27217B40C19911"]
-			id: "7814B078C6256761"
 			tasks: [{
 				id: "6C0BA4228CC4B8B0"
 				type: "item"
 				item: "ae2:wireless_booster"
 			}]
+			id: "7814B078C6256761"
+			x: -6.5d
+			y: 3.0d
 			rewards: [{
 				id: "56CE5BDC03E4B724"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Used to increase the range of the ME Wireless Access Point."
+			dependencies: ["0B27217B40C19911"]
 		}
 		{
-			x: -8.5d
-			y: -1.5d
-			subtitle: "Required to create a connection between to Quantum Network Bridges."
+			tasks: [{
+				id: "435ED5858F476384"
+				type: "item"
+				item: "ae2:quantum_entangled_singularity"
+			}]
 			description: [
 				"They are always produced in matching pairs, to create a connection place 1 of the pair of Quantum Entangled Singularity into the ME Quantum Link Chamber of the bridge on each side."
 				""
@@ -929,119 +932,119 @@
 				""
 				"It might be a good idea to label these with names when you create them using any method, ex. an Anvil."
 			]
-			dependencies: ["679955AA48F79365"]
 			id: "5CF50859A98E45FB"
-			tasks: [{
-				id: "435ED5858F476384"
-				type: "item"
-				item: "ae2:quantum_entangled_singularity"
-			}]
+			x: -8.5d
+			y: -1.5d
 			rewards: [{
 				id: "2DD77D29A7CA2D98"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Required to create a connection between to Quantum Network Bridges."
+			dependencies: ["679955AA48F79365"]
 		}
 		{
-			x: -8.5d
-			y: 0.0d
-			subtitle: "One of these blocks surrounded by a ME Quantum Ring will create a Quantum Network Bridge."
-			description: [
-				"This block doesn't connect to any cables and only registers as part of the network with the full bridge is made."
-				""
-				"This blocks inventory can only hold a single Quantum Entangled Singularity and is automation accessible."
-			]
-			dependencies: ["5CF50859A98E45FB"]
-			id: "2FB251E717EA2F3C"
 			tasks: [{
 				id: "0DAFE1BDC893DE5F"
 				type: "item"
 				item: "ae2:quantum_link"
 			}]
+			description: [
+				"This block doesn't connect to any cables and only registers as part of the network with the full bridge is made."
+				""
+				"This blocks inventory can only hold a single Quantum Entangled Singularity and is automation accessible."
+			]
+			id: "2FB251E717EA2F3C"
+			x: -8.5d
+			y: 0.0d
 			rewards: [{
 				id: "6FFEB53CB2191D64"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "One of these blocks surrounded by a ME Quantum Ring will create a Quantum Network Bridge."
+			dependencies: ["5CF50859A98E45FB"]
 		}
 		{
-			x: -8.5d
-			y: 1.5d
-			subtitle: "Eight of these blocks placed around a ME Quantum Link Chamber will create a Quantum Network Bridge."
-			description: ["Only the 4 ME Quantum Ring blocks adjacent to the ME Quantum Link Chamber will accept network connections, the 4 corner blocks cannot connect to cables."]
-			dependencies: ["2FB251E717EA2F3C"]
-			id: "300343A7965531DD"
 			tasks: [{
 				id: "422C32A11B9803B4"
 				type: "item"
 				item: "ae2:quantum_ring"
 			}]
+			description: ["Only the 4 ME Quantum Ring blocks adjacent to the ME Quantum Link Chamber will accept network connections, the 4 corner blocks cannot connect to cables."]
+			id: "300343A7965531DD"
+			x: -8.5d
+			y: 1.5d
 			rewards: [{
 				id: "7ED338DC09F7805B"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Eight of these blocks placed around a ME Quantum Link Chamber will create a Quantum Network Bridge."
+			dependencies: ["2FB251E717EA2F3C"]
 		}
 		{
-			title: "Security, Wireless and Beyond"
-			x: -7.5d
-			y: -3.0d
-			description: ["These blocks can keep your network secure and give you remote access to the ME Network contents!"]
-			dependencies: [
-				"43709A95E106563B"
-				"7CE18D246F01445D"
-			]
-			dependency_requirement: "one_completed"
-			id: "679955AA48F79365"
 			tasks: [{
 				id: "1349A47C54D391CA"
 				type: "checkmark"
 				title: "Security and Wireless"
 			}]
-		}
-		{
-			title: "Automation is key!"
-			x: 2.5d
-			y: -3.5d
-			subtitle: "Use various interfaces and automate your network."
-			description: ["You can use these to route items around and automate crafting requests on your ME Network!"]
+			description: ["These blocks can keep your network secure and give you remote access to the ME Network contents!"]
+			id: "679955AA48F79365"
+			x: -7.5d
+			y: -3.0d
+			title: "Security, Wireless and Beyond"
 			dependencies: [
 				"43709A95E106563B"
 				"7CE18D246F01445D"
 			]
 			dependency_requirement: "one_completed"
-			id: "2BE8127E1180DA21"
+		}
+		{
 			tasks: [{
 				id: "2E567019AD31DD51"
 				type: "checkmark"
 				title: "So you want to automate?"
 			}]
-		}
-		{
-			title: "Storage and Transport"
-			x: -11.0d
-			y: -4.5d
-			description: [
-				"General network and storage parts of the ME Network."
-				""
-				"The ME Network (pr. Emm-Eee: Matter Energy) is a set of connected blocks, and cables grouped into a system, where storage, power and functions cooperate between multiple components."
-			]
+			description: ["You can use these to route items around and automate crafting requests on your ME Network!"]
+			id: "2BE8127E1180DA21"
+			x: 2.5d
+			y: -3.5d
+			title: "Automation is key!"
+			dependency_requirement: "one_completed"
+			subtitle: "Use various interfaces and automate your network."
 			dependencies: [
 				"43709A95E106563B"
 				"7CE18D246F01445D"
 			]
-			dependency_requirement: "one_completed"
-			id: "5683C69200EBC4CD"
+		}
+		{
 			tasks: [{
 				id: "35DEBD075D82821D"
 				type: "checkmark"
 				title: "Storage and transport"
 			}]
+			description: [
+				"General network and storage parts of the ME Network."
+				""
+				"The ME Network (pr. Emm-Eee: Matter Energy) is a set of connected blocks, and cables grouped into a system, where storage, power and functions cooperate between multiple components."
+			]
+			id: "5683C69200EBC4CD"
+			x: -11.0d
+			y: -4.5d
+			title: "Storage and Transport"
+			dependencies: [
+				"43709A95E106563B"
+				"7CE18D246F01445D"
+			]
+			dependency_requirement: "one_completed"
 		}
 		{
-			x: 1.0d
-			y: -5.5d
-			subtitle: "Pushes crafting recipes encoded in patterns to nearby machines/containers."
+			tasks: [{
+				id: "1A5F4DE4911B984A"
+				type: "item"
+				item: "ae2:pattern_provider"
+			}]
 			description: [
 				"                                --- About Autocrafting ---"
 				"The encoded patterns need to be put into pattern providers on the same network as the Crafting CPU itself."
@@ -1072,75 +1075,60 @@
 				"> Without Redstone Signal - pushes Pattern items only when Provider is NOT powered by Redstone."
 				"> Until primary crafting result is returned (to the same Pattern Provider, that pushed the crafting recipe) - will also insert one recipe at a time."
 			]
-			dependencies: ["2BE8127E1180DA21"]
-			min_width: 400
 			id: "20AD73B935309188"
-			tasks: [{
-				id: "1A5F4DE4911B984A"
-				type: "item"
-				item: "ae2:pattern_provider"
-			}]
+			x: 1.0d
+			y: -5.5d
 			rewards: [{
 				id: "2A54A638B71261B7"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			min_width: 400
+			subtitle: "Pushes crafting recipes encoded in patterns to nearby machines/containers."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: 5.0d
-			y: -4.0d
-			subtitle: "Keeps items in stock by making crafting requests to the ME Network."
-			description: [
-				"One Requester can keep 5 items in stock."
-				""
-				"You can set the item, amount of the item to stock, and the size of one batch which will be requested continuously until the amount to stock is reached."
-			]
-			dependencies: ["2BE8127E1180DA21"]
-			id: "40FC373056C16F8D"
 			tasks: [{
 				id: "4AC53B928B57CFE4"
 				type: "item"
 				item: "merequester:requester"
 			}]
+			description: [
+				"One Requester can keep 5 items in stock."
+				""
+				"You can set the item, amount of the item to stock, and the size of one batch which will be requested continuously until the amount to stock is reached."
+			]
+			id: "40FC373056C16F8D"
+			x: 5.0d
+			y: -4.0d
 			rewards: [{
 				id: "694B1E4CF3B1F6C3"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Keeps items in stock by making crafting requests to the ME Network."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: 5.0d
-			y: -3.0d
-			subtitle: "A HID which gives you access to all ME Requesters connected to the network."
-			dependencies: ["2BE8127E1180DA21"]
-			id: "5B869B2834EFC0AA"
 			tasks: [{
 				id: "532676485F4631D2"
 				type: "item"
 				item: "merequester:requester_terminal"
 			}]
+			id: "5B869B2834EFC0AA"
+			x: 5.0d
+			y: -3.0d
 			rewards: [{
 				id: "79ED7C77A5C3193C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A HID which gives you access to all ME Requesters connected to the network."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: -12.0d
-			y: -13.0d
-			subtitle: "Higher Tier Storage Cell, which can contain 262,144 bytes of storage."
-			description: [
-				"262,144 bytes of storage can hold 32,512 Stacks of a single item. or 16,640 Stacks, while holding 63 Different items."
-				""
-				"The 256k Storage Cell uses 2,048 bytes of data to store a single type."
-				""
-				"8 Items take up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "0D1DBAAB4C29A4B2"
 			tasks: [{
 				id: "79853D301CE0FA2E"
 				type: "item"
@@ -1150,29 +1138,27 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"262,144 bytes of storage can hold 32,512 Stacks of a single item. or 16,640 Stacks, while holding 63 Different items."
+				""
+				"The 256k Storage Cell uses 2,048 bytes of data to store a single type."
+				""
+				"8 Items take up 1 byte."
+			]
+			id: "0D1DBAAB4C29A4B2"
+			x: -12.0d
+			y: -13.0d
 			rewards: [{
 				id: "327EC0D75CA14E9C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Higher Tier Storage Cell, which can contain 262,144 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -12.0d
-			y: -15.0d
-			subtitle: "Very high Tier Storage Cell, which can contain 8,388,608 bytes of storage."
-			description: [
-				"8,388,608 bytes of storage can hold 1,047,552 Stacks of a single item. or 894,976 Stacks, while holding 150 Different items."
-				""
-				"The 4096k Storage Cell uses 8,192 bytes of data to store a single type."
-				""
-				"8 Items take up 1 byte."
-				""
-				"This cell does not accept upgrades!"
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "47BF09742658937F"
 			tasks: [{
 				id: "7C0531DBC6B7CA3A"
 				type: "item"
@@ -1182,29 +1168,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"8,388,608 bytes of storage can hold 1,047,552 Stacks of a single item. or 894,976 Stacks, while holding 150 Different items."
+				""
+				"The 4096k Storage Cell uses 8,192 bytes of data to store a single type."
+				""
+				"8 Items take up 1 byte."
+				""
+				"This cell does not accept upgrades!"
+			]
+			id: "47BF09742658937F"
+			x: -12.0d
+			y: -15.0d
 			rewards: [{
 				id: "31894FEB3ADC65BD"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Very high Tier Storage Cell, which can contain 8,388,608 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -12.0d
-			y: -16.0d
-			subtitle: "Extremely high Tier Storage Cell, which can contain 16,777,216 bytes of storage."
-			description: [
-				"16,777,216 bytes of storage can hold 2,093,056 Stacks of a single item. or 1,277,952 Stacks, while holding 200 Different items."
-				""
-				"The 16384k Storage Cell uses 32,768 bytes of data to store a single type."
-				""
-				"8 Items take up 1 byte."
-				""
-				"This cell does not accept upgrades!"
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "0F0B9AEBF18374E6"
 			tasks: [{
 				id: "52B446807607C861"
 				type: "item"
@@ -1214,26 +1200,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"16,777,216 bytes of storage can hold 2,093,056 Stacks of a single item. or 1,277,952 Stacks, while holding 200 Different items."
+				""
+				"The 16384k Storage Cell uses 32,768 bytes of data to store a single type."
+				""
+				"8 Items take up 1 byte."
+				""
+				"This cell does not accept upgrades!"
+			]
+			id: "0F0B9AEBF18374E6"
+			x: -12.0d
+			y: -16.0d
 			rewards: [{
 				id: "778E8C92B12D4D32"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Extremely high Tier Storage Cell, which can contain 16,777,216 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -10.0d
-			y: -9.0d
-			subtitle: "Lowest Tier Storage Cell, which can contain 1,024 bytes of storage."
-			description: [
-				"1,024 bytes of storage can hold 8128 Buckets of a single fluid. or 7872 Buckets while holding 5 Different fluids."
-				""
-				"The 1k Storage Cell uses 8 bytes of data to store a single type."
-				""
-				"8 Buckets of fluid take up 1 byte."
-			]
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "6C1E1FE24F56BA1A"
 			tasks: [{
 				id: "667FB36E7A9D5C02"
 				type: "item"
@@ -1243,27 +1232,26 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"1,024 bytes of storage can hold 8128 Buckets of a single fluid. or 7872 Buckets while holding 5 Different fluids."
+				""
+				"The 1k Storage Cell uses 8 bytes of data to store a single type."
+				""
+				"8 Buckets of fluid take up 1 byte."
+			]
+			id: "6C1E1FE24F56BA1A"
+			x: -10.0d
+			y: -9.0d
 			rewards: [{
 				id: "5B0CB4E7E3007EC5"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Lowest Tier Storage Cell, which can contain 1,024 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
 		}
 		{
-			x: -10.0d
-			y: -10.0d
-			subtitle: "Low Tier Storage Cell, which can contain 4,096 bytes of storage."
-			description: [
-				"4,096 bytes of storage can hold 32,512 Buckets of a single fluid. or 31,488 Buckets while holding 5 Different fluids."
-				""
-				"The 4k Storage Cell uses 32 bytes of data to store a single type."
-				""
-				"8 Buckets of fluid take up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "65A0AA0DC272DABC"
 			tasks: [{
 				id: "79F0256C5B758C1B"
 				type: "item"
@@ -1273,27 +1261,27 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"4,096 bytes of storage can hold 32,512 Buckets of a single fluid. or 31,488 Buckets while holding 5 Different fluids."
+				""
+				"The 4k Storage Cell uses 32 bytes of data to store a single type."
+				""
+				"8 Buckets of fluid take up 1 byte."
+			]
+			id: "65A0AA0DC272DABC"
+			x: -10.0d
+			y: -10.0d
 			rewards: [{
 				id: "1D4F1FE54E84C260"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Low Tier Storage Cell, which can contain 4,096 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -10.0d
-			y: -11.0d
-			subtitle: "Middle Tier Storage Cell, which can contain 16,384 bytes of storage."
-			description: [
-				"16,384 bytes of storage can hold 130,048 Buckets of a single fluid. or 125,952 Buckets while holding 5 Different fluids."
-				""
-				"The 16k Storage Cell uses 128 bytes of data to store a single type."
-				""
-				"8 Buckets of fluid take up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "50C931E4D600C0FB"
 			tasks: [{
 				id: "5313D3FAA3AC4933"
 				type: "item"
@@ -1303,27 +1291,27 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"16,384 bytes of storage can hold 130,048 Buckets of a single fluid. or 125,952 Buckets while holding 5 Different fluids."
+				""
+				"The 16k Storage Cell uses 128 bytes of data to store a single type."
+				""
+				"8 Buckets of fluid take up 1 byte."
+			]
+			id: "50C931E4D600C0FB"
+			x: -10.0d
+			y: -11.0d
 			rewards: [{
 				id: "3249A717585CD19D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Middle Tier Storage Cell, which can contain 16,384 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -10.0d
-			y: -12.0d
-			subtitle: "High Tier Storage Cell, which can contain 65,536 bytes of storage."
-			description: [
-				"65,536 bytes of storage can hold 520,192 Buckets of a single fluid. or 503,808 Buckets while holding 5 Different fluids."
-				""
-				"The 64k Storage Cell uses 512 bytes of data to store a single type."
-				""
-				"8 Buckets of fluid take up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "21158C062AC7606A"
 			tasks: [{
 				id: "000F6AA7BDA7EF79"
 				type: "item"
@@ -1333,27 +1321,27 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"65,536 bytes of storage can hold 520,192 Buckets of a single fluid. or 503,808 Buckets while holding 5 Different fluids."
+				""
+				"The 64k Storage Cell uses 512 bytes of data to store a single type."
+				""
+				"8 Buckets of fluid take up 1 byte."
+			]
+			id: "21158C062AC7606A"
+			x: -10.0d
+			y: -12.0d
 			rewards: [{
 				id: "24D7707AEBE22219"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "High Tier Storage Cell, which can contain 65,536 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -10.0d
-			y: -13.0d
-			subtitle: "Higher Tier Storage Cell, which can contain 262,144 bytes of storage."
-			description: [
-				"262,144 bytes of storage can hold 2,080,768 Buckets of a single fluid. or 2,015,232 Buckets while holding 5 Different fluids."
-				""
-				"The 256k Storage Cell uses 2,048 bytes of data to store a single type."
-				""
-				"8 Buckets of fluid take up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "6B92D43A12B62631"
 			tasks: [{
 				id: "5FF24E5DB1DE2421"
 				type: "item"
@@ -1363,29 +1351,27 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"262,144 bytes of storage can hold 2,080,768 Buckets of a single fluid. or 2,015,232 Buckets while holding 5 Different fluids."
+				""
+				"The 256k Storage Cell uses 2,048 bytes of data to store a single type."
+				""
+				"8 Buckets of fluid take up 1 byte."
+			]
+			id: "6B92D43A12B62631"
+			x: -10.0d
+			y: -13.0d
 			rewards: [{
 				id: "2641C333E568C00F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Higher Tier Storage Cell, which can contain 262,144 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -10.0d
-			y: -15.0d
-			subtitle: "Very high Tier Storage Cell, which can contain 4,194,304 bytes of storage."
-			description: [
-				"4,194,304 bytes of storage can hold 33,488,896 Buckets of a single fluid. or 32,571,392 Buckets while holding 15 Different fluids."
-				""
-				"The 4096k Storage Cell uses 8,192 bytes of data to store a single type."
-				""
-				"8 Buckets of fluid take up 1 byte."
-				""
-				"This cell does not accept upgrades!"
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "3168D649A4C5C2AF"
 			tasks: [{
 				id: "1F8DBE7ADCE1EF15"
 				type: "item"
@@ -1395,29 +1381,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"4,194,304 bytes of storage can hold 33,488,896 Buckets of a single fluid. or 32,571,392 Buckets while holding 15 Different fluids."
+				""
+				"The 4096k Storage Cell uses 8,192 bytes of data to store a single type."
+				""
+				"8 Buckets of fluid take up 1 byte."
+				""
+				"This cell does not accept upgrades!"
+			]
+			id: "3168D649A4C5C2AF"
+			x: -10.0d
+			y: -15.0d
 			rewards: [{
 				id: "780AEA8111CD1E3B"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Very high Tier Storage Cell, which can contain 4,194,304 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -10.0d
-			y: -16.0d
-			subtitle: "Highest Tier Storage Cell, which can contain 16,777,216 bytes of storage."
-			description: [
-				"16,777,216 bytes of storage can hold 133,955,584 Buckets of a single fluid. or 128,974,848 Buckets while holding 20 Different fluids."
-				""
-				"The 16384k Storage Cell uses 32,768 bytes of data to store a single type."
-				""
-				"8 Buckets of fluid take up 1 byte."
-				""
-				"This cell does not accept upgrades!"
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "66C8DD50C666B571"
 			tasks: [{
 				id: "7BAD74354CC1DDF6"
 				type: "item"
@@ -1427,26 +1413,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"16,777,216 bytes of storage can hold 133,955,584 Buckets of a single fluid. or 128,974,848 Buckets while holding 20 Different fluids."
+				""
+				"The 16384k Storage Cell uses 32,768 bytes of data to store a single type."
+				""
+				"8 Buckets of fluid take up 1 byte."
+				""
+				"This cell does not accept upgrades!"
+			]
+			id: "66C8DD50C666B571"
+			x: -10.0d
+			y: -16.0d
 			rewards: [{
 				id: "5D3CCAA158F43F24"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Highest Tier Storage Cell, which can contain 16,777,216 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -12.5d
-			y: -7.0d
-			subtitle: "Lowest Tier Storage Cell, which can contain 1,024 bytes of storage."
-			description: [
-				"It stores 508,000 Mana."
-				"(about 0.5 Mana Pools)"
-			]
-			dependencies: [
-				"19FBAF9A70549BF5"
-				"1C502D06D2093A4F"
-			]
-			id: "646D7BA27DEC967C"
 			tasks: [{
 				id: "0C097C61C2D493F8"
 				type: "item"
@@ -1456,26 +1445,26 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"It stores 508,000 Mana."
+				"(about 0.5 Mana Pools)"
+			]
+			id: "646D7BA27DEC967C"
+			x: -12.5d
+			y: -7.0d
 			rewards: [{
 				id: "0CEFA996BB877366"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Lowest Tier Storage Cell, which can contain 1,024 bytes of storage."
+			dependencies: [
+				"19FBAF9A70549BF5"
+				"1C502D06D2093A4F"
+			]
 		}
 		{
-			x: -13.5d
-			y: -7.0d
-			subtitle: "Low Tier Storage Cell, which can contain 4,096 bytes of storage."
-			description: [
-				"It stores 2,032,000 mana."
-				"(about 2 Mana Pools)"
-			]
-			dependencies: [
-				"1C502D06D2093A4F"
-				"19FBAF9A70549BF5"
-			]
-			id: "45B4961C68B3B300"
 			tasks: [{
 				id: "1B6C70E93F74EB32"
 				type: "item"
@@ -1485,26 +1474,26 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"It stores 2,032,000 mana."
+				"(about 2 Mana Pools)"
+			]
+			id: "45B4961C68B3B300"
+			x: -13.5d
+			y: -7.0d
 			rewards: [{
 				id: "15E65833D7B9DA8D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			x: -14.5d
-			y: -7.0d
-			subtitle: "Middle Tier Storage Cell, which can contain 16,384 bytes of storage."
-			description: [
-				"It stores 8,128,000 mana."
-				"(about 8.1 Mana Pools)"
-			]
+			subtitle: "Low Tier Storage Cell, which can contain 4,096 bytes of storage."
 			dependencies: [
 				"1C502D06D2093A4F"
 				"19FBAF9A70549BF5"
 			]
-			id: "1721419C13B2B450"
+		}
+		{
 			tasks: [{
 				id: "44350B94F569AD59"
 				type: "item"
@@ -1514,26 +1503,26 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"It stores 8,128,000 mana."
+				"(about 8.1 Mana Pools)"
+			]
+			id: "1721419C13B2B450"
+			x: -14.5d
+			y: -7.0d
 			rewards: [{
 				id: "3DA6CFF238529DB6"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			x: -15.5d
-			y: -7.0d
-			subtitle: "High Tier Storage Cell, which can contain 65,536 bytes of storage."
-			description: [
-				"It stores 32,512,000 mana."
-				"(about 32.5 Mana Pools)"
-			]
+			subtitle: "Middle Tier Storage Cell, which can contain 16,384 bytes of storage."
 			dependencies: [
 				"1C502D06D2093A4F"
 				"19FBAF9A70549BF5"
 			]
-			id: "41C575953C323009"
+		}
+		{
 			tasks: [{
 				id: "77388A8F1B5F409C"
 				type: "item"
@@ -1543,24 +1532,26 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"It stores 32,512,000 mana."
+				"(about 32.5 Mana Pools)"
+			]
+			id: "41C575953C323009"
+			x: -15.5d
+			y: -7.0d
 			rewards: [{
 				id: "3233AE1C5B3182F3"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "High Tier Storage Cell, which can contain 65,536 bytes of storage."
+			dependencies: [
+				"1C502D06D2093A4F"
+				"19FBAF9A70549BF5"
+			]
 		}
 		{
-			x: -11.0d
-			y: -9.0d
-			subtitle: "Lowest Tier Storage Cell, which can contain 1,024 bytes of storage."
-			description: [
-				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
-				""
-				"These cells cannot be formatted nor upgraded."
-			]
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "5F5920414DBA920F"
 			tasks: [{
 				id: "327983B4CDB975A4"
 				type: "item"
@@ -1570,25 +1561,24 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
+				""
+				"These cells cannot be formatted nor upgraded."
+			]
+			id: "5F5920414DBA920F"
+			x: -11.0d
+			y: -9.0d
 			rewards: [{
 				id: "4842005D2DDB5229"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Lowest Tier Storage Cell, which can contain 1,024 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
 		}
 		{
-			x: -11.0d
-			y: -10.0d
-			subtitle: "Low Tier Storage Cell, which can contain 4,096 bytes of storage."
-			description: [
-				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
-				""
-				"These cells cannot be formatted nor upgraded."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "05C269D4892D9CD8"
 			tasks: [{
 				id: "5C6A72AFE137626B"
 				type: "item"
@@ -1598,25 +1588,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
+				""
+				"These cells cannot be formatted nor upgraded."
+			]
+			id: "05C269D4892D9CD8"
+			x: -11.0d
+			y: -10.0d
 			rewards: [{
 				id: "3A37D0501003B31F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Low Tier Storage Cell, which can contain 4,096 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -11.0d
-			y: -11.0d
-			subtitle: "Middle Tier Storage Cell, which can contain 16,384 bytes of storage."
-			description: [
-				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
-				""
-				"These cells cannot be formatted nor upgraded."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "2BD31184B35B22A8"
 			tasks: [{
 				id: "54F42F768B7E2568"
 				type: "item"
@@ -1626,25 +1616,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
+				""
+				"These cells cannot be formatted nor upgraded."
+			]
+			id: "2BD31184B35B22A8"
+			x: -11.0d
+			y: -11.0d
 			rewards: [{
 				id: "4FF14805DE3F3197"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Middle Tier Storage Cell, which can contain 16,384 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -11.0d
-			y: -12.0d
-			subtitle: "High Tier Storage Cell, which can contain 65,536 bytes of storage."
-			description: [
-				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
-				""
-				"These cells cannot be formatted nor upgraded."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "23D0A80042101606"
 			tasks: [{
 				id: "06C6C2091A89189A"
 				type: "item"
@@ -1654,25 +1644,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
+				""
+				"These cells cannot be formatted nor upgraded."
+			]
+			id: "23D0A80042101606"
+			x: -11.0d
+			y: -12.0d
 			rewards: [{
 				id: "7AFBC0D8FC17C466"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "High Tier Storage Cell, which can contain 65,536 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -11.0d
-			y: -13.0d
-			subtitle: "Higher Tier Storage Cell, which can contain 262,144 bytes of storage."
-			description: [
-				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
-				""
-				"These cells cannot be formatted nor upgraded."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "3F7ACD00C9119A5D"
 			tasks: [{
 				id: "7A349AFFA8C8679D"
 				type: "item"
@@ -1682,25 +1672,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
+				""
+				"These cells cannot be formatted nor upgraded."
+			]
+			id: "3F7ACD00C9119A5D"
+			x: -11.0d
+			y: -13.0d
 			rewards: [{
 				id: "7D9A41C02D59E894"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Higher Tier Storage Cell, which can contain 262,144 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -11.0d
-			y: -15.0d
-			subtitle: "Very high Tier Storage Cell, which can contain 4,194,304 bytes of storage."
-			description: [
-				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
-				""
-				"These cells cannot be formatted nor upgraded."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "3E2A84421F1ABA4A"
 			tasks: [{
 				id: "0587548EC3094CBB"
 				type: "item"
@@ -1710,29 +1700,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
+				""
+				"These cells cannot be formatted nor upgraded."
+			]
+			id: "3E2A84421F1ABA4A"
+			x: -11.0d
+			y: -15.0d
 			rewards: [{
 				id: "041F414A12B2ABF3"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Very high Tier Storage Cell, which can contain 4,194,304 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -12.0d
-			y: -14.0d
-			subtitle: "Even higher Tier Storage Cell, which can contain 1,048,576 bytes of storage."
-			description: [
-				"1,048,576 bytes of storage can hold 130,048 Stacks of a single item. or 79,872 Stacks, while holding 100 Different items."
-				""
-				"The 1024k Storage Cell uses 4,096 bytes of data to store a single type."
-				""
-				"8 Items take up 1 byte."
-				""
-				"This cell does not accept upgrades!"
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "56DCD1CF3647FBC7"
 			tasks: [{
 				id: "41AD49611BB82EF2"
 				type: "item"
@@ -1742,29 +1728,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"1,048,576 bytes of storage can hold 130,048 Stacks of a single item. or 79,872 Stacks, while holding 100 Different items."
+				""
+				"The 1024k Storage Cell uses 4,096 bytes of data to store a single type."
+				""
+				"8 Items take up 1 byte."
+				""
+				"This cell does not accept upgrades!"
+			]
+			id: "56DCD1CF3647FBC7"
+			x: -12.0d
+			y: -14.0d
 			rewards: [{
 				id: "49B392990F2EF5DD"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Even higher Tier Storage Cell, which can contain 1,048,576 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -10.0d
-			y: -14.0d
-			subtitle: "Even higher Tier Storage Cell, which can contain 1,048,576 bytes of storage."
-			description: [
-				"1,048,576 bytes of storage can hold 8,355,840 Buckets of a single fluid. or 8,060,928 Buckets while holding 10 Different fluids."
-				""
-				"The 1024k Storage Cell uses 4,096 bytes of data to store a single type."
-				""
-				"8 Buckets of fluid take up 1 byte."
-				""
-				"This cell does not accept upgrades!"
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "6C2DD7E2CE2DCD50"
 			tasks: [{
 				id: "033723F0C32CAD46"
 				type: "item"
@@ -1774,25 +1760,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"1,048,576 bytes of storage can hold 8,355,840 Buckets of a single fluid. or 8,060,928 Buckets while holding 10 Different fluids."
+				""
+				"The 1024k Storage Cell uses 4,096 bytes of data to store a single type."
+				""
+				"8 Buckets of fluid take up 1 byte."
+				""
+				"This cell does not accept upgrades!"
+			]
+			id: "6C2DD7E2CE2DCD50"
+			x: -10.0d
+			y: -14.0d
 			rewards: [{
 				id: "05681B2AA42503B8"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Even higher Tier Storage Cell, which can contain 1,048,576 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -11.0d
-			y: -14.0d
-			subtitle: "Even higher Tier Storage Cell, which can contain 1,048,576 bytes of storage."
-			description: [
-				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
-				""
-				"These cells cannot be formatted nor upgraded."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "3B7AE9B7813AC175"
 			tasks: [{
 				id: "1B6DCC50A072941D"
 				type: "item"
@@ -1802,25 +1792,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
+				""
+				"These cells cannot be formatted nor upgraded."
+			]
+			id: "3B7AE9B7813AC175"
+			x: -11.0d
+			y: -14.0d
 			rewards: [{
 				id: "0548F9BDA9595F0B"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Even higher Tier Storage Cell, which can contain 1,048,576 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -11.0d
-			y: -16.0d
-			subtitle: "Extremely high Tier Storage Cell, which can contain 16,777,216 bytes of storage."
-			description: [
-				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
-				""
-				"These cells cannot be formatted nor upgraded."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "7DC6E09FB2FA9027"
 			tasks: [{
 				id: "6A8CDC2839F55779"
 				type: "item"
@@ -1830,25 +1820,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
+				""
+				"These cells cannot be formatted nor upgraded."
+			]
+			id: "7DC6E09FB2FA9027"
+			x: -11.0d
+			y: -16.0d
 			rewards: [{
 				id: "30953F6E451BAA2F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Extremely high Tier Storage Cell, which can contain 16,777,216 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -11.0d
-			y: -17.0d
-			subtitle: "Highest Tier Storage Cell, which can contain 67,108,864 bytes of storage."
-			description: [
-				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
-				""
-				"These cells cannot be formatted nor upgraded."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "36051E2E5BC91744"
 			tasks: [{
 				id: "3D1B12C0F19B0BFF"
 				type: "item"
@@ -1858,29 +1848,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Super Storage Cells can hold Items, Fluids and Mana - all at once!"
+				""
+				"These cells cannot be formatted nor upgraded."
+			]
+			id: "36051E2E5BC91744"
+			x: -11.0d
+			y: -17.0d
 			rewards: [{
 				id: "18887866AB588782"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Highest Tier Storage Cell, which can contain 67,108,864 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -12.0d
-			y: -17.0d
-			subtitle: "Highest Tier Storage Cell, which can contain 67,108,864 bytes of storage."
-			description: [
-				"67,108,864 bytes of storage can hold 8,372,224 Stacks of a single item. or 3,473,408 Stacks, while holding 300 Different items."
-				""
-				"The 65536k Storage Cell uses 131,072 bytes of data to store a single type."
-				""
-				"8 Items take up 1 byte."
-				""
-				"This cell does not accept upgrades!"
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "0E64DB2A29F809C5"
 			tasks: [{
 				id: "3C349EC67674153F"
 				type: "item"
@@ -1890,24 +1876,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"67,108,864 bytes of storage can hold 8,372,224 Stacks of a single item. or 3,473,408 Stacks, while holding 300 Different items."
+				""
+				"The 65536k Storage Cell uses 131,072 bytes of data to store a single type."
+				""
+				"8 Items take up 1 byte."
+				""
+				"This cell does not accept upgrades!"
+			]
+			id: "0E64DB2A29F809C5"
+			x: -12.0d
+			y: -17.0d
 			rewards: [{
 				id: "1F755C17E6378AA0"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Highest Tier Storage Cell, which can contain 67,108,864 bytes of storage."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -9.0d
-			y: -9.0d
-			subtitle: "Lowest Tier fluid DISK, which can contain 1,024 droplets (12 ⁵²/₈₁ mb)."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
-			]
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "004758FABD151C7A"
 			tasks: [{
 				id: "5431393D4A52CC68"
 				type: "item"
@@ -1917,25 +1908,24 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
+			]
+			id: "004758FABD151C7A"
+			x: -9.0d
+			y: -9.0d
 			rewards: [{
 				id: "22472A5FA0529871"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Lowest Tier fluid DISK, which can contain 1,024 droplets (12 ⁵²/₈₁ mb)."
+			dependencies: ["19FBAF9A70549BF5"]
 		}
 		{
-			x: -9.0d
-			y: -10.0d
-			subtitle: "Low Tier fluid DISK, which can contain 4,096 droplets (50 ⁴⁶/₈₁ mB)."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "4908925B5307A07F"
 			tasks: [{
 				id: "62CD00EE63245701"
 				type: "item"
@@ -1945,25 +1935,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
+			]
+			id: "4908925B5307A07F"
+			x: -9.0d
+			y: -10.0d
 			rewards: [{
 				id: "3FE108925C26263D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Low Tier fluid DISK, which can contain 4,096 droplets (50 ⁴⁶/₈₁ mB)."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -9.0d
-			y: -11.0d
-			subtitle: "Middle Tier fluid DISK, which can contain 16,384 droplets (202 ²²/₈₁ mB)."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "36C11DD6691F4269"
 			tasks: [{
 				id: "4DF8A89B3A0E6F60"
 				type: "item"
@@ -1973,25 +1963,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
+			]
+			id: "36C11DD6691F4269"
+			x: -9.0d
+			y: -11.0d
 			rewards: [{
 				id: "4DF2A6D450C90209"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Middle Tier fluid DISK, which can contain 16,384 droplets (202 ²²/₈₁ mB)."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -9.0d
-			y: -12.0d
-			subtitle: "High Tier fluid DISK, which can contain 65,536 droplets (809 ⁷/₈₁ mB)."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "18A955BD8CDE786D"
 			tasks: [{
 				id: "54A13614C10CB89C"
 				type: "item"
@@ -2001,25 +1991,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
+			]
+			id: "18A955BD8CDE786D"
+			x: -9.0d
+			y: -12.0d
 			rewards: [{
 				id: "3B149159551A1BF2"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "High Tier fluid DISK, which can contain 65,536 droplets (809 ⁷/₈₁ mB)."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -9.0d
-			y: -13.0d
-			subtitle: "Higher Tier fluid DISK, which can contain 262,144 droplets (3,236 ²⁸/₈₁ mB)."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "3DF93144B245CFA8"
 			tasks: [{
 				id: "018E17ACC9F07211"
 				type: "item"
@@ -2029,25 +2019,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
+			]
+			id: "3DF93144B245CFA8"
+			x: -9.0d
+			y: -13.0d
 			rewards: [{
 				id: "057D157A34C15EA8"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Higher Tier fluid DISK, which can contain 262,144 droplets (3,236 ²⁸/₈₁ mB)."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -9.0d
-			y: -14.0d
-			subtitle: "Even higher Tier fluid DISK, which can contain 1,048,576 droplets (12,945 ³¹/₈₁ mB)."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "390DD76BEB28E089"
 			tasks: [{
 				id: "5062F88A93091692"
 				type: "item"
@@ -2057,25 +2047,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
+			]
+			id: "390DD76BEB28E089"
+			x: -9.0d
+			y: -14.0d
 			rewards: [{
 				id: "03E1E68D98261DCE"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Even higher Tier fluid DISK, which can contain 1,048,576 droplets (12,945 ³¹/₈₁ mB)."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -9.0d
-			y: -15.0d
-			subtitle: "Very high Tier fluid DISK, which can contain 4,194,304 droplets (51,781 ⁴³/₈₁ mB)."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "66B5DC76B4EEC937"
 			tasks: [{
 				id: "64919C14C864683E"
 				type: "item"
@@ -2085,25 +2075,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
+			]
+			id: "66B5DC76B4EEC937"
+			x: -9.0d
+			y: -15.0d
 			rewards: [{
 				id: "00D7B2A6B88B577F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Very high Tier fluid DISK, which can contain 4,194,304 droplets (51,781 ⁴³/₈₁ mB)."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -9.0d
-			y: -16.0d
-			subtitle: "Extremely high Tier fluid DISK, which can contain 16,777,216 droplets (207,126 ¹⁰/₈₁ mB)."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "5837BF8AC9B3D71D"
 			tasks: [{
 				id: "48DC87ED9A4D53CF"
 				type: "item"
@@ -2113,25 +2103,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
+			]
+			id: "5837BF8AC9B3D71D"
+			x: -9.0d
+			y: -16.0d
 			rewards: [{
 				id: "0C640C7536AA75CA"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Extremely high Tier fluid DISK, which can contain 16,777,216 droplets (207,126 ¹⁰/₈₁ mB)."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -9.0d
-			y: -17.0d
-			subtitle: "Highest Tier fluid DISK, which can contain 67,108,864 droplets (828,504 ⁴⁰/₈₁ mB)."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "7CA5674AB77F01D3"
 			tasks: [{
 				id: "75D2FD4B396A82D8"
 				type: "item"
@@ -2141,24 +2131,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"1 droplet (¹/₈₁ mB) of fluid takes up 1 byte."
+			]
+			id: "7CA5674AB77F01D3"
+			x: -9.0d
+			y: -17.0d
 			rewards: [{
 				id: "3689C3DA15CAAD69"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Highest Tier fluid DISK, which can contain 67,108,864 droplets (828,504 ⁴⁰/₈₁ mB)."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -13.0d
-			y: -9.0d
-			subtitle: "Lowest Tier DISK, which can contain 1,000 items."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"However, 1 item takes up 1 byte."
-			]
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "6E54238840D4783B"
 			tasks: [{
 				id: "673A7ECF3E8C31EA"
 				type: "item"
@@ -2168,25 +2159,24 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"However, 1 item takes up 1 byte."
+			]
+			id: "6E54238840D4783B"
+			x: -13.0d
+			y: -9.0d
 			rewards: [{
 				id: "322D94F8A4D8887E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Lowest Tier DISK, which can contain 1,000 items."
+			dependencies: ["19FBAF9A70549BF5"]
 		}
 		{
-			x: -13.0d
-			y: -10.0d
-			subtitle: "Low Tier DISK, which can contain 4,000 items."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"However, 1 item takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "6D5D3718B929F4AB"
 			tasks: [{
 				id: "423E9BB4A44B6B3C"
 				type: "item"
@@ -2196,25 +2186,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"However, 1 item takes up 1 byte."
+			]
+			id: "6D5D3718B929F4AB"
+			x: -13.0d
+			y: -10.0d
 			rewards: [{
 				id: "7848CA478AA1BFDD"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Low Tier DISK, which can contain 4,000 items."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -13.0d
-			y: -11.0d
-			subtitle: "Middle Tier DISK, which can contain 16,000 items."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"However, 1 item takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "6D3A1045F45FA69E"
 			tasks: [{
 				id: "0ED95E9897628CD8"
 				type: "item"
@@ -2224,25 +2214,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"However, 1 item takes up 1 byte."
+			]
+			id: "6D3A1045F45FA69E"
+			x: -13.0d
+			y: -11.0d
 			rewards: [{
 				id: "1DAEC0E31673DDE9"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Middle Tier DISK, which can contain 16,000 items."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -13.0d
-			y: -12.0d
-			subtitle: "High Tier DISK, which can contain 64,000 items."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"However, 1 item takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "6BDC3795A141711F"
 			tasks: [{
 				id: "2F4CB9D82CF7DB03"
 				type: "item"
@@ -2252,25 +2242,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"However, 1 item takes up 1 byte."
+			]
+			id: "6BDC3795A141711F"
+			x: -13.0d
+			y: -12.0d
 			rewards: [{
 				id: "61F5B43959209877"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "High Tier DISK, which can contain 64,000 items."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -13.0d
-			y: -13.0d
-			subtitle: "Higher Tier DISK, which can contain 262,144 items."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"However, 1 item takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "4290CC67CB9C627F"
 			tasks: [{
 				id: "506F36B0A9652E67"
 				type: "item"
@@ -2280,25 +2270,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"However, 1 item takes up 1 byte."
+			]
+			id: "4290CC67CB9C627F"
+			x: -13.0d
+			y: -13.0d
 			rewards: [{
 				id: "0F131C63BBE5CD13"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Higher Tier DISK, which can contain 262,144 items."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -13.0d
-			y: -14.0d
-			subtitle: "Even higher Tier DISK, which can contain 1,048,576 items."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"However, 1 item takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "065FFA7093CC8F1D"
 			tasks: [{
 				id: "7AAA98A08D005C17"
 				type: "item"
@@ -2308,25 +2298,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"However, 1 item takes up 1 byte."
+			]
+			id: "065FFA7093CC8F1D"
+			x: -13.0d
+			y: -14.0d
 			rewards: [{
 				id: "1DF72A3A113D54A1"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Even higher Tier DISK, which can contain 1,048,576 items."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -13.0d
-			y: -15.0d
-			subtitle: "Very high Tier DISK, which can contain 4,194,304 items."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"However, 1 item takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "16C4CF96DCDE1C9F"
 			tasks: [{
 				id: "45EA7B54BDA049B1"
 				type: "item"
@@ -2336,25 +2326,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"However, 1 item takes up 1 byte."
+			]
+			id: "16C4CF96DCDE1C9F"
+			x: -13.0d
+			y: -15.0d
 			rewards: [{
 				id: "37EF2F2C6CC0B47A"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Very high Tier DISK, which can contain 4,194,304 items."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -13.0d
-			y: -16.0d
-			subtitle: "Extremely high Tier DISK, which can contain 16,777,216 items."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"However, 1 item takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "34B2EC196D37BBD5"
 			tasks: [{
 				id: "4AAA1EBECA9A1B78"
 				type: "item"
@@ -2364,25 +2354,25 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"However, 1 item takes up 1 byte."
+			]
+			id: "34B2EC196D37BBD5"
+			x: -13.0d
+			y: -16.0d
 			rewards: [{
 				id: "3F72CF883DC7555A"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Extremely high Tier DISK, which can contain 16,777,216 items."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -13.0d
-			y: -17.0d
-			subtitle: "Highest Tier DISK, which can contain 67,108,864 items."
-			description: [
-				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
-				""
-				"However, 1 item takes up 1 byte."
-			]
-			hide_dependency_lines: true
-			dependencies: ["19FBAF9A70549BF5"]
-			id: "11AE46BDD53F6528"
 			tasks: [{
 				id: "0EE191E7AA6778DA"
 				type: "item"
@@ -2392,130 +2382,143 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"DISKs work like Storage Disks from Refined Storage - meaning that they have no type limits."
+				""
+				"However, 1 item takes up 1 byte."
+			]
+			id: "11AE46BDD53F6528"
+			x: -13.0d
+			y: -17.0d
 			rewards: [{
 				id: "2BF170D72B569467"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Highest Tier DISK, which can contain 67,108,864 items."
+			dependencies: ["19FBAF9A70549BF5"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 4.5d
-			y: -1.5d
-			subtitle: "Provides 262,144 bytes of storage for crafting."
-			dependencies: ["2BE8127E1180DA21"]
-			id: "251F9FC322ED0512"
 			tasks: [{
 				id: "03206F38961D3D1E"
 				type: "item"
 				item: "ae2:256k_crafting_storage"
 			}]
+			id: "251F9FC322ED0512"
+			x: 4.5d
+			y: -1.5d
 			rewards: [{
 				id: "7C966E6655B6DD55"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Provides 262,144 bytes of storage for crafting."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: 0.5d
-			y: -0.5d
-			subtitle: "Provides 1 MByte of storage for crafting."
-			dependencies: ["2BE8127E1180DA21"]
-			id: "1A7613F5225E87D9"
 			tasks: [{
 				id: "23B28F74DD3DF68B"
 				type: "item"
 				item: "ae2additions:1024k_crafting_storage"
 			}]
+			id: "1A7613F5225E87D9"
+			x: 0.5d
+			y: -0.5d
 			rewards: [{
 				id: "558FFF0928C1B0BE"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Provides 1 MByte of storage for crafting."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: 1.5d
-			y: -0.5d
-			subtitle: "Provides 4 MBytes of storage for crafting."
-			dependencies: ["2BE8127E1180DA21"]
-			id: "54B37947E3639AA6"
 			tasks: [{
 				id: "172C1C7F0EF4E703"
 				type: "item"
 				item: "ae2additions:4096k_crafting_storage"
 			}]
+			id: "54B37947E3639AA6"
+			x: 1.5d
+			y: -0.5d
 			rewards: [{
 				id: "21AC25FA69A32FD9"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Provides 4 MBytes of storage for crafting."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: 2.5d
-			y: -0.5d
-			subtitle: "Provides 16 MBytes of storage for crafting."
-			dependencies: ["2BE8127E1180DA21"]
-			id: "113040498970252F"
 			tasks: [{
 				id: "30D1A0766804585C"
 				type: "item"
 				item: "ae2additions:16384k_crafting_storage"
 			}]
+			id: "113040498970252F"
+			x: 2.5d
+			y: -0.5d
 			rewards: [{
 				id: "7DABA660AB4F6819"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Provides 16 MBytes of storage for crafting."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: 3.5d
-			y: -0.5d
-			subtitle: "Provides 64 MBytes of storage for crafting."
-			dependencies: ["2BE8127E1180DA21"]
-			id: "364A5BE6DF49FEAE"
 			tasks: [{
 				id: "020BECF4F1EA3E82"
 				type: "item"
 				item: "ae2additions:65536k_crafting_storage"
 			}]
+			id: "364A5BE6DF49FEAE"
+			x: 3.5d
+			y: -0.5d
 			rewards: [{
 				id: "70A03D8559F6DDFF"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Provides 64 MBytes of storage for crafting."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: -3.5d
-			y: -4.0d
-			subtitle: "Contrary to a standard Inscriber, Advanced Inscriber can hold entire stacks of items at once!"
-			description: [
-				"It can accept 5 Acceleration Cards to speed up processing."
-				""
-				"Additionally, it will automatically export its output into the attached ME Network!"
-			]
-			dependencies: ["42721BC1F7734286"]
-			id: "21F87EAF080BEDCF"
 			tasks: [{
 				id: "495B03BC7076DDD8"
 				type: "item"
 				item: "ae2things:advanced_inscriber"
 			}]
+			description: [
+				"It can accept 5 Acceleration Cards to speed up processing."
+				""
+				"Additionally, it will automatically export its output into the attached ME Network!"
+			]
+			id: "21F87EAF080BEDCF"
+			x: -3.5d
+			y: -4.0d
 			rewards: [{
 				id: "570A4AA4D0E92791"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Contrary to a standard Inscriber, Advanced Inscriber can hold entire stacks of items at once!"
+			dependencies: ["42721BC1F7734286"]
 		}
 		{
-			x: -2.0d
-			y: -11.5d
-			subtitle: "Crystal Growth in a box!"
+			tasks: [{
+				id: "5378BE7961B80D6B"
+				type: "item"
+				item: "ae2things:crystal_growth"
+			}]
 			description: [
 				"It has a inventory with 27 slots for growing crystals."
 				""
@@ -2523,33 +2526,19 @@
 				""
 				"It can also automatically export grown Crystals into the attached ME Network."
 			]
-			dependencies: ["7B3F4A3D79F2988B"]
 			id: "5F14B12A3DF739A7"
-			tasks: [{
-				id: "5378BE7961B80D6B"
-				type: "item"
-				item: "ae2things:crystal_growth"
-			}]
+			x: -2.0d
+			y: -11.5d
 			rewards: [{
 				id: "26B8764FC29DD83E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Crystal Growth in a box!"
+			dependencies: ["7B3F4A3D79F2988B"]
 		}
 		{
-			x: -16.5d
-			y: -7.0d
-			subtitle: "Highest Tier Storage Cell, which can contain 262,144 bytes of storage."
-			description: [
-				"It stores 130,048,000 mana."
-				"(about 130 Mana Pools)"
-			]
-			dependencies: [
-				"1C502D06D2093A4F"
-				"19FBAF9A70549BF5"
-			]
-			id: "672B1B1A28716D45"
 			tasks: [{
 				id: "27FE7B27871E203D"
 				type: "item"
@@ -2559,29 +2548,43 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"It stores 130,048,000 mana."
+				"(about 130 Mana Pools)"
+			]
+			id: "672B1B1A28716D45"
+			x: -16.5d
+			y: -7.0d
+			subtitle: "Highest Tier Storage Cell, which can contain 262,144 bytes of storage."
+			dependencies: [
+				"1C502D06D2093A4F"
+				"19FBAF9A70549BF5"
+			]
 		}
 		{
-			x: 4.5d
-			y: -0.5d
-			subtitle: "When in the Crafting CPU Multiblock, it allows processing of 1 more step in parallel."
-			dependencies: ["2BE8127E1180DA21"]
-			id: "40A8018DEDB92CD7"
 			tasks: [{
 				id: "2107AA88057E5F27"
 				type: "item"
 				item: "ae2:crafting_accelerator"
 			}]
+			id: "40A8018DEDB92CD7"
+			x: 4.5d
+			y: -0.5d
 			rewards: [{
 				id: "7FCB381D1B0FF034"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "When in the Crafting CPU Multiblock, it allows processing of 1 more step in parallel."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 		{
-			x: -9.5d
-			y: -5.0d
-			subtitle: "Perfectly balanced."
+			tasks: [{
+				id: "5EBE6FD266BB954E"
+				type: "item"
+				item: "ae2:equal_distribution_card"
+			}]
 			description: [
 				"The Equal Distribution Card will ensure equal maximum amount of items/fluids that can fit into the Cell."
 				""
@@ -2589,24 +2592,24 @@
 				""
 				"Together with Overflow Destruction Card, this makes a great, compact alternative for walls of Drawers."
 			]
-			dependencies: ["5683C69200EBC4CD"]
 			id: "126ED91F2DDB5014"
-			tasks: [{
-				id: "5EBE6FD266BB954E"
-				type: "item"
-				item: "ae2:equal_distribution_card"
-			}]
+			x: -9.5d
+			y: -5.0d
 			rewards: [{
 				id: "568C97838AD92DE0"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Perfectly balanced."
+			dependencies: ["5683C69200EBC4CD"]
 		}
 		{
-			x: -9.5d
-			y: -4.0d
-			subtitle: "Prevents spillouts."
+			tasks: [{
+				id: "5F44631DB3C274F8"
+				type: "item"
+				item: "ae2:void_card"
+			}]
 			description: [
 				"If an item/fluid would not fit inside of a Cell or would exceed the quota managed by the Equal Distribution Card, the item/fluid would be destroyed instead of filling other Cells."
 				""
@@ -2614,46 +2617,46 @@
 				""
 				"Together with Equal Distribution Card, this makes a great, compact alternative for walls of Drawers."
 			]
-			dependencies: ["5683C69200EBC4CD"]
 			id: "517D8D869BF16C7A"
-			tasks: [{
-				id: "5F44631DB3C274F8"
-				type: "item"
-				item: "ae2:void_card"
-			}]
+			x: -9.5d
+			y: -4.0d
 			rewards: [{
 				id: "5FD3057D1C937E26"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Prevents spillouts."
+			dependencies: ["5683C69200EBC4CD"]
 		}
 		{
-			x: -5.0d
-			y: -10.0d
-			subtitle: "Transmits only power."
+			tasks: [{
+				id: "7E9B7D58547006CD"
+				type: "item"
+				item: "ae2:quartz_fiber"
+			}]
 			description: [
 				"It does not transmit channels."
 				""
 				"Useful for separating Subnetworks from your main ME Network."
 			]
 			id: "00259AC734AF1B4D"
-			tasks: [{
-				id: "7E9B7D58547006CD"
-				type: "item"
-				item: "ae2:quartz_fiber"
-			}]
+			x: -5.0d
+			y: -10.0d
 			rewards: [{
 				id: "750B0A0536E68927"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Transmits only power."
 		}
 		{
-			x: 0.0d
-			y: -4.5d
-			subtitle: "Emits a redstone signal based on contents of the ME Network."
+			tasks: [{
+				id: "2C46ECA134C472FC"
+				type: "item"
+				item: "ae2:level_emitter"
+			}]
 			description: [
 				"It can accept upgrades:"
 				""
@@ -2668,21 +2671,18 @@
 				""
 				"This device §ndoes NOT require a channel§r to be operational!"
 			]
-			dependencies: ["2BE8127E1180DA21"]
-			min_width: 300
 			id: "4BF6E8068B7C3090"
-			tasks: [{
-				id: "2C46ECA134C472FC"
-				type: "item"
-				item: "ae2:level_emitter"
-			}]
+			x: 0.0d
+			y: -4.5d
 			rewards: [{
 				id: "3F19628F7F67B23B"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			min_width: 300
+			subtitle: "Emits a redstone signal based on contents of the ME Network."
+			dependencies: ["2BE8127E1180DA21"]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/arcanus.snbt
+++ b/config/ftbquests/quests/chapters/arcanus.snbt
@@ -1,9 +1,10 @@
 {
-	id: "292065E5EB368449"
+	quest_links: [ ]
+	default_hide_dependency_lines: false
 	group: "1039AC171AB01709"
-	order_index: 0
+	id: "292065E5EB368449"
 	filename: "arcanus"
-	title: "Arcanus"
+	default_quest_shape: ""
 	icon: {
 		id: "arcanus:master_wand"
 		Count: 1b
@@ -11,32 +12,22 @@
 			arcanus: { }
 		}
 	}
-	default_quest_shape: ""
-	default_hide_dependency_lines: false
+	title: "Arcanus"
 	images: [{
-		x: 1.0d
-		y: -9.5d
-		width: 2.0d
-		height: 2.0d
 		rotation: 0.0d
 		image: "arcanus:textures/item/initiate_wand.png"
-		hover: ["One of our favorite simple yet effective magic mods from a great dev. We hope you enjoy it."]
+		width: 2.0d
 		click: ""
-		dev: false
+		hover: ["One of our favorite simple yet effective magic mods from a great dev. We hope you enjoy it."]
+		x: 1.0d
+		y: -9.5d
 		corner: false
+		dev: false
+		height: 2.0d
 	}]
+	order_index: 0
 	quests: [
 		{
-			title: "Welcome to Arcanus"
-			x: 1.0d
-			y: 0.5d
-			subtitle: "You're a wizard, Harry!"
-			description: [
-				"A simple spell based mod. Using Amethyst to create mana and a single wand."
-				""
-				"The spells are found in loot from dungeons."
-			]
-			id: "756D7FADB9841FA5"
 			tasks: [
 				{
 					id: "686A5004ACD6FFD0"
@@ -48,19 +39,23 @@
 					item: "minecraft:amethyst_shard"
 				}
 			]
+			description: [
+				"A simple spell based mod. Using Amethyst to create mana and a single wand."
+				""
+				"The spells are found in loot from dungeons."
+			]
+			id: "756D7FADB9841FA5"
+			x: 1.0d
+			y: 0.5d
+			title: "Welcome to Arcanus"
 			rewards: [{
 				id: "7135AEF7BAE4E236"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "You're a wizard, Harry!"
 		}
 		{
-			x: 1.0d
-			y: -3.0d
-			subtitle: "Mic check, Mic check. Is this thing on?"
-			description: ["Remember to use R in REI to look at the recipe."]
-			dependencies: ["3B0E9B2A366C6574"]
-			id: "3575FEA5A4C605B0"
 			tasks: [{
 				id: "3579AF788DF77E8B"
 				type: "item"
@@ -72,6 +67,10 @@
 					}
 				}
 			}]
+			description: ["Remember to use R in REI to look at the recipe."]
+			id: "3575FEA5A4C605B0"
+			x: 1.0d
+			y: -3.0d
 			rewards: [
 				{
 					id: "478D95294735B6BC"
@@ -85,13 +84,10 @@
 					table_id: 13756307348121783L
 				}
 			]
+			subtitle: "Mic check, Mic check. Is this thing on?"
+			dependencies: ["3B0E9B2A366C6574"]
 		}
 		{
-			x: 1.0d
-			y: -4.5d
-			subtitle: "The more you use your wand, the more XP it gains. Get enough XP and your wand will upgrade itself."
-			dependencies: ["3575FEA5A4C605B0"]
-			id: "23919FDE0D10E077"
 			tasks: [{
 				id: "762251340AF9A8F2"
 				type: "item"
@@ -103,18 +99,18 @@
 					}
 				}
 			}]
+			id: "23919FDE0D10E077"
+			x: 1.0d
+			y: -4.5d
 			rewards: [{
 				id: "3FD04EDE2F0A0B84"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The more you use your wand, the more XP it gains. Get enough XP and your wand will upgrade itself."
+			dependencies: ["3575FEA5A4C605B0"]
 		}
 		{
-			x: 1.0d
-			y: -6.0d
-			subtitle: "Use your wand enough to get to this level and you truely are a magic master."
-			dependencies: ["23919FDE0D10E077"]
-			id: "77C1E1E5BA31AE01"
 			tasks: [{
 				id: "1CB9E7004495D24B"
 				type: "item"
@@ -126,22 +122,18 @@
 					}
 				}
 			}]
+			id: "77C1E1E5BA31AE01"
+			x: 1.0d
+			y: -6.0d
 			rewards: [{
 				id: "03AF315E665983C5"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Use your wand enough to get to this level and you truely are a magic master."
+			dependencies: ["23919FDE0D10E077"]
 		}
 		{
-			x: 1.0d
-			y: -1.5d
-			description: [
-				"Amethyst and a mana flask is all you need to get this item."
-				""
-				"You need to fill the mana flask to complete this quest."
-			]
-			dependencies: ["756D7FADB9841FA5"]
-			id: "3B0E9B2A366C6574"
 			tasks: [{
 				id: "624C9A1DE570923E"
 				type: "item"
@@ -155,47 +147,54 @@
 					}
 				}
 			}]
+			description: [
+				"Amethyst and a mana flask is all you need to get this item."
+				""
+				"You need to fill the mana flask to complete this quest."
+			]
+			id: "3B0E9B2A366C6574"
+			x: 1.0d
+			y: -1.5d
 			rewards: [{
 				id: "7BB090CC49CBDFDB"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["756D7FADB9841FA5"]
 		}
 		{
-			x: 2.5d
-			y: -4.0d
-			subtitle: "Store your spell books here."
-			description: ["Also the textures look cool, the more you add or remove books."]
-			dependencies: ["3575FEA5A4C605B0"]
-			id: "3C7CCACADEC2A3AC"
 			tasks: [{
 				id: "783F238DEE18AF29"
 				type: "item"
 				item: "arcanus:fillable_bookshelf"
 			}]
+			description: ["Also the textures look cool, the more you add or remove books."]
+			id: "3C7CCACADEC2A3AC"
+			x: 2.5d
+			y: -4.0d
 			rewards: [{
 				id: "59CF3FE369C4A623"
 				type: "item"
 				item: "minecraft:book"
 				count: 6
 			}]
+			subtitle: "Store your spell books here."
+			dependencies: ["3575FEA5A4C605B0"]
 		}
 		{
-			x: -0.5d
-			y: -4.0d
-			subtitle: "Protect the goods."
-			description: [
-				"Or just show it off."
-				""
-				"Get a spyglass to give to the haters. So they can admire from a far."
-			]
-			dependencies: ["3575FEA5A4C605B0"]
-			id: "7B72273FBB8B70DD"
 			tasks: [{
 				id: "3BF8F2AE1D1B98AA"
 				type: "item"
 				item: "arcanus:display_case"
 			}]
+			description: [
+				"Or just show it off."
+				""
+				"Get a spyglass to give to the haters. So they can admire from a far."
+			]
+			id: "7B72273FBB8B70DD"
+			x: -0.5d
+			y: -4.0d
 			rewards: [
 				{
 					id: "247E7CA7B4803333"
@@ -208,16 +207,10 @@
 					table_id: 13756307348121783L
 				}
 			]
+			subtitle: "Protect the goods."
+			dependencies: ["3575FEA5A4C605B0"]
 		}
 		{
-			x: -2.0d
-			y: 2.0d
-			description: [
-				"Lunges you forward."
-				"Costs 5 Mana to cast."
-			]
-			dependencies: ["756D7FADB9841FA5"]
-			id: "4E0B2BC595E5C2D2"
 			tasks: [{
 				id: "1EEA90CD59064665"
 				type: "item"
@@ -232,22 +225,22 @@
 					}
 				}
 			}]
+			description: [
+				"Lunges you forward."
+				"Costs 5 Mana to cast."
+			]
+			id: "4E0B2BC595E5C2D2"
+			x: -2.0d
+			y: 2.0d
 			rewards: [{
 				id: "7A64DCC9DD2E3518"
 				type: "item"
 				item: "minecraft:stick"
 				count: 12
 			}]
+			dependencies: ["756D7FADB9841FA5"]
 		}
 		{
-			x: 4.0d
-			y: 2.0d
-			description: [
-				"Warps you back to your Spawnpoint."
-				"Costs 15 Mana to cast."
-			]
-			dependencies: ["756D7FADB9841FA5"]
-			id: "335A800C1EFCCD3F"
 			tasks: [{
 				id: "0E9E5F9690FB177B"
 				type: "item"
@@ -262,21 +255,21 @@
 					}
 				}
 			}]
+			description: [
+				"Warps you back to your Spawnpoint."
+				"Costs 15 Mana to cast."
+			]
+			id: "335A800C1EFCCD3F"
+			x: 4.0d
+			y: 2.0d
 			rewards: [{
 				id: "43F44E33EA7A4810"
 				type: "item"
 				item: "minecraft:cyan_bed"
 			}]
+			dependencies: ["756D7FADB9841FA5"]
 		}
 		{
-			x: 4.0d
-			y: 1.0d
-			description: [
-				"Summons a magic missile that deals 7 damage."
-				"Costs 3 Mana to cast."
-			]
-			dependencies: ["756D7FADB9841FA5"]
-			id: "669C1B2C2A01DB9C"
 			tasks: [{
 				id: "2F8FCFBB1480FC0E"
 				type: "item"
@@ -291,22 +284,22 @@
 					}
 				}
 			}]
+			description: [
+				"Summons a magic missile that deals 7 damage."
+				"Costs 3 Mana to cast."
+			]
+			id: "669C1B2C2A01DB9C"
+			x: 4.0d
+			y: 1.0d
 			rewards: [{
 				id: "6D9F72597619D747"
 				type: "item"
 				item: "minecraft:arrow"
 				count: 12
 			}]
+			dependencies: ["756D7FADB9841FA5"]
 		}
 		{
-			x: 4.0d
-			y: 0.0d
-			description: [
-				"Knocks the hit enemy back."
-				"Costs 4 Mana to cast."
-			]
-			dependencies: ["756D7FADB9841FA5"]
-			id: "7D56E6051F60B00F"
 			tasks: [{
 				id: "2AD6F90758713D4F"
 				type: "item"
@@ -321,16 +314,16 @@
 					}
 				}
 			}]
-		}
-		{
-			x: -2.0d
-			y: 1.0d
 			description: [
-				"Restores 10 Health points."
-				"Costs 10 Mana to cast."
+				"Knocks the hit enemy back."
+				"Costs 4 Mana to cast."
 			]
 			dependencies: ["756D7FADB9841FA5"]
-			id: "4C5214B3519865DF"
+			id: "7D56E6051F60B00F"
+			y: 0.0d
+			x: 4.0d
+		}
+		{
 			tasks: [{
 				id: "6D01618D0A06ECEC"
 				type: "item"
@@ -345,18 +338,21 @@
 					}
 				}
 			}]
+			description: [
+				"Restores 10 Health points."
+				"Costs 10 Mana to cast."
+			]
+			id: "4C5214B3519865DF"
+			x: -2.0d
+			y: 1.0d
 			rewards: [{
 				id: "29AA802DC1085B29"
 				type: "item"
 				item: "minecraft:glow_berries"
 			}]
+			dependencies: ["756D7FADB9841FA5"]
 		}
 		{
-			x: -2.0d
-			y: -1.0d
-			description: ["Costs 10 Mana to cast."]
-			dependencies: ["756D7FADB9841FA5"]
-			id: "5EDA0D094D24D820"
 			tasks: [{
 				id: "6FEA2CA6455D67F0"
 				type: "item"
@@ -371,21 +367,18 @@
 					}
 				}
 			}]
+			description: ["Costs 10 Mana to cast."]
+			id: "5EDA0D094D24D820"
+			x: -2.0d
+			y: -1.0d
 			rewards: [{
 				id: "796C666CFAFB0EDC"
 				type: "item"
 				item: "minecraft:glass"
 			}]
+			dependencies: ["756D7FADB9841FA5"]
 		}
 		{
-			x: 4.0d
-			y: -1.0d
-			description: [
-				"Summons a powerful Solar Strike that damages mobs on impact."
-				"Costs 20 Mana to cast."
-			]
-			dependencies: ["756D7FADB9841FA5"]
-			id: "16C3CDC79927B81E"
 			tasks: [{
 				id: "0ADD6ED8F76BD871"
 				type: "item"
@@ -400,22 +393,22 @@
 					}
 				}
 			}]
+			description: [
+				"Summons a powerful Solar Strike that damages mobs on impact."
+				"Costs 20 Mana to cast."
+			]
+			id: "16C3CDC79927B81E"
+			x: 4.0d
+			y: -1.0d
 			rewards: [{
 				id: "09D276D5A1CD31FB"
 				type: "item"
 				item: "minecraft:sunflower"
 				count: 12
 			}]
+			dependencies: ["756D7FADB9841FA5"]
 		}
 		{
-			x: -2.0d
-			y: 0.0d
-			description: [
-				"Summons a 3-block tall barrier."
-				"Costs 4 Mana to cast."
-			]
-			dependencies: ["756D7FADB9841FA5"]
-			id: "1AA763E8C46B95A2"
 			tasks: [{
 				id: "285939FC28874007"
 				type: "item"
@@ -430,24 +423,30 @@
 					}
 				}
 			}]
+			description: [
+				"Summons a 3-block tall barrier."
+				"Costs 4 Mana to cast."
+			]
+			id: "1AA763E8C46B95A2"
+			x: -2.0d
+			y: 0.0d
 			rewards: [{
 				id: "044FB7EDC89183A8"
 				type: "item"
 				item: "blockus:rainbow_brick_wall"
 			}]
+			dependencies: ["756D7FADB9841FA5"]
 		}
 		{
-			icon: "minecraft:amethyst_cluster"
-			x: 1.0d
-			y: -7.5d
-			subtitle: "It feels good to be an adventurer."
-			dependencies: ["77C1E1E5BA31AE01"]
-			id: "3935DB54BD9C5E4E"
 			tasks: [{
 				id: "78C59C1613C26A83"
 				type: "checkmark"
 				title: "Arcanus Champ"
 			}]
+			icon: "minecraft:amethyst_cluster"
+			id: "3935DB54BD9C5E4E"
+			x: 1.0d
+			y: -7.5d
 			rewards: [
 				{
 					id: "04E73FB23BC62C52"
@@ -460,7 +459,8 @@
 					table_id: 13756307348121783L
 				}
 			]
+			subtitle: "It feels good to be an adventurer."
+			dependencies: ["77C1E1E5BA31AE01"]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/automatedtasksandtriggers.snbt
+++ b/config/ftbquests/quests/chapters/automatedtasksandtriggers.snbt
@@ -1,57 +1,45 @@
 {
-	id: "014DBB8A0BF57DC7"
-	group: ""
-	order_index: 1
-	filename: "automatedtasksandtriggers"
-	title: "AutomatedTasksAndTriggers"
 	always_invisible: true
-	default_quest_shape: ""
 	default_hide_dependency_lines: false
+	group: ""
+	id: "014DBB8A0BF57DC7"
+	filename: "automatedtasksandtriggers"
+	default_quest_shape: ""
+	title: "AutomatedTasksAndTriggers"
+	order_index: 1
 	quests: [
 		{
-			x: -3.0d
-			y: -1.5d
-			subtitle: "Well known simple early game!"
-			description: ["Basic Sky Block, you will start on a oak tree."]
-			hide: true
-			invisible: true
-			id: "3AC0329506E80AA4"
 			tasks: [{
 				id: "5DB597A4B3A2F623"
 				type: "custom"
 				title: "Simple Tree Island"
 				icon: "minecraft:oak_sapling"
 			}]
+			description: ["Basic Sky Block, you will start on a oak tree."]
+			id: "3AC0329506E80AA4"
+			x: -3.0d
+			y: -1.5d
+			invisible: true
+			subtitle: "Well known simple early game!"
+			hide: true
 		}
 		{
-			x: -3.0d
-			y: -0.5d
-			subtitle: "A different, more challenging early-game!"
-			description: ["You will build your island from just a bamboo and a block of podzol. You can craft Wood from bamboo. Wood is the basis for everything."]
-			hide: true
-			dependency_requirement: "one_completed"
-			invisible: true
-			id: "329CC4079DB5DABE"
 			tasks: [{
 				id: "56B5556B44C046F2"
 				type: "custom"
 				title: "Bamboo Island"
 				icon: "minecraft:bamboo"
 			}]
+			description: ["You will build your island from just a bamboo and a block of podzol. You can craft Wood from bamboo. Wood is the basis for everything."]
+			id: "329CC4079DB5DABE"
+			x: -3.0d
+			y: -0.5d
+			invisible: true
+			subtitle: "A different, more challenging early-game!"
+			dependency_requirement: "one_completed"
+			hide: true
 		}
 		{
-			x: -3.0d
-			y: 0.5d
-			subtitle: "Very time intensive early-game!"
-			description: [
-				"Just try to get a sapling and a soil block. This is the most difficult mode but you will be rewarded. Good Luck. "
-				""
-				"Origin Challenge: this island type is the only choice if you would like to play as the Merling Origin."
-			]
-			hide: true
-			dependency_requirement: "one_completed"
-			invisible: true
-			id: "7849BD01ACBFAC3A"
 			tasks: [{
 				id: "251CD869A0906B24"
 				type: "custom"
@@ -64,6 +52,18 @@
 					}
 				}
 			}]
+			description: [
+				"Just try to get a sapling and a soil block. This is the most difficult mode but you will be rewarded. Good Luck. "
+				""
+				"Origin Challenge: this island type is the only choice if you would like to play as the Merling Origin."
+			]
+			id: "7849BD01ACBFAC3A"
+			x: -3.0d
+			y: 0.5d
+			invisible: true
+			subtitle: "Very time intensive early-game!"
+			dependency_requirement: "one_completed"
+			hide: true
 		}
 	]
 	quest_links: [ ]

--- a/config/ftbquests/quests/chapters/bewitchment.snbt
+++ b/config/ftbquests/quests/chapters/bewitchment.snbt
@@ -1,25 +1,15 @@
 {
-	id: "1B81080941D776C5"
-	group: "1039AC171AB01709"
-	order_index: 1
-	filename: "bewitchment"
-	title: "Bewitchment"
-	icon: "bewitchment:hellish_bauble"
-	default_quest_shape: ""
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "1039AC171AB01709"
+	id: "1B81080941D776C5"
+	filename: "bewitchment"
+	default_quest_shape: ""
+	icon: "bewitchment:hellish_bauble"
+	title: "Bewitchment"
+	order_index: 1
 	quests: [
 		{
-			x: -1.0d
-			y: -1.5d
-			subtitle: "Convenient tools for any witch."
-			description: [
-				"The Athame is a very helpful tool for your journey into the Bewitchment Mod."
-				"It can be used to gather heads from mobs, among other niche uses."
-				"Being made out of Silver, it is perfectly usable against unholy creatures."
-				"Athames can also be used to start Rituals from a Dispenser."
-			]
-			hide: true
-			id: "51E73309110A8113"
 			tasks: [{
 				id: "7D4A1EA73E0D48DD"
 				type: "item"
@@ -31,45 +21,51 @@
 					}
 				}
 			}]
+			description: [
+				"The Athame is a very helpful tool for your journey into the Bewitchment Mod."
+				"It can be used to gather heads from mobs, among other niche uses."
+				"Being made out of Silver, it is perfectly usable against unholy creatures."
+				"Athames can also be used to start Rituals from a Dispenser."
+			]
+			id: "51E73309110A8113"
+			x: -1.0d
+			y: -1.5d
 			rewards: [{
 				id: "720DD3F227DC81BE"
 				type: "item"
 				item: "bewitchment:book_of_shadows"
 			}]
+			subtitle: "Convenient tools for any witch."
+			hide: true
 		}
 		{
-			x: 0.0d
-			y: -2.5d
-			description: ["Use the Athame to get Barks."]
-			dependencies: ["51E73309110A8113"]
-			id: "5B56F27E804C5718"
 			tasks: [{
 				id: "0D956C53EC25A05C"
 				type: "item"
 				item: "bewitchment:oak_bark"
 			}]
+			description: ["Use the Athame to get Barks."]
+			dependencies: ["51E73309110A8113"]
+			id: "5B56F27E804C5718"
+			y: -2.5d
+			x: 0.0d
 		}
 		{
-			x: 1.0d
-			y: -1.5d
+			tasks: [{
+				id: "5A621B7262181672"
+				type: "item"
+				item: "bewitchment:wood_ash"
+			}]
 			description: [
 				"Burn Barks on a Campfire to get Wood Ash."
 				"When thrown into a filled Witch Cauldron it will immediately empty it."
 			]
 			dependencies: ["5B56F27E804C5718"]
 			id: "0CF1E4923DB74544"
-			tasks: [{
-				id: "5A621B7262181672"
-				type: "item"
-				item: "bewitchment:wood_ash"
-			}]
+			y: -1.5d
+			x: 1.0d
 		}
 		{
-			x: 2.5d
-			y: 0.0d
-			description: ["Follow the instructions in the Guide-Book to figure out how to start your rituals."]
-			dependencies: ["0CF1E4923DB74544"]
-			id: "11729DAA115C6DE1"
 			tasks: [{
 				id: "6006E823BF0B4073"
 				type: "item"
@@ -81,28 +77,36 @@
 					}
 				}
 			}]
+			description: ["Follow the instructions in the Guide-Book to figure out how to start your rituals."]
+			dependencies: ["0CF1E4923DB74544"]
+			id: "11729DAA115C6DE1"
+			y: 0.0d
+			x: 2.5d
 		}
 		{
-			x: 0.0d
-			y: -1.5d
-			subtitle: "Altars are the cornerstone of any witch's lair."
+			tasks: [{
+				id: "439CEC0927C5284C"
+				type: "item"
+				item: "bewitchment:stone_witch_altar"
+			}]
 			description: [
 				"Altars can be used to collect magical energy."
 				"This energy is essential to most witchcraft, and is collected from nearby plants."
 				"You'll want many different plants to collect maximum power."
 				"You may also place swords, pentacles, and wands atop the altar to modify it."
 			]
-			dependencies: ["5B56F27E804C5718"]
 			id: "3B7F081B65EAB0BB"
-			tasks: [{
-				id: "439CEC0927C5284C"
-				type: "item"
-				item: "bewitchment:stone_witch_altar"
-			}]
+			x: 0.0d
+			y: -1.5d
+			subtitle: "Altars are the cornerstone of any witch's lair."
+			dependencies: ["5B56F27E804C5718"]
 		}
 		{
-			x: -2.0d
-			y: -4.5d
+			tasks: [{
+				id: "283C4E1520240BFD"
+				type: "item"
+				item: "bewitchment:witch_cauldron"
+			}]
 			description: [
 				"This magical cauldron is extremely versatile in use and is namely used for Oil Crafting, Brewing and and Teleportation."
 				""
@@ -110,25 +114,16 @@
 				""
 				"The Witch Cauldron requires Altar Power, except for Oil Crafting."
 			]
+			id: "26C7CDBCC8599727"
+			x: -2.0d
+			y: -4.5d
 			dependencies: [
 				"5B56F27E804C5718"
 				"7B43B945C37783BA"
 			]
 			hide: true
-			id: "26C7CDBCC8599727"
-			tasks: [{
-				id: "283C4E1520240BFD"
-				type: "item"
-				item: "bewitchment:witch_cauldron"
-			}]
 		}
 		{
-			title: "Basic Plants"
-			x: -2.0d
-			y: -3.0d
-			description: ["By breaking grass you might get some Bewitchment seeds."]
-			hide: true
-			id: "7B43B945C37783BA"
 			tasks: [
 				{
 					id: "61E865F1B83B2F1A"
@@ -151,78 +146,80 @@
 					item: "bewitchment:garlic"
 				}
 			]
+			description: ["By breaking grass you might get some Bewitchment seeds."]
+			id: "7B43B945C37783BA"
+			x: -2.0d
+			y: -3.0d
+			title: "Basic Plants"
+			hide: true
 		}
 		{
-			x: -3.0d
-			y: -5.5d
-			dependencies: ["26C7CDBCC8599727"]
-			id: "6D71FE568C8E8A76"
 			tasks: [{
 				id: "6975725D164A79AB"
 				type: "item"
 				item: "bewitchment:heaven_extract"
 			}]
+			dependencies: ["26C7CDBCC8599727"]
+			id: "6D71FE568C8E8A76"
+			y: -5.5d
+			x: -3.0d
 		}
 		{
-			x: -1.0d
-			y: -5.5d
-			dependencies: ["26C7CDBCC8599727"]
-			id: "448938BBA9352019"
 			tasks: [{
 				id: "6E1D23DE7834A9A6"
 				type: "item"
 				item: "bewitchment:cleansing_balm"
 			}]
+			dependencies: ["26C7CDBCC8599727"]
+			id: "448938BBA9352019"
+			y: -5.5d
+			x: -1.0d
 		}
 		{
-			x: -2.0d
-			y: -6.0d
-			dependencies: ["26C7CDBCC8599727"]
-			id: "277FB76034FD4B8B"
 			tasks: [{
 				id: "54DF541016D50530"
 				type: "item"
 				item: "bewitchment:grim_elixir"
 			}]
+			dependencies: ["26C7CDBCC8599727"]
+			id: "277FB76034FD4B8B"
+			y: -6.0d
+			x: -2.0d
 		}
 		{
-			x: -3.0d
-			y: -3.5d
-			dependencies: ["26C7CDBCC8599727"]
-			id: "19C683CCD6A3DE00"
 			tasks: [{
 				id: "555D662C419161C8"
 				type: "item"
 				item: "bewitchment:aqua_cerate"
 			}]
+			dependencies: ["26C7CDBCC8599727"]
+			id: "19C683CCD6A3DE00"
+			y: -3.5d
+			x: -3.0d
 		}
 		{
-			x: -3.5d
-			y: -4.5d
-			dependencies: ["26C7CDBCC8599727"]
-			id: "73AC7EB854EFF6F5"
 			tasks: [{
 				id: "4CF23FFAB19A59FD"
 				type: "item"
 				item: "bewitchment:fiery_serum"
 			}]
+			dependencies: ["26C7CDBCC8599727"]
+			id: "73AC7EB854EFF6F5"
+			y: -4.5d
+			x: -3.5d
 		}
 		{
-			x: -0.5d
-			y: -4.5d
-			dependencies: ["26C7CDBCC8599727"]
-			id: "3CC93604C74D8EF6"
 			tasks: [{
 				id: "1B842885F0E22C16"
 				type: "item"
 				item: "bewitchment:earth_ichor"
 			}]
+			dependencies: ["26C7CDBCC8599727"]
+			id: "3CC93604C74D8EF6"
+			y: -4.5d
+			x: -0.5d
 		}
 		{
-			x: 2.0d
-			y: -5.5d
-			dependencies: ["3F6A16857A4317D3"]
-			id: "621173DFA13F83F8"
 			tasks: [{
 				id: "7FE8258B44B70C7D"
 				type: "item"
@@ -234,12 +231,12 @@
 					}
 				}
 			}]
+			dependencies: ["3F6A16857A4317D3"]
+			id: "621173DFA13F83F8"
+			y: -5.5d
+			x: 2.0d
 		}
 		{
-			x: 3.0d
-			y: -6.0d
-			dependencies: ["3F6A16857A4317D3"]
-			id: "4C4B745E9F9F3955"
 			tasks: [{
 				id: "3B68F252F106F62F"
 				type: "item"
@@ -251,12 +248,12 @@
 					}
 				}
 			}]
+			dependencies: ["3F6A16857A4317D3"]
+			id: "4C4B745E9F9F3955"
+			y: -6.0d
+			x: 3.0d
 		}
 		{
-			x: 1.5d
-			y: -4.5d
-			dependencies: ["3F6A16857A4317D3"]
-			id: "6BE3E700EA366ED6"
 			tasks: [{
 				id: "5BB55991AE4B6E27"
 				type: "item"
@@ -268,12 +265,12 @@
 					}
 				}
 			}]
+			dependencies: ["3F6A16857A4317D3"]
+			id: "6BE3E700EA366ED6"
+			y: -4.5d
+			x: 1.5d
 		}
 		{
-			x: 4.0d
-			y: -5.5d
-			dependencies: ["3F6A16857A4317D3"]
-			id: "07DB332B2D23C53A"
 			tasks: [{
 				id: "5CC07A8D13448286"
 				type: "item"
@@ -285,12 +282,12 @@
 					}
 				}
 			}]
+			dependencies: ["3F6A16857A4317D3"]
+			id: "07DB332B2D23C53A"
+			y: -5.5d
+			x: 4.0d
 		}
 		{
-			x: 4.5d
-			y: -4.5d
-			dependencies: ["3F6A16857A4317D3"]
-			id: "3920293F35F05316"
 			tasks: [{
 				id: "6250469155819B85"
 				type: "item"
@@ -302,12 +299,12 @@
 					}
 				}
 			}]
+			dependencies: ["3F6A16857A4317D3"]
+			id: "3920293F35F05316"
+			y: -4.5d
+			x: 4.5d
 		}
 		{
-			x: 4.0d
-			y: -3.5d
-			dependencies: ["3F6A16857A4317D3"]
-			id: "500B6D4A12FAA58B"
 			tasks: [{
 				id: "56E7D77FC66C59F1"
 				type: "item"
@@ -319,12 +316,12 @@
 					}
 				}
 			}]
+			dependencies: ["3F6A16857A4317D3"]
+			id: "500B6D4A12FAA58B"
+			y: -3.5d
+			x: 4.0d
 		}
 		{
-			x: 2.0d
-			y: -3.5d
-			dependencies: ["3F6A16857A4317D3"]
-			id: "2415E3EBE0309EA4"
 			tasks: [{
 				id: "7D0AF0D8204DE6B3"
 				type: "item"
@@ -336,12 +333,12 @@
 					}
 				}
 			}]
+			dependencies: ["3F6A16857A4317D3"]
+			id: "2415E3EBE0309EA4"
+			y: -3.5d
+			x: 2.0d
 		}
 		{
-			x: 3.0d
-			y: -3.0d
-			dependencies: ["3F6A16857A4317D3"]
-			id: "6939F79DC61FB6D0"
 			tasks: [{
 				id: "5334AF9FEEDC173A"
 				type: "item"
@@ -353,25 +350,23 @@
 					}
 				}
 			}]
+			dependencies: ["3F6A16857A4317D3"]
+			id: "6939F79DC61FB6D0"
+			y: -3.0d
+			x: 3.0d
 		}
 		{
-			x: 1.5d
-			y: 1.0d
-			dependencies: ["11729DAA115C6DE1"]
-			id: "7006D17754235A44"
 			tasks: [{
 				id: "761B5C8085806DD8"
 				type: "item"
 				item: "bewitchment:demon_heart"
 			}]
+			dependencies: ["11729DAA115C6DE1"]
+			id: "7006D17754235A44"
+			y: 1.0d
+			x: 1.5d
 		}
 		{
-			title: "Brooms"
-			x: 0.5d
-			y: 1.0d
-			description: ["They enable the user to fly through the skies. Brooms come in four variants, each with unique properties."]
-			dependencies: ["7006D17754235A44"]
-			id: "7FDDEEA84EE05FC2"
 			tasks: [
 				{
 					id: "326100CDED4246C3"
@@ -410,24 +405,25 @@
 					}
 				}
 			]
+			description: ["They enable the user to fly through the skies. Brooms come in four variants, each with unique properties."]
+			id: "7FDDEEA84EE05FC2"
+			x: 0.5d
+			y: 1.0d
+			title: "Brooms"
+			dependencies: ["7006D17754235A44"]
 		}
 		{
-			x: 3.5d
-			y: 1.0d
-			dependencies: ["11729DAA115C6DE1"]
-			id: "3092EF2FC246625F"
 			tasks: [{
 				id: "6BD179C511C3F9CC"
 				type: "item"
 				item: "bewitchment:demon_horn"
 			}]
+			dependencies: ["11729DAA115C6DE1"]
+			id: "3092EF2FC246625F"
+			y: 1.0d
+			x: 3.5d
 		}
 		{
-			x: 4.5d
-			y: 0.0d
-			description: ["It can be combined with a Splash Potion, which can then be thrown four times using the Scepter at the cost of ME."]
-			dependencies: ["3092EF2FC246625F"]
-			id: "5F5CBB1A93F9222E"
 			tasks: [{
 				id: "0C497A073658514A"
 				type: "item"
@@ -439,16 +435,13 @@
 					}
 				}
 			}]
+			description: ["It can be combined with a Splash Potion, which can then be thrown four times using the Scepter at the cost of ME."]
+			dependencies: ["3092EF2FC246625F"]
+			id: "5F5CBB1A93F9222E"
+			y: 0.0d
+			x: 4.5d
 		}
 		{
-			x: 4.5d
-			y: 1.0d
-			description: [
-				"It has multiple-tool functionality comparable to Netherite."
-				"It can also be used to throw powerful fireballs at the cost of some ME."
-			]
-			dependencies: ["3092EF2FC246625F"]
-			id: "549C5C564C46694A"
 			tasks: [{
 				id: "501164C2C4611CDC"
 				type: "item"
@@ -460,13 +453,16 @@
 					}
 				}
 			}]
+			description: [
+				"It has multiple-tool functionality comparable to Netherite."
+				"It can also be used to throw powerful fireballs at the cost of some ME."
+			]
+			dependencies: ["3092EF2FC246625F"]
+			id: "549C5C564C46694A"
+			y: 1.0d
+			x: 4.5d
 		}
 		{
-			x: 4.5d
-			y: 2.0d
-			description: ["Much like a Trident, it can be thrown towards a target, and will always return to whoever threw it."]
-			dependencies: ["3092EF2FC246625F"]
-			id: "2597B9C9D971FD32"
 			tasks: [{
 				id: "493F4A6394C13B5A"
 				type: "item"
@@ -478,12 +474,13 @@
 					}
 				}
 			}]
+			description: ["Much like a Trident, it can be thrown towards a target, and will always return to whoever threw it."]
+			dependencies: ["3092EF2FC246625F"]
+			id: "2597B9C9D971FD32"
+			y: 2.0d
+			x: 4.5d
 		}
 		{
-			x: 3.5d
-			y: -1.0d
-			dependencies: ["11729DAA115C6DE1"]
-			id: "41F6EF5636067396"
 			tasks: [{
 				id: "72DC90709649D192"
 				type: "item"
@@ -496,89 +493,84 @@
 					}
 				}
 			}]
+			dependencies: ["11729DAA115C6DE1"]
+			id: "41F6EF5636067396"
+			y: -1.0d
+			x: 3.5d
 		}
 		{
-			x: -2.5d
-			y: 0.0d
-			hide_dependency_lines: true
-			dependencies: ["26C7CDBCC8599727"]
-			id: "705074EBE2B43A39"
 			tasks: [{
 				id: "017F09323F7BAF9C"
 				type: "item"
 				item: "bewitchment:specter_bangle"
 			}]
+			dependencies: ["26C7CDBCC8599727"]
+			id: "705074EBE2B43A39"
+			hide_dependency_lines: true
+			y: 0.0d
+			x: -2.5d
 		}
 		{
-			x: -3.5d
-			y: 0.0d
-			hide_dependency_lines: true
-			dependencies: ["26C7CDBCC8599727"]
-			id: "34B8C2CE1DCDC976"
 			tasks: [{
 				id: "02E67CE2D2BFC1FB"
 				type: "item"
 				item: "bewitchment:nazar"
 			}]
+			dependencies: ["26C7CDBCC8599727"]
+			id: "34B8C2CE1DCDC976"
+			hide_dependency_lines: true
+			y: 0.0d
+			x: -3.5d
 		}
 		{
-			x: -3.5d
-			y: 1.0d
-			hide_dependency_lines: true
-			dependencies: ["26C7CDBCC8599727"]
-			id: "3AA2D217E71215AF"
 			tasks: [{
 				id: "09314C401576F5EA"
 				type: "item"
 				item: "bewitchment:hellish_bauble"
 			}]
+			dependencies: ["26C7CDBCC8599727"]
+			id: "3AA2D217E71215AF"
+			hide_dependency_lines: true
+			y: 1.0d
+			x: -3.5d
 		}
 		{
-			x: -2.5d
-			y: 1.0d
-			hide_dependency_lines: true
-			dependencies: ["26C7CDBCC8599727"]
-			id: "59EFB1BA7732F069"
 			tasks: [{
 				id: "2178281AE1B074F5"
 				type: "item"
 				item: "bewitchment:prickly_belt"
 			}]
+			dependencies: ["26C7CDBCC8599727"]
+			id: "59EFB1BA7732F069"
+			hide_dependency_lines: true
+			y: 1.0d
+			x: -2.5d
 		}
 		{
-			x: -3.5d
-			y: 2.0d
-			hide_dependency_lines: true
-			dependencies: ["26C7CDBCC8599727"]
-			id: "7A4B1A19AA7ABEBE"
 			tasks: [{
 				id: "2B2815267B59E9AF"
 				type: "item"
 				item: "bewitchment:druid_band"
 			}]
+			dependencies: ["26C7CDBCC8599727"]
+			id: "7A4B1A19AA7ABEBE"
+			hide_dependency_lines: true
+			y: 2.0d
+			x: -3.5d
 		}
 		{
-			x: -2.5d
-			y: 2.0d
-			hide_dependency_lines: true
-			dependencies: ["26C7CDBCC8599727"]
-			id: "10735C0DC340E1D8"
 			tasks: [{
 				id: "172AE3E41B61E6AB"
 				type: "item"
 				item: "bewitchment:zephyr_harness"
 			}]
+			dependencies: ["26C7CDBCC8599727"]
+			id: "10735C0DC340E1D8"
+			hide_dependency_lines: true
+			y: 2.0d
+			x: -2.5d
 		}
 		{
-			title: "Poppet Items"
-			x: 3.0d
-			y: -4.5d
-			description: [
-				"To gather a taglock from an entity, either sneak up from behind or search for their bed."
-				"To gather a taglock from a Bed, use it while sneaking so you don't accidentally sleep."
-			]
-			hide: true
-			id: "3F6A16857A4317D3"
 			tasks: [
 				{
 					id: "2A69030049B39B71"
@@ -601,27 +593,30 @@
 					item: "bewitchment:taglock"
 				}
 			]
+			description: [
+				"To gather a taglock from an entity, either sneak up from behind or search for their bed."
+				"To gather a taglock from a Bed, use it while sneaking so you don't accidentally sleep."
+			]
+			id: "3F6A16857A4317D3"
+			x: 3.0d
+			y: -4.5d
+			title: "Poppet Items"
+			hide: true
 		}
 		{
-			x: -1.5d
-			y: 0.0d
-			hide_dependency_lines: true
-			dependencies: ["26C7CDBCC8599727"]
-			progression_mode: "linear"
-			id: "4B052AFF65E35A89"
 			tasks: [{
 				id: "7E5D63F5A623048C"
 				type: "item"
 				item: "besmirchment:elite_coffin"
 			}]
+			id: "4B052AFF65E35A89"
+			x: -1.5d
+			y: 0.0d
+			progression_mode: "linear"
+			dependencies: ["26C7CDBCC8599727"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -1.5d
-			y: 1.0d
-			description: ["Reach Lichdom and become immortal by storing souls in here."]
-			hide_dependency_lines: true
-			dependencies: ["26C7CDBCC8599727"]
-			id: "2ED8F6E3A1250146"
 			tasks: [
 				{
 					id: "55D34B4DDAA936EB"
@@ -634,34 +629,39 @@
 					item: "besmirchment:lich_gem"
 				}
 			]
+			description: ["Reach Lichdom and become immortal by storing souls in here."]
+			id: "2ED8F6E3A1250146"
+			x: -1.5d
+			y: 1.0d
+			dependencies: ["26C7CDBCC8599727"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -1.5d
-			y: 2.0d
-			hide_dependency_lines: true
-			dependencies: ["26C7CDBCC8599727"]
-			id: "74A8B6E3A2D31EDA"
 			tasks: [{
 				id: "483F2120648CF26F"
 				type: "item"
 				item: "besmirchment:scroll_of_torment"
 			}]
+			dependencies: ["26C7CDBCC8599727"]
+			id: "74A8B6E3A2D31EDA"
+			hide_dependency_lines: true
+			y: 2.0d
+			x: -1.5d
 		}
 		{
-			x: 0.0d
-			y: -0.5d
+			tasks: [{
+				id: "121A7338855CDF7F"
+				type: "item"
+				item: "bewitchment:crystal_ball"
+			}]
 			description: [
 				"When used, they will give the caster a fortune, at the cost of some ME drawn from a nearby Altar."
 				"Additionally, Crystal Balls may be used for scrying."
 			]
 			dependencies: ["3B7F081B65EAB0BB"]
 			id: "113A3B1354A13AD5"
-			tasks: [{
-				id: "121A7338855CDF7F"
-				type: "item"
-				item: "bewitchment:crystal_ball"
-			}]
+			y: -0.5d
+			x: 0.0d
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/botania.snbt
+++ b/config/ftbquests/quests/chapters/botania.snbt
@@ -1,9 +1,10 @@
 {
-	id: "33C9E52EF9326063"
+	quest_links: [ ]
+	default_hide_dependency_lines: false
 	group: "1039AC171AB01709"
-	order_index: 2
+	id: "33C9E52EF9326063"
 	filename: "botania"
-	title: "Botania"
+	default_quest_shape: ""
 	icon: {
 		id: "botania:lexicon"
 		Count: 1b
@@ -11,15 +12,10 @@
 			"botania:elven_unlock": 1b
 		}
 	}
-	default_quest_shape: ""
-	default_hide_dependency_lines: false
+	title: "Botania"
+	order_index: 2
 	quests: [
 		{
-			title: "Mystical Flowers"
-			x: 4.5d
-			y: -2.5d
-			dependencies: ["358776C4E9A01BCC"]
-			id: "485B2B25658C5301"
 			tasks: [{
 				id: "7ABB92917F9A529C"
 				type: "item"
@@ -32,23 +28,19 @@
 					}
 				}
 			}]
+			id: "485B2B25658C5301"
+			x: 4.5d
+			y: -2.5d
+			title: "Mystical Flowers"
 			rewards: [{
 				id: "0D4613B04BEFE3D5"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["358776C4E9A01BCC"]
 		}
 		{
-			title: "Colored Petals"
-			x: 4.5d
-			y: -3.5d
-			description: [
-				"Petals are obtained by placing a Mystical Flower in the crafting table."
-				"They are used later to craft special flowers."
-			]
-			dependencies: ["485B2B25658C5301"]
-			id: "6A1CC424788CAC34"
 			tasks: [{
 				id: "3F596D2ECA308348"
 				type: "item"
@@ -61,36 +53,47 @@
 					}
 				}
 			}]
+			description: [
+				"Petals are obtained by placing a Mystical Flower in the crafting table."
+				"They are used later to craft special flowers."
+			]
+			id: "6A1CC424788CAC34"
+			x: 4.5d
+			y: -3.5d
+			title: "Colored Petals"
 			rewards: [{
 				id: "52C94F530D5278D3"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["485B2B25658C5301"]
 		}
 		{
-			x: 4.5d
-			y: -0.5d
-			subtitle: "Botania is a tech mod themed around Natural Magic."
-			description: ["If you need more information about any content in the Botania Mod, check the Lexica Botania. It will describe every part in more detail."]
-			hide: true
-			id: "06796341AB3CFBB4"
 			tasks: [{
 				id: "7AB518F0AAAD7EF3"
 				type: "item"
 				item: "botania:lexicon"
 			}]
+			description: ["If you need more information about any content in the Botania Mod, check the Lexica Botania. It will describe every part in more detail."]
+			id: "06796341AB3CFBB4"
+			x: 4.5d
+			y: -0.5d
 			rewards: [{
 				id: "7CDFCC5D44D1D8AE"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Botania is a tech mod themed around Natural Magic."
+			hide: true
 		}
 		{
-			x: 6.0d
-			y: -3.5d
-			subtitle: "Here, you will craft various Botania flowers."
+			tasks: [{
+				id: "60358EC46F777869"
+				type: "item"
+				item: "botania:apothecary_default"
+			}]
 			description: [
 				"Learn how to use it, by performing a simple craft:"
 				"1. Fill it with Water by Right-Clicking the Apothecary with Water Bucket, or by throwing the Water Bucket on top."
@@ -103,85 +106,83 @@
 				"Did you know, that Create's Spouts can fill Petal Apothecaries as well?"
 				"{image:kubejs:textures/item/spout_apothecary.png width:60 height:125 align:1}"
 			]
-			dependencies: ["6A1CC424788CAC34"]
-			progression_mode: "linear"
 			id: "7D112B8FC4531A7E"
-			tasks: [{
-				id: "60358EC46F777869"
-				type: "item"
-				item: "botania:apothecary_default"
-			}]
+			x: 6.0d
+			y: -3.5d
 			rewards: [{
 				id: "78A063E6B8038C85"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			progression_mode: "linear"
+			subtitle: "Here, you will craft various Botania flowers."
+			dependencies: ["6A1CC424788CAC34"]
 		}
 		{
-			x: 12.088435374149675d
-			y: 2.0081632653061163d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "4E431ECCB8171C07"
 			tasks: [{
 				id: "1EB6A4F1B3BA45BA"
 				type: "item"
 				item: "botania:rune_water"
 			}]
+			id: "4E431ECCB8171C07"
+			x: 12.088435374149675d
+			y: 2.0081632653061163d
 			rewards: [{
 				id: "74CFFFF4231A0D1D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 12.476190476190482d
-			y: 1.2938775510204081d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "18757A36806F1878"
 			tasks: [{
 				id: "191B867FA467FAEA"
 				type: "item"
 				item: "botania:rune_fire"
 			}]
+			id: "18757A36806F1878"
+			x: 12.476190476190482d
+			y: 1.2938775510204081d
 			rewards: [{
 				id: "1EF62E6C61755851"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 11.700680272108848d
-			y: 1.2938775510204081d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "51FEC6EAE37CA66E"
 			tasks: [{
 				id: "551BE5A6EE690AAF"
 				type: "item"
 				item: "botania:rune_earth"
 			}]
+			id: "51FEC6EAE37CA66E"
+			x: 11.700680272108848d
+			y: 1.2938775510204081d
 			rewards: [{
 				id: "38775BE18FB00A5A"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 12.079591836734664d
-			y: 0.5744897959183675d
-			dependencies: ["278D27920CB07C59"]
-			id: "40C1CB6DAA269B0A"
 			tasks: [{
 				id: "2913177D2A0D273B"
 				type: "item"
 				item: "botania:rune_air"
 			}]
+			dependencies: ["278D27920CB07C59"]
+			id: "40C1CB6DAA269B0A"
+			y: 0.5744897959183675d
+			x: 12.079591836734664d
 			rewards: [{
 				id: "434E4D189F377EC1"
 				type: "random"
@@ -190,33 +191,33 @@
 			}]
 		}
 		{
-			x: 14.45578231292518d
-			y: 1.2938775510204081d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "3F670ACF86589C8E"
 			tasks: [{
 				id: "486ED749D6BEF0C5"
 				type: "item"
 				item: "botania:rune_spring"
 			}]
+			id: "3F670ACF86589C8E"
+			x: 14.45578231292518d
+			y: 1.2938775510204081d
 			rewards: [{
 				id: "13E60E701E1EBF9F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 14.047619047619058d
-			y: 0.5591836734693842d
-			dependencies: ["278D27920CB07C59"]
-			id: "268644F3A210BECD"
 			tasks: [{
 				id: "748A43501A988927"
 				type: "item"
 				item: "botania:rune_summer"
 			}]
+			dependencies: ["278D27920CB07C59"]
+			id: "268644F3A210BECD"
+			y: 0.5591836734693842d
+			x: 14.047619047619058d
 			rewards: [{
 				id: "0541DDB94F66C756"
 				type: "random"
@@ -225,302 +226,304 @@
 			}]
 		}
 		{
-			x: 14.038775510204047d
-			y: 2.003061224489791d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "078A3BC997198FB7"
 			tasks: [{
 				id: "4DBA59169107C7FE"
 				type: "item"
 				item: "botania:rune_autumn"
 			}]
+			id: "078A3BC997198FB7"
+			x: 14.038775510204047d
+			y: 2.003061224489791d
 			rewards: [{
 				id: "575ABEB4D1CC3A16"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 13.653401360544258d
-			y: 1.2836734693877432d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "1C59FEEFD6AA31A2"
 			tasks: [{
 				id: "2079BFA573F0D5B8"
 				type: "item"
 				item: "botania:rune_winter"
 			}]
+			id: "1C59FEEFD6AA31A2"
+			x: 13.653401360544258d
+			y: 1.2836734693877432d
 			rewards: [{
 				id: "07B8BEF029D5B405"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 14.047619047619058d
-			y: 3.0489795918367335d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "0A7B6621E69A8F30"
 			tasks: [{
 				id: "321E06D341688ECA"
 				type: "item"
 				item: "botania:rune_mana"
 			}]
+			id: "0A7B6621E69A8F30"
+			x: 14.047619047619058d
+			y: 3.0489795918367335d
 			rewards: [{
 				id: "25F5EC446759FBF7"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 12.108843537414977d
-			y: 3.069387755102042d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "0012D01682469313"
 			tasks: [{
 				id: "624831524D3FC47A"
 				type: "item"
 				item: "botania:rune_lust"
 			}]
+			id: "0012D01682469313"
+			x: 12.108843537414977d
+			y: 3.069387755102042d
 			rewards: [{
 				id: "5F83A46745E2CA06"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 13.653401360544258d
-			y: 3.783673469387743d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "619D01CEB1837AFA"
 			tasks: [{
 				id: "685FD69CEE9312AB"
 				type: "item"
 				item: "botania:rune_gluttony"
 			}]
+			id: "619D01CEB1837AFA"
+			x: 13.653401360544258d
+			y: 3.783673469387743d
 			rewards: [{
 				id: "1E6C2F512CD85249"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 14.45578231292518d
-			y: 3.7836734693877503d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "0A81B43CDC63A60B"
 			tasks: [{
 				id: "05A7C741B4F1918F"
 				type: "item"
 				item: "botania:rune_sloth"
 			}]
+			id: "0A81B43CDC63A60B"
+			x: 14.45578231292518d
+			y: 3.7836734693877503d
 			rewards: [{
 				id: "7659B88EE8C6944B"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 12.108843537414977d
-			y: 4.497959183673466d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "5B2E592C9D42AA01"
 			tasks: [{
 				id: "1E6A14A9439DBC96"
 				type: "item"
 				item: "botania:rune_wrath"
 			}]
+			id: "5B2E592C9D42AA01"
+			x: 12.108843537414977d
+			y: 4.497959183673466d
 			rewards: [{
 				id: "566548D70FAF30AA"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 11.700680272108848d
-			y: 3.7836734693877503d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "5AFD85DD78555528"
 			tasks: [{
 				id: "440FC1619630DC28"
 				type: "item"
 				item: "botania:rune_envy"
 			}]
+			id: "5AFD85DD78555528"
+			x: 11.700680272108848d
+			y: 3.7836734693877503d
 			rewards: [{
 				id: "7D36C2EC9D0F1FC0"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 12.510544217687112d
-			y: 3.783673469387743d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "414BC15D4F10F7C2"
 			tasks: [{
 				id: "28AE00744FDAD2F4"
 				type: "item"
 				item: "botania:rune_pride"
 			}]
+			id: "414BC15D4F10F7C2"
+			x: 12.510544217687112d
+			y: 3.783673469387743d
 			rewards: [{
 				id: "677F67A05C9C1709"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 12.5d
-			y: -8.5d
-			subtitle: "Place next to a Mana Pool to see if you are gaining or losing Mana."
-			description: [
-				"The flower shines §cred§r, if you are losing Mana."
-				""
-				"The flower shines §9blue§r, if you are gaining Mana."
-			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "26C37DB6B3A9A36C"
 			tasks: [{
 				id: "18392FB576050DD5"
 				type: "item"
 				item: "botania:manastar"
 			}]
+			description: [
+				"The flower shines §cred§r, if you are losing Mana."
+				""
+				"The flower shines §9blue§r, if you are gaining Mana."
+			]
+			id: "26C37DB6B3A9A36C"
+			x: 12.5d
+			y: -8.5d
 			rewards: [{
 				id: "62CF3676A7E5381F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Place next to a Mana Pool to see if you are gaining or losing Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 10.5d
-			y: -8.5d
-			subtitle: "A Passive flower, that generates Mana out of water."
-			description: ["It will decay after 1 hour. But it might be a cheap option to start generating mana."]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "09DDD53672B0A561"
 			tasks: [{
 				id: "5E242EF65557C353"
 				type: "item"
 				item: "botania:hydroangeas"
 			}]
+			description: ["It will decay after 1 hour. But it might be a cheap option to start generating mana."]
+			id: "09DDD53672B0A561"
+			x: 10.5d
+			y: -8.5d
 			rewards: [{
 				id: "252C7151361DC274"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A Passive flower, that generates Mana out of water."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 7.5d
-			y: -8.5d
-			subtitle: "Consumes burnable materials to generate Mana."
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "71A4C5B1E8C9C79C"
 			tasks: [{
 				id: "7551A29BB6766D8B"
 				type: "item"
 				item: "botania:endoflame"
 			}]
+			id: "71A4C5B1E8C9C79C"
+			x: 7.5d
+			y: -8.5d
 			rewards: [{
 				id: "2142C66BF03D4D80"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Consumes burnable materials to generate Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 6.5d
-			y: -8.5d
-			subtitle: "Absorbs Lava around itself to produce Mana."
-			description: [
-				"After absorbing the lava source block, Thermalily will rapidly generate mana for 45 seconds, after which Thermalily will enter a 5-minute cooldown."
-				""
-				"During that cooldown, Lava will be consumed without giving any Mana."
-			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "718F083C919115DE"
 			tasks: [{
 				id: "231D6FF6A9599D39"
 				type: "item"
 				item: "botania:thermalily"
 			}]
+			description: [
+				"After absorbing the lava source block, Thermalily will rapidly generate mana for 45 seconds, after which Thermalily will enter a 5-minute cooldown."
+				""
+				"During that cooldown, Lava will be consumed without giving any Mana."
+			]
+			id: "718F083C919115DE"
+			x: 6.5d
+			y: -8.5d
 			rewards: [{
 				id: "124B2037FB0094AA"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Absorbs Lava around itself to produce Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 9.5d
-			y: -8.5d
-			subtitle: "This flower converts XP into Mana."
-			description: [
-				"It can grab XP from a nearby player (full efficiency) or from XP Orbs (lower efficiency)."
-				""
-				"Might be a good choice if you have a lot of excess XP."
-			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "25A5A748D3DB6FD0"
 			tasks: [{
 				id: "01401C09AFABF05D"
 				type: "item"
 				item: "botania:rosa_arcana"
 			}]
+			description: [
+				"It can grab XP from a nearby player (full efficiency) or from XP Orbs (lower efficiency)."
+				""
+				"Might be a good choice if you have a lot of excess XP."
+			]
+			id: "25A5A748D3DB6FD0"
+			x: 9.5d
+			y: -8.5d
 			rewards: [{
 				id: "0B56CC54BFA94436"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "This flower converts XP into Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 9.0d
-			y: -9.5d
-			subtitle: "Eats nearby Leaf blocks to generate Mana."
-			description: ["However, eaten leaves won't drop any Saplings, so keep that in mind."]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "0A75593D0D68EC0F"
 			tasks: [{
 				id: "0D6842DE6A0F5F86"
 				type: "item"
 				item: "botania:munchdew"
 			}]
+			description: ["However, eaten leaves won't drop any Saplings, so keep that in mind."]
+			id: "0A75593D0D68EC0F"
+			x: 9.0d
+			y: -9.5d
 			rewards: [{
 				id: "685A80F3D56E231E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Eats nearby Leaf blocks to generate Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 7.0d
-			y: -9.5d
-			subtitle: "Absorbs TNT explosions to generate Mana."
+			tasks: [{
+				id: "482C855E73511E3B"
+				type: "item"
+				item: "botania:entropinnyum"
+			}]
 			description: [
 				"If a Primed TNT would explode in the Entropinnyum's range, the explosion will be absorbed, generating Mana."
 				""
@@ -528,45 +531,45 @@
 				""
 				"Also, duping TNT is no use, since duped TNT generates very little Mana, so avoid priming TNT near pistons or rails."
 			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
 			id: "2F399FC03DB26EBD"
-			tasks: [{
-				id: "482C855E73511E3B"
-				type: "item"
-				item: "botania:entropinnyum"
-			}]
+			x: 7.0d
+			y: -9.5d
 			rewards: [{
 				id: "58DF513589CD78F1"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Absorbs TNT explosions to generate Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 8.0d
-			y: -7.5d
-			subtitle: "Eats nearby Cakes to generate Mana."
-			description: ["Automating this flower can be a good challenge, so give it a try!"]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "4E9962D7D506C825"
 			tasks: [{
 				id: "16B6114ED1DA62F7"
 				type: "item"
 				item: "botania:kekimurus"
 			}]
+			description: ["Automating this flower can be a good challenge, so give it a try!"]
+			id: "4E9962D7D506C825"
+			x: 8.0d
+			y: -7.5d
 			rewards: [{
 				id: "6B68D989C820289E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Eats nearby Cakes to generate Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 10.0d
-			y: -7.5d
-			subtitle: "Consumes nearby dropped food to generate Mana."
+			tasks: [{
+				id: "2CB39AF7466DC8C1"
+				type: "item"
+				item: "botania:gourmaryllis"
+			}]
 			description: [
 				"The more nourishing the food is, the more Mana it gives and the longer is digested."
 				""
@@ -574,74 +577,74 @@
 				""
 				"The best way to generate Mana with this flower is to cycle between 6 different nourishing foods."
 			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
 			id: "1A2858B1927BC08F"
-			tasks: [{
-				id: "2CB39AF7466DC8C1"
-				type: "item"
-				item: "botania:gourmaryllis"
-			}]
+			x: 10.0d
+			y: -7.5d
 			rewards: [{
 				id: "195A6B49E7D2F87A"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Consumes nearby dropped food to generate Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 7.0d
-			y: -7.5d
-			subtitle: "Absorbs naturally spawned Slimes to generate Mana."
-			description: [
-				"Best used in a slime chunk, as low as possible since the lower the surface, the more mobs spawn."
-				""
-				"Narslimmus will generate more Mana, the bigger the consumed Slime is."
-			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "4B45C598CB667293"
 			tasks: [{
 				id: "0B6D440D84C8D897"
 				type: "item"
 				item: "botania:narslimmus"
 			}]
+			description: [
+				"Best used in a slime chunk, as low as possible since the lower the surface, the more mobs spawn."
+				""
+				"Narslimmus will generate more Mana, the bigger the consumed Slime is."
+			]
+			id: "4B45C598CB667293"
+			x: 7.0d
+			y: -7.5d
 			rewards: [{
 				id: "1EA3C41055D5DD6D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Absorbs naturally spawned Slimes to generate Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 9.0d
-			y: -7.5d
-			subtitle: "Consumes nearby dropped Wool to generate Mana."
+			tasks: [{
+				id: "621014BB3335D3EF"
+				type: "item"
+				item: "botania:spectrolus"
+			}]
 			description: [
 				"However, there's a caveat:"
 				"The wool must be given in the correct order, according to default metadata order, as seen in REI."
 				""
 				"If you give this flower a wrong color of Wool, it will be consumed without giving any Mana."
 			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
 			id: "20CD84F21593809A"
-			tasks: [{
-				id: "621014BB3335D3EF"
-				type: "item"
-				item: "botania:spectrolus"
-			}]
+			x: 9.0d
+			y: -7.5d
 			rewards: [{
 				id: "06100F237921A5A5"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Consumes nearby dropped Wool to generate Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 8.5d
-			y: -8.5d
-			subtitle: "Simulates Conway's Game of Life to generate Mana."
+			tasks: [{
+				id: "707A9D4D4FAC8A11"
+				type: "item"
+				item: "botania:dandelifeon"
+			}]
 			description: [
 				"The simulation is performed in 25x25 arena around the Dandelifeon."
 				""
@@ -663,25 +666,25 @@
 				""
 				"{image:kubejs:textures/item/botania_gameoflife.png width:160 height:140 align:1}"
 			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
 			id: "2DB8FCEEAA44B8EE"
-			tasks: [{
-				id: "707A9D4D4FAC8A11"
-				type: "item"
-				item: "botania:dandelifeon"
-			}]
+			x: 8.5d
+			y: -8.5d
 			rewards: [{
 				id: "07ADA1CEF2409B0A"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Simulates Conway's Game of Life to generate Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 10.0d
-			y: -9.5d
-			subtitle: "Consumes man-made Flowers to generate Mana."
+			tasks: [{
+				id: "1592854EC4383B50"
+				type: "item"
+				item: "botania:rafflowsia"
+			}]
 			description: [
 				"The more complicated the Flower is, the more Mana it gives."
 				""
@@ -689,25 +692,25 @@
 				""
 				"The best way to generate Mana with this flower is to cycle between 6 different Flowers."
 			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
 			id: "6B6C1338DA6E05E1"
-			tasks: [{
-				id: "1592854EC4383B50"
-				type: "item"
-				item: "botania:rafflowsia"
-			}]
+			x: 10.0d
+			y: -9.5d
 			rewards: [{
 				id: "00479B14C7D1BB81"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Consumes man-made Flowers to generate Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 8.0d
-			y: -9.5d
-			subtitle: "Generates Mana, when a Shulker hits another monster."
+			tasks: [{
+				id: "3CC564AD9E634521"
+				type: "item"
+				item: "botania:shulk_me_not"
+			}]
 			description: [
 				"The Shulker must target that monster - so tricks like putting a Snowman or a Iron Golem won't work."
 				""
@@ -719,270 +722,270 @@
 				""
 				"Both the Shulker and the monster will be killed without dropping anything."
 			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
 			id: "3C6E5B44E163C799"
-			tasks: [{
-				id: "3CC564AD9E634521"
-				type: "item"
-				item: "botania:shulk_me_not"
-			}]
+			x: 8.0d
+			y: -9.5d
 			rewards: [{
 				id: "58CDA4138663B4B4"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Mana, when a Shulker hits another monster."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 18.0d
-			y: -9.5d
-			subtitle: "Harms nearby mobs using Mana."
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "739DFA411EBFB864"
 			tasks: [{
 				id: "44FA281DB71055AB"
 				type: "item"
 				item: "botania:bellethorn"
 			}]
+			id: "739DFA411EBFB864"
+			x: 18.0d
+			y: -9.5d
 			rewards: [{
 				id: "2437C67D4954DDD5"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Harms nearby mobs using Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 13.5d
-			y: -8.5d
-			subtitle: "Shut up!"
-			description: [
-				"The Bergamute will muffle any sounds around itself."
-				""
-				"Does not use Mana."
-			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "570B152BB34722E6"
 			tasks: [{
 				id: "7E4F636F96B907BE"
 				type: "item"
 				item: "botania:bergamute"
 			}]
+			description: [
+				"The Bergamute will muffle any sounds around itself."
+				""
+				"Does not use Mana."
+			]
+			id: "570B152BB34722E6"
+			x: 13.5d
+			y: -8.5d
 			rewards: [{
 				id: "48D53D32C6BCB062"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Shut up!"
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 16.0d
-			y: -7.5d
-			subtitle: "Harms any nearby adult animals using Mana."
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "397FC7D166A82A7A"
 			tasks: [{
 				id: "4040C2C9FF8D502C"
 				type: "item"
 				item: "botania:dreadthorn"
 			}]
+			id: "397FC7D166A82A7A"
+			x: 16.0d
+			y: -7.5d
 			rewards: [{
 				id: "30BE6C091B924A4E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Harms any nearby adult animals using Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 15.5d
-			y: -10.5d
-			subtitle: "I'm angry."
-			description: ["This flower will manipulate nearby mobs so they will try to kill each other."]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "74876684DC462F9A"
 			tasks: [{
 				id: "2F4D09CA6AC20B14"
 				type: "item"
 				item: "botania:heisei_dream"
 			}]
+			description: ["This flower will manipulate nearby mobs so they will try to kill each other."]
+			id: "74876684DC462F9A"
+			x: 15.5d
+			y: -10.5d
 			rewards: [{
 				id: "40EE8221267C307D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "I'm angry."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 18.5d
-			y: -10.5d
-			subtitle: "Creeper? Aww man!"
-			description: ["This flower acts like an cat. Creepers are not able to explode near the flower and they will flee from players."]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "3677DAB681F8D9C8"
 			tasks: [{
 				id: "20070489CA09CFEE"
 				type: "item"
 				item: "botania:tigerseye"
 			}]
+			description: ["This flower acts like an cat. Creepers are not able to explode near the flower and they will flee from players."]
+			id: "3677DAB681F8D9C8"
+			x: 18.5d
+			y: -10.5d
 			rewards: [{
 				id: "7FE64CE1526053C8"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Creeper? Aww man!"
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 16.0d
-			y: -9.5d
-			subtitle: "Grows Mystical Flowers around itself using Mana."
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "4910B83CB988196B"
 			tasks: [{
 				id: "64132B6C1780F3E8"
 				type: "item"
 				item: "botania:jaded_amaranthus"
 			}]
+			id: "4910B83CB988196B"
+			x: 16.0d
+			y: -9.5d
 			rewards: [{
 				id: "5D879ABBEEED7838"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Grows Mystical Flowers around itself using Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 18.5d
-			y: -8.5d
-			subtitle: "Uses Mana to generate ores in Stone."
-			description: [
-				"Note that Garden of Glass is installed."
-				""
-				"This means that this plant is way cheaper, faster and uses less Mana than vanilla Orechid."
-			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "68C6FBD10D2B6D72"
 			tasks: [{
 				id: "42706D477581554D"
 				type: "item"
 				item: "botania:orechid"
 			}]
+			description: [
+				"Note that Garden of Glass is installed."
+				""
+				"This means that this plant is way cheaper, faster and uses less Mana than vanilla Orechid."
+			]
+			id: "68C6FBD10D2B6D72"
+			x: 18.5d
+			y: -8.5d
 			rewards: [{
 				id: "2A6BEC125D0F8D4C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Uses Mana to generate ores in Stone."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 15.5d
-			y: -8.5d
-			subtitle: "Uses Mana to provide nearby players with Regeneration III."
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "27AC22B620B89DF4"
 			tasks: [{
 				id: "5E6CA696214A2F55"
 				type: "item"
 				item: "botania:fallen_kanade"
 			}]
+			id: "27AC22B620B89DF4"
+			x: 15.5d
+			y: -8.5d
 			rewards: [{
 				id: "2571139906FE9E92"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Uses Mana to provide nearby players with Regeneration III."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 17.5d
-			y: -6.5d
-			subtitle: "Fuels nearby Furnaces using Mana."
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "7D1CEAA94F356A43"
 			tasks: [{
 				id: "2DF6E5FE50E32377"
 				type: "item"
 				item: "botania:exoflame"
 			}]
+			id: "7D1CEAA94F356A43"
+			x: 17.5d
+			y: -6.5d
 			rewards: [{
 				id: "211DC3CF7E71194D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Fuels nearby Furnaces using Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 16.5d
-			y: -8.5d
-			subtitle: "Fertilizes nearby plants using Mana."
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "3FBBF519A94669E4"
 			tasks: [{
 				id: "153F2C7FC129ABCC"
 				type: "item"
 				item: "botania:agricarnation"
 			}]
+			id: "3FBBF519A94669E4"
+			x: 16.5d
+			y: -8.5d
 			rewards: [{
 				id: "2F2424AC56246BBA"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Fertilizes nearby plants using Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 17.5d
-			y: -8.5d
-			subtitle: "A magical Vacuum Hopper."
-			description: [
-				"This flower picks up nearby items and places the into an inventory placed next to it."
-				""
-				"You can filter the items picked up by placing Item Frames on the soil under the Hopperhock."
-			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "380C15C1DAC3F9D7"
 			tasks: [{
 				id: "0422DE55C3632C9D"
 				type: "item"
 				item: "botania:hopperhock"
 			}]
+			description: [
+				"This flower picks up nearby items and places the into an inventory placed next to it."
+				""
+				"You can filter the items picked up by placing Item Frames on the soil under the Hopperhock."
+			]
+			id: "380C15C1DAC3F9D7"
+			x: 17.5d
+			y: -8.5d
 			rewards: [{
 				id: "5A054E5F24A25F56"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A magical Vacuum Hopper."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 19.0d
-			y: -7.5d
-			subtitle: "Prevents mobs from leaving the area around the flower."
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "26DD7670DD6BC270"
 			tasks: [{
 				id: "2EA241B535AFCA80"
 				type: "item"
 				item: "botania:tangleberrie"
 			}]
+			id: "26DD7670DD6BC270"
+			x: 19.0d
+			y: -7.5d
 			rewards: [{
 				id: "421D525063AD56E6"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Prevents mobs from leaving the area around the flower."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 17.0d
-			y: -7.5d
-			subtitle: "Picks up nearby blocks and places them in a large radius around itself."
+			tasks: [{
+				id: "6ECD669989AF4C96"
+				type: "item"
+				item: "botania:rannuncarpus"
+			}]
 			description: [
 				"Specify the block by putting it below the Rannucarpus."
 				""
@@ -990,170 +993,170 @@
 				""
 				"Using Wand of the Forest in Function Mode, you can change whether the blockstate is respected or not."
 			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
 			id: "521A546902D8C10B"
-			tasks: [{
-				id: "6ECD669989AF4C96"
-				type: "item"
-				item: "botania:rannuncarpus"
-			}]
+			x: 17.0d
+			y: -7.5d
 			rewards: [{
 				id: "731173C37955B48B"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Picks up nearby blocks and places them in a large radius around itself."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 20.0d
-			y: -9.5d
-			subtitle: "For some reason, Poison does not kill."
-			description: [
-				"This flower can be used in Mob Farms."
-				""
-				"It will inflict Poison to them, allowing the mobs to be one-hitted by the player."
-			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "3276FA70E0225D04"
 			tasks: [{
 				id: "70812B6BF6E48C18"
 				type: "item"
 				item: "botania:hyacidus"
 			}]
+			description: [
+				"This flower can be used in Mob Farms."
+				""
+				"It will inflict Poison to them, allowing the mobs to be one-hitted by the player."
+			]
+			id: "3276FA70E0225D04"
+			x: 20.0d
+			y: -9.5d
 			rewards: [{
 				id: "49DA5EFB916FBDE1"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "For some reason, Poison does not kill."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 19.0d
-			y: -11.5d
-			subtitle: "Uses nearby dropped food items to feed nearby animals."
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "41742AAE9E513983"
 			tasks: [{
 				id: "3B1D18185B892357"
 				type: "item"
 				item: "botania:pollidisiac"
 			}]
+			id: "41742AAE9E513983"
+			x: 19.0d
+			y: -11.5d
 			rewards: [{
 				id: "432523431A8BD938"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Uses nearby dropped food items to feed nearby animals."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 18.0d
-			y: -7.5d
-			subtitle: "Prevents mobs from entering the area around the flower."
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "4AF639EFD211E634"
 			tasks: [{
 				id: "3E1B23D1B6023C3F"
 				type: "item"
 				item: "botania:jiyuulia"
 			}]
+			id: "4AF639EFD211E634"
+			x: 18.0d
+			y: -7.5d
 			rewards: [{
 				id: "49C9503811063508"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Prevents mobs from entering the area around the flower."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 19.0d
-			y: -9.5d
-			subtitle: "Balanced because it takes effort."
-			description: ["This flower uses Mana to convert Sand into Clay."]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "2E6728E2898E3201"
 			tasks: [{
 				id: "41621C2949CFF126"
 				type: "item"
 				item: "botania:clayconia"
 			}]
+			description: ["This flower uses Mana to convert Sand into Clay."]
+			id: "2E6728E2898E3201"
+			x: 19.0d
+			y: -9.5d
 			rewards: [{
 				id: "513727C8193D2741"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Balanced because it takes effort."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 18.0d
-			y: -11.5d
-			subtitle: "Uses Mana to summon monsters holding dungeon loot."
-			description: [
-				"Kill the monster to get the dungeon loot."
-				""
-				"The dungeon loot will NOT contain any Music Discs nor Overgrowth Seeds."
-			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "178CEDDE5FB1477D"
 			tasks: [{
 				id: "4ACCF4F716289804"
 				type: "item"
 				item: "botania:loonium"
 			}]
+			description: [
+				"Kill the monster to get the dungeon loot."
+				""
+				"The dungeon loot will NOT contain any Music Discs nor Overgrowth Seeds."
+			]
+			id: "178CEDDE5FB1477D"
+			x: 18.0d
+			y: -11.5d
 			rewards: [{
 				id: "6AB932FEB2D16C57"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Uses Mana to summon monsters holding dungeon loot."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 17.0d
-			y: -9.5d
-			subtitle: "A Mana powered fan?"
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "1DED9FFD8AC3C2FB"
 			tasks: [{
 				id: "30A0D772BEA3A5CE"
 				type: "item"
 				item: "botania:daffomill"
 			}]
+			id: "1DED9FFD8AC3C2FB"
+			x: 17.0d
+			y: -9.5d
 			rewards: [{
 				id: "77B638DC49792BE2"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A Mana powered fan?"
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 17.0d
-			y: -11.5d
-			subtitle: "Ender Tether."
-			description: ["This flower has a large area of effect, in this area, any enerman which tries to teleport, will be teleported directly to this flower."]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "46BD42AE54F2CE89"
 			tasks: [{
 				id: "20B3E523F483DF85"
 				type: "item"
 				item: "botania:vinculotus"
 			}]
+			description: ["This flower has a large area of effect, in this area, any enerman which tries to teleport, will be teleported directly to this flower."]
+			id: "46BD42AE54F2CE89"
+			x: 17.0d
+			y: -11.5d
 			rewards: [{
 				id: "44748FE294808B11"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Ender Tether."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 16.5d
-			y: -10.5d
-			subtitle: "Teleports items using Mana."
+			tasks: [{
+				id: "5F91F1F95CD351DE"
+				type: "item"
+				item: "botania:spectranthemum"
+			}]
 			description: [
 				"You can bind it to a block just like you can bind Mana Spreaders to Pools."
 				""
@@ -1165,169 +1168,161 @@
 				""
 				"Useful for aesthetically pleasing Botania automations."
 			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
 			id: "569D4AF8036BF532"
-			tasks: [{
-				id: "5F91F1F95CD351DE"
-				type: "item"
-				item: "botania:spectranthemum"
-			}]
+			x: 16.5d
+			y: -10.5d
 			rewards: [{
 				id: "72A0DFD35249A072"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Teleports items using Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 17.5d
-			y: -5.5d
-			subtitle: "Slows down mobs (but not players) around itself using Mana."
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "1440C7814E99B2C6"
 			tasks: [{
 				id: "6A5F4C331F61E829"
 				type: "item"
 				item: "botania:medumone"
 			}]
+			id: "1440C7814E99B2C6"
+			x: 17.5d
+			y: -5.5d
 			rewards: [{
 				id: "3BF9B8C9484D81C7"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Slows down mobs (but not players) around itself using Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 17.5d
-			y: -10.5d
-			subtitle: "Converts nearby stone into other stone variants."
-			description: ["You will surely love some color pallets of stones generated by this flower."]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "0975F41A35E0A953"
 			tasks: [{
 				id: "48E4655E900F3330"
 				type: "item"
 				item: "botania:marimorphosis"
 			}]
+			description: ["You will surely love some color pallets of stones generated by this flower."]
+			id: "0975F41A35E0A953"
+			x: 17.5d
+			y: -10.5d
 			rewards: [{
 				id: "1A03EDBAB1A1DF27"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Converts nearby stone into other stone variants."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 15.0d
-			y: -9.5d
-			subtitle: "... and whistle."
-			description: ["If placed underwater and supplied with Mana, it will remove water in a 12 blocks radius."]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "13D165DA7627571B"
 			tasks: [{
 				id: "1ADD49FF68CADF5B"
 				type: "item"
 				item: "botania:bubbell"
 			}]
+			description: ["If placed underwater and supplied with Mana, it will remove water in a 12 blocks radius."]
+			id: "13D165DA7627571B"
+			x: 15.0d
+			y: -9.5d
 			rewards: [{
 				id: "5104F74419B3C1AB"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "... and whistle."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 19.5d
-			y: -8.5d
-			subtitle: "Prevents the Rings of Magnetization from attracting items in its radius."
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "420D15E11CFCA292"
 			tasks: [{
 				id: "62B58805D061F3E8"
 				type: "item"
 				item: "botania:solegnolia"
 			}]
+			id: "420D15E11CFCA292"
+			x: 19.5d
+			y: -8.5d
 			rewards: [{
 				id: "643DBF458E365579"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Prevents the Rings of Magnetization from attracting items in its radius."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 19.5d
-			y: -10.5d
-			subtitle: "Generates Nether ores in Netherrack using hefty amounts of Mana."
-			description: ["Works ONLY in the Nether."]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "17D7A712F5CCFEDF"
 			tasks: [{
 				id: "4429F9A7995A3D4B"
 				type: "item"
 				item: "botania:orechid_ignem"
 			}]
+			description: ["Works ONLY in the Nether."]
+			id: "17D7A712F5CCFEDF"
+			x: 19.5d
+			y: -10.5d
 			rewards: [{
 				id: "4D0CEF2450F1F138"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Nether ores in Netherrack using hefty amounts of Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 16.0d
-			y: -11.5d
-			subtitle: "Labels nearby Items of Mobs using Mana."
-			description: [
-				"This flower will pick up name tags dropped on top of it and uses mana to rename any dropped item or entity in its 5x5 radius."
-				""
-				"The Name Tag will be consumed in the process."
-			]
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "0D7302F3B76BEC3A"
 			tasks: [{
 				id: "415C63BEFFC4F2FF"
 				type: "item"
 				item: "botania:labellia"
 			}]
+			description: [
+				"This flower will pick up name tags dropped on top of it and uses mana to rename any dropped item or entity in its 5x5 radius."
+				""
+				"The Name Tag will be consumed in the process."
+			]
+			id: "0D7302F3B76BEC3A"
+			x: 16.0d
+			y: -11.5d
 			rewards: [{
 				id: "41C308D8D7C12141"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Labels nearby Items of Mobs using Mana."
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 6.0d
-			y: -2.5d
-			subtitle: "Transforms 8 blocks around itself into other blocks."
-			description: ["Try placing Logs or Stone!"]
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "0BA60C71BADB27EA"
 			tasks: [{
 				id: "2DE51BB02B5241F2"
 				type: "item"
 				item: "botania:pure_daisy"
 			}]
+			description: ["Try placing Logs or Stone!"]
+			id: "0BA60C71BADB27EA"
+			x: 6.0d
+			y: -2.5d
 			rewards: [{
 				id: "4BF5CC2F81566680"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Transforms 8 blocks around itself into other blocks."
+			dependencies: ["7D112B8FC4531A7E"]
 		}
 		{
-			title: "Living Wood / Rock"
-			x: 7.0d
-			y: -2.5d
-			description: ["By placing Blocks like stone and wood around the Pure Daisy, it will take some time to transform the blocks into e.g. living wood or rock."]
-			dependencies: ["0BA60C71BADB27EA"]
-			id: "793DCC312DFF0198"
 			tasks: [
 				{
 					id: "595062CEFAB338F0"
@@ -1340,41 +1335,47 @@
 					item: "botania:livingwood_log"
 				}
 			]
+			description: ["By placing Blocks like stone and wood around the Pure Daisy, it will take some time to transform the blocks into e.g. living wood or rock."]
+			id: "793DCC312DFF0198"
+			x: 7.0d
+			y: -2.5d
+			title: "Living Wood / Rock"
 			rewards: [{
 				id: "6A17FE1BE4DC3385"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["0BA60C71BADB27EA"]
 		}
 		{
-			x: 6.0d
-			y: -1.0d
-			description: ["Any Log or Wood can be transformed to Livingwood Logs."]
-			dependencies: ["0BA60C71BADB27EA"]
-			id: "0365DF3000755BCA"
 			tasks: [{
 				id: "12AB987B855C150E"
 				type: "item"
 				item: "botania:livingwood_log"
 			}]
+			description: ["Any Log or Wood can be transformed to Livingwood Logs."]
+			id: "0365DF3000755BCA"
+			x: 6.0d
+			y: -1.0d
 			rewards: [{
 				id: "664B975DE1255B13"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["0BA60C71BADB27EA"]
 		}
 		{
-			x: 6.0d
-			y: 1.0d
-			dependencies: ["19A554515EB494CB"]
-			id: "2B967CD07CAA4F0C"
 			tasks: [{
 				id: "455ADCF3A6364652"
 				type: "item"
 				item: "botania:glimmering_livingwood"
 			}]
+			dependencies: ["19A554515EB494CB"]
+			id: "2B967CD07CAA4F0C"
+			y: 1.0d
+			x: 6.0d
 			rewards: [{
 				id: "06CD4A97CA07D2EF"
 				type: "random"
@@ -1383,187 +1384,187 @@
 			}]
 		}
 		{
-			x: 6.0d
-			y: 0.0d
-			description: ["By adding some Glowstone to your Livingwood Log in an Crafting Table you can get glimmering Livingwood Logs."]
-			dependencies: ["0365DF3000755BCA"]
-			id: "19A554515EB494CB"
 			tasks: [{
 				id: "5D5BA7EE0BAE6896"
 				type: "item"
 				item: "botania:glimmering_livingwood_log"
 			}]
+			description: ["By adding some Glowstone to your Livingwood Log in an Crafting Table you can get glimmering Livingwood Logs."]
+			id: "19A554515EB494CB"
+			x: 6.0d
+			y: 0.0d
 			rewards: [{
 				id: "1766CA28C52A4760"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["0365DF3000755BCA"]
 		}
 		{
-			x: 6.0d
-			y: 2.0d
-			description: ["Take a look in the Lexica Botania to get a visualization on how to build the Elven Portal."]
-			dependencies: [
-				"2B967CD07CAA4F0C"
-				"44DF71B4C8D2B61A"
-			]
-			id: "52250F3E2FB2AE6F"
 			tasks: [{
 				id: "04212E9B57103BD3"
 				type: "item"
 				item: "botania:alfheim_portal"
 			}]
+			description: ["Take a look in the Lexica Botania to get a visualization on how to build the Elven Portal."]
+			id: "52250F3E2FB2AE6F"
+			x: 6.0d
+			y: 2.0d
 			rewards: [{
 				id: "53E764BA3014408D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: [
+				"2B967CD07CAA4F0C"
+				"44DF71B4C8D2B61A"
+			]
 		}
 		{
-			x: 8.0d
-			y: 2.0d
-			description: [
-				"Throw a Manasteel Ingot, Mana Diamond and Mana Pearl on the Terrestrial Agglomeration Plate."
-				""
-				"It will then consume half a Mana Pool worth of Mana to create a Terrasteel Ingot."
-			]
-			dependencies: ["0D915881A8BF7EE3"]
-			id: "44DF71B4C8D2B61A"
 			tasks: [{
 				id: "789EA90E2F090F61"
 				type: "item"
 				item: "botania:terrasteel_ingot"
 			}]
+			description: [
+				"Throw a Manasteel Ingot, Mana Diamond and Mana Pearl on the Terrestrial Agglomeration Plate."
+				""
+				"It will then consume half a Mana Pool worth of Mana to create a Terrasteel Ingot."
+			]
+			id: "44DF71B4C8D2B61A"
+			x: 8.0d
+			y: 2.0d
 			rewards: [{
 				id: "7F35BF0317C45F62"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["0D915881A8BF7EE3"]
 		}
 		{
-			x: 8.0d
-			y: -1.0d
-			description: [
-				"You have to place 4 Lapis Lazuli Blocks and 5 Living Rocks under the Plate."
-				"Take a look into the Lexica Botania to get a visualization."
-			]
-			dependencies: ["01200B72145FDADD"]
-			id: "0D915881A8BF7EE3"
 			tasks: [{
 				id: "649A1947D59AC3FA"
 				type: "item"
 				item: "botania:terra_plate"
 			}]
+			description: [
+				"You have to place 4 Lapis Lazuli Blocks and 5 Living Rocks under the Plate."
+				"Take a look into the Lexica Botania to get a visualization."
+			]
+			id: "0D915881A8BF7EE3"
+			x: 8.0d
+			y: -1.0d
 			rewards: [{
 				id: "1F52C3499CC2F1D0"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["01200B72145FDADD"]
 		}
 		{
-			x: 9.0d
-			y: -2.5d
-			subtitle: "Drop an Iron Ingot into the Mana Pool."
-			dependencies: ["45AC772575502EB6"]
-			id: "01200B72145FDADD"
 			tasks: [{
 				id: "7F3F8F93A8299CC6"
 				type: "item"
 				item: "botania:manasteel_ingot"
 			}]
+			id: "01200B72145FDADD"
+			x: 9.0d
+			y: -2.5d
 			rewards: [{
 				id: "2FB2958D6542A699"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Drop an Iron Ingot into the Mana Pool."
+			dependencies: ["45AC772575502EB6"]
 		}
 		{
-			x: 10.0d
-			y: -2.5d
-			subtitle: "Drop an Ender Pearl into the Mana Pool."
-			dependencies: ["45AC772575502EB6"]
-			id: "7129CFCFCC75AAFC"
 			tasks: [{
 				id: "0EC8AF84752722B9"
 				type: "item"
 				item: "botania:mana_pearl"
 			}]
+			id: "7129CFCFCC75AAFC"
+			x: 10.0d
+			y: -2.5d
 			rewards: [{
 				id: "039E232232C24F1C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Drop an Ender Pearl into the Mana Pool."
+			dependencies: ["45AC772575502EB6"]
 		}
 		{
-			x: 11.0d
-			y: -2.5d
-			subtitle: "Drop Redstone, Sugar, Gunpowder or any Dye into the Mana Pool."
-			dependencies: ["45AC772575502EB6"]
-			id: "5A76DF911EFC76EE"
 			tasks: [{
 				id: "7C60D9A5B78A7340"
 				type: "item"
 				item: "botania:mana_powder"
 			}]
+			id: "5A76DF911EFC76EE"
+			x: 11.0d
+			y: -2.5d
 			rewards: [{
 				id: "1C476E578F1AF472"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Drop Redstone, Sugar, Gunpowder or any Dye into the Mana Pool."
+			dependencies: ["45AC772575502EB6"]
 		}
 		{
-			x: 12.0d
-			y: -2.5d
-			subtitle: "Drop a Diamond into the Mana Pool."
-			dependencies: ["45AC772575502EB6"]
-			id: "641E7D71ACC0F28B"
 			tasks: [{
 				id: "1C5CA8CAF9AA3DCE"
 				type: "item"
 				item: "botania:mana_diamond"
 			}]
+			id: "641E7D71ACC0F28B"
+			x: 12.0d
+			y: -2.5d
 			rewards: [{
 				id: "5682C4E0F57D33C2"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Drop a Diamond into the Mana Pool."
+			dependencies: ["45AC772575502EB6"]
 		}
 		{
-			x: 13.0d
-			y: -2.5d
-			description: ["Drop a String in a Mana Pool."]
-			dependencies: ["45AC772575502EB6"]
-			id: "651A934D02AD1F90"
 			tasks: [{
 				id: "26EDDAFE43B34F88"
 				type: "item"
 				item: "botania:mana_string"
 			}]
+			description: ["Drop a String in a Mana Pool."]
+			id: "651A934D02AD1F90"
+			x: 13.0d
+			y: -2.5d
 			rewards: [{
 				id: "1D95DB3FE7497096"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["45AC772575502EB6"]
 		}
 		{
-			x: 14.0d
-			y: -1.0d
-			dependencies: ["651A934D02AD1F90"]
-			id: "375F904F1F7C628D"
 			tasks: [{
 				id: "6C90591D820C4C30"
 				type: "item"
 				item: "botania:manaweave_cloth"
 			}]
+			dependencies: ["651A934D02AD1F90"]
+			id: "375F904F1F7C628D"
+			y: -1.0d
+			x: 14.0d
 			rewards: [{
 				id: "622787961FD77506"
 				type: "random"
@@ -1572,33 +1573,35 @@
 			}]
 		}
 		{
-			x: 11.0d
-			y: -3.5d
-			subtitle: "Basic Mana Storage, easy to use for mana infusing."
-			description: [
-				"Sometimes, Mana will be related to in numbers in quests. (Botania is not constructed for number-crunching and min-maxing)."
-				""
-				"The Mana Pool stores 1,000,000 Mana."
-			]
-			hide_dependency_lines: true
-			dependencies: ["793DCC312DFF0198"]
-			id: "45AC772575502EB6"
 			tasks: [{
 				id: "2AEB1FA3E37A8C54"
 				type: "item"
 				item: "botania:mana_pool"
 			}]
+			description: [
+				"Sometimes, Mana will be related to in numbers in quests. (Botania is not constructed for number-crunching and min-maxing)."
+				""
+				"The Mana Pool stores 1,000,000 Mana."
+			]
+			id: "45AC772575502EB6"
+			x: 11.0d
+			y: -3.5d
 			rewards: [{
 				id: "7FECE90E5F1D4444"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Basic Mana Storage, easy to use for mana infusing."
+			dependencies: ["793DCC312DFF0198"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 9.0d
-			y: -1.0d
-			subtitle: "Portable, magical Worktable."
+			tasks: [{
+				id: "0F8655C28058E4CD"
+				type: "item"
+				item: "botania:crafting_halo"
+			}]
 			description: [
 				"It is a portable Crafting Table, that can also remember 11 different recipes."
 				""
@@ -1606,72 +1609,70 @@
 				""
 				"You can then Right-Click the memorized recipe to craft it without opening the crafting GUI."
 			]
-			dependencies: [
-				"01200B72145FDADD"
-				"7129CFCFCC75AAFC"
-			]
 			id: "4BB6AB7809B102B9"
-			tasks: [{
-				id: "0F8655C28058E4CD"
-				type: "item"
-				item: "botania:crafting_halo"
-			}]
+			x: 9.0d
+			y: -1.0d
 			rewards: [{
 				id: "628F5FC335D32437"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Portable, magical Worktable."
+			dependencies: [
+				"01200B72145FDADD"
+				"7129CFCFCC75AAFC"
+			]
 		}
 		{
-			x: 14.0d
-			y: 8.0d
-			hide_dependency_lines: true
-			dependencies: ["01200B72145FDADD"]
-			id: "2EEB7BBE8DFA13DB"
 			tasks: [{
 				id: "389469E828006E4A"
 				type: "item"
 				item: "botania:aura_ring"
 			}]
+			id: "2EEB7BBE8DFA13DB"
+			x: 14.0d
+			y: 8.0d
 			rewards: [{
 				id: "36F89598569BA9C6"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["01200B72145FDADD"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 16.0d
-			y: 8.0d
-			hide_dependency_lines: true
-			dependencies: [
-				"01200B72145FDADD"
-				"29BBD83472699DA4"
-			]
-			id: "5AA730044BE9D730"
 			tasks: [{
 				id: "1AA7220F7E2519A1"
 				type: "item"
 				item: "botania:mana_ring"
 			}]
+			id: "5AA730044BE9D730"
+			x: 16.0d
+			y: 8.0d
 			rewards: [{
 				id: "4E7ECFEB0E24244A"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: [
+				"01200B72145FDADD"
+				"29BBD83472699DA4"
+			]
+			hide_dependency_lines: true
 		}
 		{
-			x: 11.0d
-			y: -1.0d
-			dependencies: ["7129CFCFCC75AAFC"]
-			id: "29BBD83472699DA4"
 			tasks: [{
 				id: "2BBEA41959561DDC"
 				type: "item"
 				item: "botania:mana_tablet"
 			}]
+			dependencies: ["7129CFCFCC75AAFC"]
+			id: "29BBD83472699DA4"
+			y: -1.0d
+			x: 11.0d
 			rewards: [{
 				id: "1EDC894DE5674730"
 				type: "random"
@@ -1680,37 +1681,37 @@
 			}]
 		}
 		{
-			x: 13.0d
-			y: -1.0d
-			description: [
-				"Obtaining Runes is essential to continue in Botania."
-				"Adding the ingredient items and some mana, will fuse it into new items."
-				"To finalize the process, place a living rock on the altar and right click with you Wand."
-			]
-			dependencies: ["641E7D71ACC0F28B"]
-			id: "278D27920CB07C59"
 			tasks: [{
 				id: "7F09BE20C379E9DC"
 				type: "item"
 				item: "botania:runic_altar"
 			}]
+			description: [
+				"Obtaining Runes is essential to continue in Botania."
+				"Adding the ingredient items and some mana, will fuse it into new items."
+				"To finalize the process, place a living rock on the altar and right click with you Wand."
+			]
+			id: "278D27920CB07C59"
+			x: 13.0d
+			y: -1.0d
 			rewards: [{
 				id: "1AE997B3E54928E1"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["641E7D71ACC0F28B"]
 		}
 		{
-			x: 12.0d
-			y: -1.0d
-			dependencies: ["5A76DF911EFC76EE"]
-			id: "0FEC116243374677"
 			tasks: [{
 				id: "06B757DA5D3849DC"
 				type: "item"
 				item: "botania:animated_torch"
 			}]
+			dependencies: ["5A76DF911EFC76EE"]
+			id: "0FEC116243374677"
+			y: -1.0d
+			x: 12.0d
 			rewards: [{
 				id: "21899F71390BCD84"
 				type: "random"
@@ -1719,45 +1720,27 @@
 			}]
 		}
 		{
-			x: 6.0d
-			y: 3.0d
-			description: [
-				"You can use this pylons near your enchanting table and it will act like Bookshelves."
-				"Two are enough to have a level 30 Enchantment Table."
-			]
-			dependencies: ["52250F3E2FB2AE6F"]
-			id: "52EFBE28E4AD5797"
 			tasks: [{
 				id: "2E495E3EFB192769"
 				type: "item"
 				item: "botania:mana_pylon"
 			}]
+			description: [
+				"You can use this pylons near your enchanting table and it will act like Bookshelves."
+				"Two are enough to have a level 30 Enchantment Table."
+			]
+			id: "52EFBE28E4AD5797"
+			x: 6.0d
+			y: 3.0d
 			rewards: [{
 				id: "2611EE0DBF8D78F7"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["52250F3E2FB2AE6F"]
 		}
 		{
-			title: "Manaweave Armor"
-			x: 15.0d
-			y: -1.0d
-			subtitle: "Doesn't do well in defense, but is very powerful in magic."
-			description: [
-				"Wearing a full set of Manaweave Armor grants:"
-				""
-				"> 35% Mana discount on all tools and Rods,"
-				"> Increased range on Bifrost, Plentiful Mantle, Shifting Crust, and Terra Firma rods,"
-				"> Increased height of the Rod of the Skies,"
-				"> Increased time before the bridge created by the Rod of the Bifrost decays,"
-				"> Increased smelting speed of the Rod of the Molten Core,"
-				"> Increased item pulling speed of the Rod of the Shaded Mesa,"
-				"> Doubled fire rate of the Rod of the Unstable Reservoir,"
-				"> Decreased cooldown on the Rod of the Hells."
-			]
-			dependencies: ["375F904F1F7C628D"]
-			id: "5943C8B3EF469F17"
 			tasks: [
 				{
 					id: "29BF7FC0F9BD2DC4"
@@ -1808,40 +1791,52 @@
 					}
 				}
 			]
+			description: [
+				"Wearing a full set of Manaweave Armor grants:"
+				""
+				"> 35% Mana discount on all tools and Rods,"
+				"> Increased range on Bifrost, Plentiful Mantle, Shifting Crust, and Terra Firma rods,"
+				"> Increased height of the Rod of the Skies,"
+				"> Increased time before the bridge created by the Rod of the Bifrost decays,"
+				"> Increased smelting speed of the Rod of the Molten Core,"
+				"> Increased item pulling speed of the Rod of the Shaded Mesa,"
+				"> Doubled fire rate of the Rod of the Unstable Reservoir,"
+				"> Decreased cooldown on the Rod of the Hells."
+			]
+			id: "5943C8B3EF469F17"
+			x: 15.0d
+			y: -1.0d
+			title: "Manaweave Armor"
 			rewards: [{
 				id: "6D3824DBD3617E28"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Doesn't do well in defense, but is very powerful in magic."
+			dependencies: ["375F904F1F7C628D"]
 		}
 		{
-			title: "Make a Mana Enchanter"
-			x: 14.0d
-			y: -2.5d
-			description: ["Take a look into the Lexica Botania to figure out how to build this magical enchanting shrine."]
-			dependencies: ["45AC772575502EB6"]
-			id: "54517F82F4BBEDB5"
 			tasks: [{
 				id: "3D00B10632B642F5"
 				type: "advancement"
 				advancement: "botania:main/enchanter_make"
 				criterion: ""
 			}]
+			description: ["Take a look into the Lexica Botania to figure out how to build this magical enchanting shrine."]
+			id: "54517F82F4BBEDB5"
+			x: 14.0d
+			y: -2.5d
+			title: "Make a Mana Enchanter"
 			rewards: [{
 				id: "75B484891F776208"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["45AC772575502EB6"]
 		}
 		{
-			title: "Manasteel Gear"
-			x: 9.0d
-			y: -3.5d
-			subtitle: "Check out the \"Tools and Armor\" tab for more info."
-			dependencies: ["01200B72145FDADD"]
-			id: "2AF513D68BE988F3"
 			tasks: [
 				{
 					id: "482EF4320920B504"
@@ -1954,21 +1949,20 @@
 					}
 				}
 			]
+			id: "2AF513D68BE988F3"
+			x: 9.0d
+			y: -3.5d
+			title: "Manasteel Gear"
 			rewards: [{
 				id: "4D7B51528423853E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Check out the \"Tools and Armor\" tab for more info."
+			dependencies: ["01200B72145FDADD"]
 		}
 		{
-			title: "Terrasteel Gear"
-			x: 8.0d
-			y: 3.0d
-			subtitle: "Check out the \"Tools and Armor\" tab for more info."
-			description: ["Terrasteel Equipment has special abilities, feel free to try it out."]
-			dependencies: ["44DF71B4C8D2B61A"]
-			id: "1F640301A7DFAF61"
 			tasks: [
 				{
 					id: "428C6144BC0F73CC"
@@ -2037,19 +2031,21 @@
 					}
 				}
 			]
+			description: ["Terrasteel Equipment has special abilities, feel free to try it out."]
+			id: "1F640301A7DFAF61"
+			x: 8.0d
+			y: 3.0d
+			title: "Terrasteel Gear"
 			rewards: [{
 				id: "79E07621EDB0B112"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Check out the \"Tools and Armor\" tab for more info."
+			dependencies: ["44DF71B4C8D2B61A"]
 		}
 		{
-			x: 3.5d
-			y: -3.5d
-			description: ["You will need this tool in many situations when playing with Botania. It allows you to connect various blocks or change their function."]
-			dependencies: ["6A1CC424788CAC34"]
-			id: "22B2C00FB3706A6F"
 			tasks: [{
 				id: "4329EC960DEF3600"
 				type: "item"
@@ -2062,24 +2058,19 @@
 					}
 				}
 			}]
+			description: ["You will need this tool in many situations when playing with Botania. It allows you to connect various blocks or change their function."]
+			id: "22B2C00FB3706A6F"
+			x: 3.5d
+			y: -3.5d
 			rewards: [{
 				id: "129219E0C6B85ABA"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["6A1CC424788CAC34"]
 		}
 		{
-			x: 6.0d
-			y: 4.0d
-			description: [
-				"Nature Pylons are required to open the Elven Portal."
-				"Place two of them on top of Mana Pools near your portal frame."
-				""
-				"You need at least 0.2 Mana Pools worth of Mana across your Pools to open the portal."
-			]
-			dependencies: ["52EFBE28E4AD5797"]
-			id: "486A51B5EAECBF17"
 			tasks: [{
 				id: "26AFEB45A912AA44"
 				type: "item"
@@ -2089,36 +2080,42 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Nature Pylons are required to open the Elven Portal."
+				"Place two of them on top of Mana Pools near your portal frame."
+				""
+				"You need at least 0.2 Mana Pools worth of Mana across your Pools to open the portal."
+			]
+			id: "486A51B5EAECBF17"
+			x: 6.0d
+			y: 4.0d
 			rewards: [{
 				id: "3968A588C2BCA5C5"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["52EFBE28E4AD5797"]
 		}
 		{
-			x: 16.5d
-			y: 3.0d
-			hide_dependency_lines: true
-			dependencies: ["0A7B6621E69A8F30"]
-			id: "38BC867C7A861B7B"
 			tasks: [{
 				id: "08311AEF83BFDACE"
 				type: "item"
 				item: "botania:brewery"
 			}]
+			id: "38BC867C7A861B7B"
+			x: 16.5d
+			y: 3.0d
 			rewards: [{
 				id: "057CD550AB6C276F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["0A7B6621E69A8F30"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 18.0d
-			y: 3.0d
-			dependencies: ["38BC867C7A861B7B"]
-			id: "489EB5C64AC87B6F"
 			tasks: [{
 				id: "3DA68957389BFC6C"
 				type: "item"
@@ -2130,6 +2127,10 @@
 					}
 				}
 			}]
+			dependencies: ["38BC867C7A861B7B"]
+			id: "489EB5C64AC87B6F"
+			y: 3.0d
+			x: 18.0d
 			rewards: [{
 				id: "4D0374F9CB521DAE"
 				type: "random"
@@ -2138,10 +2139,6 @@
 			}]
 		}
 		{
-			x: 18.0d
-			y: 2.0d
-			dependencies: ["38BC867C7A861B7B"]
-			id: "33C400A55CD8BE27"
 			tasks: [{
 				id: "6AE450FC306E791A"
 				type: "item"
@@ -2153,6 +2150,10 @@
 					}
 				}
 			}]
+			dependencies: ["38BC867C7A861B7B"]
+			id: "33C400A55CD8BE27"
+			y: 2.0d
+			x: 18.0d
 			rewards: [{
 				id: "1A08F59BF6F8A01A"
 				type: "random"
@@ -2161,10 +2162,6 @@
 			}]
 		}
 		{
-			x: 18.0d
-			y: 1.0d
-			dependencies: ["38BC867C7A861B7B"]
-			id: "08EE811FCECCDCCD"
 			tasks: [{
 				id: "3BBDEC1B96D91A3A"
 				type: "item"
@@ -2176,6 +2173,10 @@
 					}
 				}
 			}]
+			dependencies: ["38BC867C7A861B7B"]
+			id: "08EE811FCECCDCCD"
+			y: 1.0d
+			x: 18.0d
 			rewards: [{
 				id: "107B61C581A2936F"
 				type: "random"
@@ -2184,10 +2185,6 @@
 			}]
 		}
 		{
-			x: 18.0d
-			y: 4.0d
-			dependencies: ["38BC867C7A861B7B"]
-			id: "158410AC5894F49E"
 			tasks: [{
 				id: "7E2383D7A3E352A4"
 				type: "item"
@@ -2199,6 +2196,10 @@
 					}
 				}
 			}]
+			dependencies: ["38BC867C7A861B7B"]
+			id: "158410AC5894F49E"
+			y: 4.0d
+			x: 18.0d
 			rewards: [{
 				id: "5208F099CBA95055"
 				type: "random"
@@ -2207,10 +2208,6 @@
 			}]
 		}
 		{
-			x: 18.0d
-			y: 5.0d
-			dependencies: ["38BC867C7A861B7B"]
-			id: "176D9E7471E82642"
 			tasks: [{
 				id: "4D5B9E0E4C2C1E35"
 				type: "item"
@@ -2222,6 +2219,10 @@
 					}
 				}
 			}]
+			dependencies: ["38BC867C7A861B7B"]
+			id: "176D9E7471E82642"
+			y: 5.0d
+			x: 18.0d
 			rewards: [{
 				id: "25DD88E6CDC5D3D3"
 				type: "random"
@@ -2230,11 +2231,6 @@
 			}]
 		}
 		{
-			x: 19.0d
-			y: 5.0d
-			hide_dependency_lines: true
-			dependencies: ["38BC867C7A861B7B"]
-			id: "22C7B66675783937"
 			tasks: [{
 				id: "75E96AEB970BAB8C"
 				type: "item"
@@ -2246,19 +2242,19 @@
 					}
 				}
 			}]
+			id: "22C7B66675783937"
+			x: 19.0d
+			y: 5.0d
 			rewards: [{
 				id: "776628215178ED4D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["38BC867C7A861B7B"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 19.0d
-			y: 4.0d
-			hide_dependency_lines: true
-			dependencies: ["38BC867C7A861B7B"]
-			id: "147900ED2204A8BF"
 			tasks: [{
 				id: "28403C22A4EE0C96"
 				type: "item"
@@ -2270,19 +2266,19 @@
 					}
 				}
 			}]
+			id: "147900ED2204A8BF"
+			x: 19.0d
+			y: 4.0d
 			rewards: [{
 				id: "2AD5428D3E18B285"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["38BC867C7A861B7B"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 19.0d
-			y: 3.0d
-			hide_dependency_lines: true
-			dependencies: ["38BC867C7A861B7B"]
-			id: "519F9149EA59123D"
 			tasks: [{
 				id: "4DB302925BC2C635"
 				type: "item"
@@ -2294,19 +2290,19 @@
 					}
 				}
 			}]
+			id: "519F9149EA59123D"
+			x: 19.0d
+			y: 3.0d
 			rewards: [{
 				id: "1C7D451F245603DF"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["38BC867C7A861B7B"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 19.0d
-			y: 2.0d
-			hide_dependency_lines: true
-			dependencies: ["38BC867C7A861B7B"]
-			id: "78CB20F0D70010E6"
 			tasks: [{
 				id: "79255BA258C0B5E0"
 				type: "item"
@@ -2318,19 +2314,19 @@
 					}
 				}
 			}]
+			id: "78CB20F0D70010E6"
+			x: 19.0d
+			y: 2.0d
 			rewards: [{
 				id: "1A2529E23CD29B8F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["38BC867C7A861B7B"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 19.0d
-			y: 1.0d
-			hide_dependency_lines: true
-			dependencies: ["38BC867C7A861B7B"]
-			id: "4F246AEE8153CEE8"
 			tasks: [{
 				id: "44DAE01F9437FB49"
 				type: "item"
@@ -2342,19 +2338,19 @@
 					}
 				}
 			}]
+			id: "4F246AEE8153CEE8"
+			x: 19.0d
+			y: 1.0d
 			rewards: [{
 				id: "68B4113D22A644B1"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["38BC867C7A861B7B"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 20.0d
-			y: 1.0d
-			hide_dependency_lines: true
-			dependencies: ["38BC867C7A861B7B"]
-			id: "0878C54E93AABBB2"
 			tasks: [{
 				id: "0CBE905C0AC84784"
 				type: "item"
@@ -2366,19 +2362,19 @@
 					}
 				}
 			}]
+			id: "0878C54E93AABBB2"
+			x: 20.0d
+			y: 1.0d
 			rewards: [{
 				id: "2BB09ED5DA109B70"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["38BC867C7A861B7B"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 20.0d
-			y: 2.0d
-			hide_dependency_lines: true
-			dependencies: ["38BC867C7A861B7B"]
-			id: "46A021FFE34AFB8E"
 			tasks: [{
 				id: "139B7E714DEB4B7F"
 				type: "item"
@@ -2390,19 +2386,19 @@
 					}
 				}
 			}]
+			id: "46A021FFE34AFB8E"
+			x: 20.0d
+			y: 2.0d
 			rewards: [{
 				id: "677DD7864D624D7C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["38BC867C7A861B7B"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 20.0d
-			y: 3.0d
-			hide_dependency_lines: true
-			dependencies: ["38BC867C7A861B7B"]
-			id: "1968DA8521B79855"
 			tasks: [{
 				id: "0653AD10EC9CBE26"
 				type: "item"
@@ -2414,19 +2410,19 @@
 					}
 				}
 			}]
+			id: "1968DA8521B79855"
+			x: 20.0d
+			y: 3.0d
 			rewards: [{
 				id: "7996FBAA76DE846C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["38BC867C7A861B7B"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 20.0d
-			y: 4.0d
-			hide_dependency_lines: true
-			dependencies: ["38BC867C7A861B7B"]
-			id: "7395B9A226A64B82"
 			tasks: [{
 				id: "4003AA14126D51B7"
 				type: "item"
@@ -2438,19 +2434,19 @@
 					}
 				}
 			}]
+			id: "7395B9A226A64B82"
+			x: 20.0d
+			y: 4.0d
 			rewards: [{
 				id: "6FB74DAA97EEB96E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["38BC867C7A861B7B"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 20.0d
-			y: 5.0d
-			hide_dependency_lines: true
-			dependencies: ["38BC867C7A861B7B"]
-			id: "672503C5F2724C3D"
 			tasks: [{
 				id: "1A35715187DD0985"
 				type: "item"
@@ -2462,48 +2458,53 @@
 					}
 				}
 			}]
+			id: "672503C5F2724C3D"
+			x: 20.0d
+			y: 5.0d
 			rewards: [{
 				id: "2BF4B869885084FF"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["38BC867C7A861B7B"]
+			hide_dependency_lines: true
 		}
 		{
-			title: "Open the Alfheim Portal"
-			x: 5.0d
-			y: 4.0d
-			description: [
-				"Right click the Core with your Wand of the forest to open the Portal."
-				"Make sure to have enough Mana in your pools, the activation process will take a lot mana."
-			]
-			dependencies: ["486A51B5EAECBF17"]
-			id: "49D0F5D9196D9E2A"
 			tasks: [{
 				id: "270F36D3E74E74C5"
 				type: "advancement"
 				advancement: "botania:main/elf_portal_open"
 				criterion: ""
 			}]
+			description: [
+				"Right click the Core with your Wand of the forest to open the Portal."
+				"Make sure to have enough Mana in your pools, the activation process will take a lot mana."
+			]
+			id: "49D0F5D9196D9E2A"
+			x: 5.0d
+			y: 4.0d
+			title: "Open the Alfheim Portal"
 			rewards: [{
 				id: "7DDB9BB1A5B83F33"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["486A51B5EAECBF17"]
 		}
 		{
-			x: 2.0d
-			y: 5.0d
-			dependencies: ["6B0E85AA7CDEF191"]
-			id: "4F5A513E14904BDA"
 			tasks: [{
-				id: "2DD7A2D965330759"
 				type: "kill"
+				value: 1L
+				id: "2DD7A2D965330759"
 				icon: "botania:gaia_head"
 				entity: "botania:doppleganger"
-				value: 1L
 			}]
+			dependencies: ["6B0E85AA7CDEF191"]
+			id: "4F5A513E14904BDA"
+			y: 5.0d
+			x: 2.0d
 			rewards: [{
 				id: "52F6B763C27B4933"
 				type: "random"
@@ -2512,37 +2513,27 @@
 			}]
 		}
 		{
-			x: 3.0d
-			y: 5.0d
-			description: [
-				"If you would like to defend the Gaia, you will have to craft 4 of this pylons."
-				"Please check the Lexica Botania to get a visualization and more details on how to summon the Gaia Boss."
-			]
-			dependencies: ["006D707637E3F606"]
-			id: "6B0E85AA7CDEF191"
 			tasks: [{
 				id: "3FCFB77DF9211A92"
 				type: "item"
 				item: "botania:gaia_pylon"
 			}]
+			description: [
+				"If you would like to defend the Gaia, you will have to craft 4 of this pylons."
+				"Please check the Lexica Botania to get a visualization and more details on how to summon the Gaia Boss."
+			]
+			id: "6B0E85AA7CDEF191"
+			x: 3.0d
+			y: 5.0d
 			rewards: [{
 				id: "7A187D2492559BC1"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["006D707637E3F606"]
 		}
 		{
-			x: 2.0d
-			y: 6.0d
-			subtitle: "Allows you to fly."
-			description: [
-				"However, not infinitely - there's a flight bar, upon depleting it you will stop flying."
-				""
-				"You can add wings by crafting the Flugel Tiara with different quartz types."
-			]
-			dependencies: ["4F5A513E14904BDA"]
-			id: "768DB75FDF38BB98"
 			tasks: [{
 				id: "1FFE94D5DA0B4183"
 				type: "item"
@@ -2554,23 +2545,33 @@
 					}
 				}
 			}]
+			description: [
+				"However, not infinitely - there's a flight bar, upon depleting it you will stop flying."
+				""
+				"You can add wings by crafting the Flugel Tiara with different quartz types."
+			]
+			id: "768DB75FDF38BB98"
+			x: 2.0d
+			y: 6.0d
 			rewards: [{
 				id: "06B71FC891303190"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Allows you to fly."
+			dependencies: ["4F5A513E14904BDA"]
 		}
 		{
-			x: 2.0d
-			y: 4.0d
-			dependencies: ["4F5A513E14904BDA"]
-			id: "252BD7F83644F34A"
 			tasks: [{
 				id: "113ADF66181455AB"
 				type: "item"
 				item: "botania:mana_bomb"
 			}]
+			dependencies: ["4F5A513E14904BDA"]
+			id: "252BD7F83644F34A"
+			y: 4.0d
+			x: 2.0d
 			rewards: [{
 				id: "5FED9541D389A020"
 				type: "random"
@@ -2579,18 +2580,18 @@
 			}]
 		}
 		{
-			x: 1.0d
-			y: 5.0d
-			dependencies: [
-				"4F5A513E14904BDA"
-				"57EFC9565DA78FE8"
-			]
-			id: "3603740347DD9051"
 			tasks: [{
 				id: "3F8B87ACBE621908"
 				type: "item"
 				item: "botania:spawner_mover"
 			}]
+			dependencies: [
+				"4F5A513E14904BDA"
+				"57EFC9565DA78FE8"
+			]
+			id: "3603740347DD9051"
+			y: 5.0d
+			x: 1.0d
 			rewards: [{
 				id: "44571518B7BF67AA"
 				type: "random"
@@ -2599,66 +2600,68 @@
 			}]
 		}
 		{
-			x: 0.0d
-			y: 5.0d
-			hide_dependency_lines: true
-			dependencies: ["49D0F5D9196D9E2A"]
-			id: "57EFC9565DA78FE8"
 			tasks: [{
 				id: "1DA0111A4E797787"
 				type: "item"
 				item: "botania:ender_air_bottle"
 			}]
+			id: "57EFC9565DA78FE8"
+			x: 0.0d
+			y: 5.0d
 			rewards: [{
 				id: "3E9D8BCA48BB8371"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["49D0F5D9196D9E2A"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 3.0d
-			y: 3.0d
-			description: [
-				"A kind of teleporters?"
-				"Find out how it works by checking the Lexica Botania."
-			]
-			dependencies: ["4BD4D197F9DC863F"]
-			id: "2E1BF033CA30ECDA"
 			tasks: [{
 				id: "0E376E9C808FB402"
 				type: "item"
 				item: "botania:light_relay"
 			}]
+			description: [
+				"A kind of teleporters?"
+				"Find out how it works by checking the Lexica Botania."
+			]
+			id: "2E1BF033CA30ECDA"
+			x: 3.0d
+			y: 3.0d
 			rewards: [{
 				id: "42AD73CC711253C8"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["4BD4D197F9DC863F"]
 		}
 		{
-			x: 2.0d
-			y: 3.0d
-			description: ["With this device you can transfer items or e.g. animals with you Luminizers."]
-			dependencies: ["2E1BF033CA30ECDA"]
-			id: "29C392416255DF7A"
 			tasks: [{
 				id: "7CBE310562DB0D4E"
 				type: "item"
 				item: "botania:light_launcher"
 			}]
+			description: ["With this device you can transfer items or e.g. animals with you Luminizers."]
+			id: "29C392416255DF7A"
+			x: 2.0d
+			y: 3.0d
 			rewards: [{
 				id: "6A98DD7F25E2E6C9"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["2E1BF033CA30ECDA"]
 		}
 		{
-			x: 2.5d
-			y: -3.5d
-			subtitle: "Mana Transfer!"
+			tasks: [{
+				id: "13DCC4C05E215CC6"
+				type: "item"
+				item: "botania:mana_spreader"
+			}]
 			description: [
 				"Can transfer Mana from one point to another."
 				""
@@ -2682,62 +2685,62 @@
 				""
 				"You can put a Scaffolding onto the Spreader to make its hitbox a full block."
 			]
-			dependencies: ["22B2C00FB3706A6F"]
 			id: "1CE364B83E30A5F9"
-			tasks: [{
-				id: "13DCC4C05E215CC6"
-				type: "item"
-				item: "botania:mana_spreader"
-			}]
+			x: 2.5d
+			y: -3.5d
 			rewards: [{
 				id: "5E45D0ECAC7064B8"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Mana Transfer!"
+			dependencies: ["22B2C00FB3706A6F"]
 		}
 		{
-			x: 1.5d
-			y: -3.5d
-			subtitle: "A Mana Spreader, that only shoots upon a redstone pulse."
-			description: ["The \"burst reached its destination\" rule still applies, though."]
-			dependencies: ["1CE364B83E30A5F9"]
-			id: "6FCE275B8B4666F6"
 			tasks: [{
 				id: "0AD80A460F2296C8"
 				type: "item"
 				item: "botania:redstone_spreader"
 			}]
+			description: ["The \"burst reached its destination\" rule still applies, though."]
+			id: "6FCE275B8B4666F6"
+			x: 1.5d
+			y: -3.5d
 			rewards: [{
 				id: "4302B83EFB491850"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A Mana Spreader, that only shoots upon a redstone pulse."
+			dependencies: ["1CE364B83E30A5F9"]
 		}
 		{
-			x: 0.5d
-			y: -3.5d
-			subtitle: "Faster than a regular Mana Spreader."
-			description: ["After 20 blocks, the burst shot by this spreader will suffer a Mana loss."]
-			dependencies: ["6FCE275B8B4666F6"]
-			id: "41AE0B6A34EE680F"
 			tasks: [{
 				id: "153B7C2DA50049AD"
 				type: "item"
 				item: "botania:elven_spreader"
 			}]
+			description: ["After 20 blocks, the burst shot by this spreader will suffer a Mana loss."]
+			id: "41AE0B6A34EE680F"
+			x: 0.5d
+			y: -3.5d
 			rewards: [{
 				id: "26AE0C5445202411"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Faster than a regular Mana Spreader."
+			dependencies: ["6FCE275B8B4666F6"]
 		}
 		{
-			x: -0.5d
-			y: -3.5d
-			subtitle: "The fastest Mana Spreader available."
+			tasks: [{
+				id: "097EF12E52DEB6E5"
+				type: "item"
+				item: "botania:gaia_spreader"
+			}]
 			description: [
 				"After 48 blocks, the burst shot by this spreader will suffer a Mana loss."
 				""
@@ -2745,103 +2748,91 @@
 				""
 				"Still not fast enough? Apply a Potency-Velocity Compound Mana Lens!"
 			]
-			dependencies: ["41AE0B6A34EE680F"]
 			id: "24598EAB4F2A89E0"
-			tasks: [{
-				id: "097EF12E52DEB6E5"
-				type: "item"
-				item: "botania:gaia_spreader"
-			}]
+			x: -0.5d
+			y: -3.5d
 			rewards: [{
 				id: "22A0A366FC44DC92"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The fastest Mana Spreader available."
+			dependencies: ["41AE0B6A34EE680F"]
 		}
 		{
-			x: 4.0d
-			y: 5.0d
-			description: ["Simply throw a Manasteel Ingot through the portal to get this upgraded variant back."]
-			dependencies: ["49D0F5D9196D9E2A"]
-			id: "006D707637E3F606"
 			tasks: [{
 				id: "05697A894CC9C263"
 				type: "item"
 				item: "botania:elementium_ingot"
 			}]
+			description: ["Simply throw a Manasteel Ingot through the portal to get this upgraded variant back."]
+			id: "006D707637E3F606"
+			x: 4.0d
+			y: 5.0d
 			rewards: [{
 				id: "72962AE9D315A558"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["49D0F5D9196D9E2A"]
 		}
 		{
-			x: 4.0d
-			y: 3.0d
-			description: ["Simply throw a Livingwood Log through the portal to get this upgraded variant back."]
-			dependencies: ["49D0F5D9196D9E2A"]
-			id: "4BD4D197F9DC863F"
 			tasks: [{
 				id: "4EE0CA39D7110BC9"
 				type: "item"
 				item: "botania:dreamwood_log"
 			}]
+			description: ["Simply throw a Livingwood Log through the portal to get this upgraded variant back."]
+			id: "4BD4D197F9DC863F"
+			x: 4.0d
+			y: 3.0d
 			rewards: [{
 				id: "6678051D11EA430F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["49D0F5D9196D9E2A"]
 		}
 		{
-			x: 5.0d
-			y: 5.0d
-			description: ["Simply throw a Mana Diamond through the portal to get this upgraded variant back."]
-			dependencies: ["49D0F5D9196D9E2A"]
-			id: "14D1B573F4741CBE"
 			tasks: [{
 				id: "7531FA5DA0BC8F85"
 				type: "item"
 				item: "botania:dragonstone"
 			}]
+			description: ["Simply throw a Mana Diamond through the portal to get this upgraded variant back."]
+			id: "14D1B573F4741CBE"
+			x: 5.0d
+			y: 5.0d
 			rewards: [{
 				id: "4B6707E69ADB4626"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["49D0F5D9196D9E2A"]
 		}
 		{
-			x: 4.0d
-			y: 4.0d
-			description: ["Simply throw a Mana Pearl through the portal to get this upgraded variant back."]
-			dependencies: ["49D0F5D9196D9E2A"]
-			id: "4714CF6728EF8D9B"
 			tasks: [{
 				id: "3BB86645F1B70973"
 				type: "item"
 				item: "botania:pixie_dust"
 			}]
+			description: ["Simply throw a Mana Pearl through the portal to get this upgraded variant back."]
+			id: "4714CF6728EF8D9B"
+			x: 4.0d
+			y: 4.0d
 			rewards: [{
 				id: "145801C37DF2C232"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["49D0F5D9196D9E2A"]
 		}
 		{
-			title: "Elementium Gear"
-			x: 4.0d
-			y: 6.0d
-			description: [
-				"With Elementium you now have access to a new set of tools and armor, but is it better than the Terrasteel Set?"
-				""
-				"Check it out in the \"Tools and Armor\" tab!"
-			]
-			dependencies: ["006D707637E3F606"]
-			id: "2AFF3A18E9A02A42"
 			tasks: [
 				{
 					id: "18632F439A7C3010"
@@ -2966,16 +2957,29 @@
 					}
 				}
 			]
+			description: [
+				"With Elementium you now have access to a new set of tools and armor, but is it better than the Terrasteel Set?"
+				""
+				"Check it out in the \"Tools and Armor\" tab!"
+			]
+			id: "2AFF3A18E9A02A42"
+			x: 4.0d
+			y: 6.0d
+			title: "Elementium Gear"
 			rewards: [{
 				id: "21F945843DB4F6FD"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["006D707637E3F606"]
 		}
 		{
-			x: 4.5d
-			y: -5.5d
+			tasks: [{
+				id: "02225091E1C7C825"
+				type: "item"
+				item: "botania:spark"
+			}]
 			description: [
 				"Sparks are powerful way to transport Mana, mainly between Pools."
 				""
@@ -2985,66 +2989,65 @@
 				""
 				"You can later add Spark Augments to control the mana flow."
 			]
-			dependencies: ["6A1CC424788CAC34"]
 			id: "5C05E71686140C61"
-			tasks: [{
-				id: "02225091E1C7C825"
-				type: "item"
-				item: "botania:spark"
-			}]
+			x: 4.5d
+			y: -5.5d
 			rewards: [{
 				id: "70827AE21B952000"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["6A1CC424788CAC34"]
 		}
 		{
-			x: 3.0d
-			y: 7.0d
-			subtitle: "When powered by Redstone, it swaps Spark Augments between the Spark and itself."
-			description: ["Useful for two-way Mana Batteries!"]
-			dependencies: ["427099DD01253700"]
-			id: "4F1519138246C47C"
 			tasks: [{
 				id: "735D7905C30990DD"
 				type: "item"
 				item: "botania:spark_changer"
 			}]
+			description: ["Useful for two-way Mana Batteries!"]
+			id: "4F1519138246C47C"
+			x: 3.0d
+			y: 7.0d
 			rewards: [{
 				id: "4EA5EC6DA8E7553C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "When powered by Redstone, it swaps Spark Augments between the Spark and itself."
+			dependencies: ["427099DD01253700"]
 		}
 		{
-			x: 4.5d
-			y: -6.5d
-			subtitle: "ME Network, magical version."
-			description: [
-				"Put them on inventories to connect them to Corporea Network."
-				""
-				"Like regular Sparks, you can dye them to separate different Corporea Networks."
-			]
-			dependencies: ["5C05E71686140C61"]
-			id: "1F8DC917E3C860B4"
 			tasks: [{
 				id: "6EF9753240967770"
 				type: "item"
 				item: "botania:corporea_spark"
 			}]
+			description: [
+				"Put them on inventories to connect them to Corporea Network."
+				""
+				"Like regular Sparks, you can dye them to separate different Corporea Networks."
+			]
+			id: "1F8DC917E3C860B4"
+			x: 4.5d
+			y: -6.5d
 			rewards: [{
 				id: "5B957E69A53DFD7A"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "ME Network, magical version."
+			dependencies: ["5C05E71686140C61"]
 		}
 		{
-			x: 4.5d
-			y: -7.5d
-			subtitle: "The Brain of Corporea Network."
+			tasks: [{
+				id: "012467B2DACF1F50"
+				type: "item"
+				item: "botania:corporea_spark_master"
+			}]
 			description: [
 				"Each Corporea Network needs one of these as a controller."
 				""
@@ -3052,66 +3055,66 @@
 				""
 				"Because of this, placing this on a Corporea Index would be your best bet."
 			]
-			dependencies: ["1F8DC917E3C860B4"]
 			id: "223B017578ED4A5E"
-			tasks: [{
-				id: "012467B2DACF1F50"
-				type: "item"
-				item: "botania:corporea_spark_master"
-			}]
+			x: 4.5d
+			y: -7.5d
 			rewards: [{
 				id: "6CC84256B3F546D4"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The Brain of Corporea Network."
+			dependencies: ["1F8DC917E3C860B4"]
 		}
 		{
-			x: 3.0d
-			y: 4.0d
-			subtitle: "Creates a starry sky at night."
-			description: ["You might find a decorative use for this device."]
-			dependencies: ["006D707637E3F606"]
-			id: "187B054D0DC85DE3"
 			tasks: [{
 				id: "24ABCA3520EC28F4"
 				type: "item"
 				item: "botania:starfield"
 			}]
+			description: ["You might find a decorative use for this device."]
+			id: "187B054D0DC85DE3"
+			x: 3.0d
+			y: 4.0d
 			rewards: [{
 				id: "4B18D18392CAEA79"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Creates a starry sky at night."
+			dependencies: ["006D707637E3F606"]
 		}
 		{
-			x: 3.5d
-			y: -6.5d
-			subtitle: "Corporea Decor."
-			description: [
-				"Used for decoration."
-				""
-				"You can also attach Corporea Sparks on them for lag-friendly Corporea Network extension."
-			]
-			dependencies: ["1F8DC917E3C860B4"]
-			id: "3307FC8385E2C531"
 			tasks: [{
 				id: "56749162671DE356"
 				type: "item"
 				item: "botania:corporea_block"
 			}]
+			description: [
+				"Used for decoration."
+				""
+				"You can also attach Corporea Sparks on them for lag-friendly Corporea Network extension."
+			]
+			id: "3307FC8385E2C531"
+			x: 3.5d
+			y: -6.5d
 			rewards: [{
 				id: "4495D4E04A68A8C9"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Corporea Decor."
+			dependencies: ["1F8DC917E3C860B4"]
 		}
 		{
-			x: 3.5d
-			y: -5.5d
-			subtitle: "Trying to restock..."
+			tasks: [{
+				id: "634124C50462628E"
+				type: "item"
+				item: "botania:corporea_retainer"
+			}]
 			description: [
 				"Place this adjacent to a Corporea Interceptor."
 				""
@@ -3122,24 +3125,24 @@
 				"A Redstone Comparator can read out the number of items that were originally requested."
 				"You can change this behavior using the Wand of the Forest to read out the amount of missing items."
 			]
-			dependencies: ["1F8DC917E3C860B4"]
 			id: "013D73DB5C77DEAA"
-			tasks: [{
-				id: "634124C50462628E"
-				type: "item"
-				item: "botania:corporea_retainer"
-			}]
+			x: 3.5d
+			y: -5.5d
 			rewards: [{
 				id: "26DCADC2B3F3AC3D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Trying to restock..."
+			dependencies: ["1F8DC917E3C860B4"]
 		}
 		{
-			x: 3.5d
-			y: -7.5d
-			subtitle: "Warning: Item out of stock."
+			tasks: [{
+				id: "5C3175A43F569B6C"
+				type: "item"
+				item: "botania:corporea_interceptor"
+			}]
 			description: [
 				"Place Item Frames on it to filter requests."
 				""
@@ -3147,24 +3150,24 @@
 				""
 				"You can then use the Redstone Pulse to your heart's contents: ex. trigger your auto-crafter, light up a lamp, etc."
 			]
-			dependencies: ["1F8DC917E3C860B4"]
 			id: "22D41FA56CD242A1"
-			tasks: [{
-				id: "5C3175A43F569B6C"
-				type: "item"
-				item: "botania:corporea_interceptor"
-			}]
+			x: 3.5d
+			y: -7.5d
 			rewards: [{
 				id: "23EE8F434D8698DF"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Warning: Item out of stock."
+			dependencies: ["1F8DC917E3C860B4"]
 		}
 		{
-			x: 5.5d
-			y: -5.5d
-			subtitle: "A magical Export Bus."
+			tasks: [{
+				id: "6749F22578952FC8"
+				type: "item"
+				item: "botania:corporea_funnel"
+			}]
 			description: [
 				"Place the Item Frame on the Corporea Funnel and put the desired item into the Item Frame."
 				""
@@ -3174,24 +3177,24 @@
 				""
 				"If there are multiple Item Frames on the Corporea Funnel, it will request items at random."
 			]
-			dependencies: ["1F8DC917E3C860B4"]
 			id: "2B4703CA4EF9B3F4"
-			tasks: [{
-				id: "6749F22578952FC8"
-				type: "item"
-				item: "botania:corporea_funnel"
-			}]
+			x: 5.5d
+			y: -5.5d
 			rewards: [{
 				id: "68AABDE4E1BD1885"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A magical Export Bus."
+			dependencies: ["1F8DC917E3C860B4"]
 		}
 		{
-			x: 5.5d
-			y: -7.5d
-			subtitle: "A Voice-controlled item terminal."
+			tasks: [{
+				id: "7DEEC88468569615"
+				type: "item"
+				item: "botania:corporea_index"
+			}]
 			description: [
 				"This description is huge, so remember that you can use the Scroll Wheel to scroll the text."
 				""
@@ -3236,25 +3239,25 @@
 				"Ctrl + C will request half a stack."
 				"Ctrl + Shift + C will request a quarter of a stack."
 			]
-			dependencies: ["1F8DC917E3C860B4"]
-			min_width: 300
 			id: "5A07ED60A5C78C87"
-			tasks: [{
-				id: "7DEEC88468569615"
-				type: "item"
-				item: "botania:corporea_index"
-			}]
+			x: 5.5d
+			y: -7.5d
 			rewards: [{
 				id: "0444E7BEA5A37AF4"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			min_width: 300
+			subtitle: "A Voice-controlled item terminal."
+			dependencies: ["1F8DC917E3C860B4"]
 		}
 		{
-			x: 5.5d
-			y: -6.5d
-			subtitle: "A fortuneteller would see a future inside."
+			tasks: [{
+				id: "7E1B38FEF88714A7"
+				type: "item"
+				item: "botania:corporea_crystal_cube"
+			}]
 			description: [
 				"But you can see the present inside."
 				""
@@ -3271,30 +3274,28 @@
 				"Sneak-Right Click with a Wand of the Forest to lock it to that item."
 				"Useful in order to not accidentaly change the item displayed in the cube."
 			]
-			dependencies: ["1F8DC917E3C860B4"]
 			id: "3DA7EDA176FF1819"
-			tasks: [{
-				id: "7E1B38FEF88714A7"
-				type: "item"
-				item: "botania:corporea_crystal_cube"
-			}]
+			x: 5.5d
+			y: -6.5d
 			rewards: [{
 				id: "797CF7C24C7ADE31"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A fortuneteller would see a future inside."
+			dependencies: ["1F8DC917E3C860B4"]
 		}
 		{
-			x: 1.0d
-			y: 6.0d
-			dependencies: ["4F5A513E14904BDA"]
-			id: "6C892E06A15C3774"
 			tasks: [{
 				id: "24723957C8B136B4"
 				type: "item"
 				item: "botania:gaia_ingot"
 			}]
+			dependencies: ["4F5A513E14904BDA"]
+			id: "6C892E06A15C3774"
+			y: 6.0d
+			x: 1.0d
 			rewards: [{
 				id: "097D84B49B83B066"
 				type: "random"
@@ -3303,15 +3304,15 @@
 			}]
 		}
 		{
-			x: 10.0d
-			y: -1.0d
-			dependencies: ["7129CFCFCC75AAFC"]
-			id: "59D87E91D1A823D2"
 			tasks: [{
 				id: "54EEC2EB4F66562D"
 				type: "item"
 				item: "botania:alchemy_catalyst"
 			}]
+			dependencies: ["7129CFCFCC75AAFC"]
+			id: "59D87E91D1A823D2"
+			y: -1.0d
+			x: 10.0d
 			rewards: [{
 				id: "792BEAEBA7302809"
 				type: "random"
@@ -3320,15 +3321,15 @@
 			}]
 		}
 		{
-			x: 5.0d
-			y: 6.0d
-			dependencies: ["006D707637E3F606"]
-			id: "31816946D9E31733"
 			tasks: [{
 				id: "360A72F13680D0BD"
 				type: "item"
 				item: "botania:conjuration_catalyst"
 			}]
+			dependencies: ["006D707637E3F606"]
+			id: "31816946D9E31733"
+			y: 6.0d
+			x: 5.0d
 			rewards: [{
 				id: "6BDD6CB3CF721D1C"
 				type: "random"
@@ -3337,52 +3338,47 @@
 			}]
 		}
 		{
-			x: 11.0d
-			y: -4.5d
-			subtitle: "Mana on rails!"
-			dependencies: ["45AC772575502EB6"]
-			id: "3EC6CBCD308A0830"
 			tasks: [{
 				id: "295150CC59CFCB6B"
 				type: "item"
 				item: "botania:pool_minecart"
 			}]
+			id: "3EC6CBCD308A0830"
+			x: 11.0d
+			y: -4.5d
 			rewards: [{
 				id: "3CDBB2A930CB6C95"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Mana on rails!"
+			dependencies: ["45AC772575502EB6"]
 		}
 		{
-			x: 11.0d
-			y: -5.5d
-			subtitle: "Pumps Mana from or into the Minecart with Mana Pool."
-			description: [
-				"Pumps Mana so quickly, that it can drain/fill the whole pool in just 5 seconds!"
-				""
-				"Warning: It can lose Mana if the target Pool can accept less Mana than the Mana Pump sends."
-			]
-			dependencies: ["3EC6CBCD308A0830"]
-			id: "1CB1AAF1AA5D6CFF"
 			tasks: [{
 				id: "5B1FFFB439FE1CC0"
 				type: "item"
 				item: "botania:pump"
 			}]
+			description: [
+				"Pumps Mana so quickly, that it can drain/fill the whole pool in just 5 seconds!"
+				""
+				"Warning: It can lose Mana if the target Pool can accept less Mana than the Mana Pump sends."
+			]
+			id: "1CB1AAF1AA5D6CFF"
+			x: 11.0d
+			y: -5.5d
 			rewards: [{
 				id: "02BF73B209B821AA"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Pumps Mana from or into the Minecart with Mana Pool."
+			dependencies: ["3EC6CBCD308A0830"]
 		}
 		{
-			x: 9.0d
-			y: 2.0d
-			description: ["You should always carry some mana around with you, e.g. through a mana tablet, so that this tool never breaks. This also applies to various other Botania tools."]
-			dependencies: ["44DF71B4C8D2B61A"]
-			id: "7F4A982FF8F7F124"
 			tasks: [{
 				id: "2311D036C30172F7"
 				type: "item"
@@ -3395,101 +3391,100 @@
 					}
 				}
 			}]
+			description: ["You should always carry some mana around with you, e.g. through a mana tablet, so that this tool never breaks. This also applies to various other Botania tools."]
+			id: "7F4A982FF8F7F124"
+			x: 9.0d
+			y: 2.0d
 			rewards: [{
 				id: "197E935FB3CF7460"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["44DF71B4C8D2B61A"]
 		}
 		{
-			x: 2.5d
-			y: -2.5d
-			description: [
-				"Place a Mana Spreader on top of it to rotate it."
-				"You can change the speed, and stop it with a redstone signal."
-			]
-			dependencies: ["1CE364B83E30A5F9"]
-			id: "718CFFBDA0ABEF28"
 			tasks: [{
 				id: "2854D0DD6E578B7A"
 				type: "item"
 				item: "botania:turntable"
 			}]
+			description: [
+				"Place a Mana Spreader on top of it to rotate it."
+				"You can change the speed, and stop it with a redstone signal."
+			]
+			id: "718CFFBDA0ABEF28"
+			x: 2.5d
+			y: -2.5d
 			rewards: [{
 				id: "4EB1BAD893B07FEE"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["1CE364B83E30A5F9"]
 		}
 		{
-			x: 1.5d
-			y: -4.5d
-			subtitle: "Changes Mana Bursts effects on the fly."
-			description: [
-				"Just equip a lens inside."
-				"More information is available in the Lexica Botania."
-			]
-			dependencies: ["479CCC7995B0C0D4"]
-			id: "01466AA75BC97D89"
 			tasks: [{
 				id: "512136CD2D70F198"
 				type: "item"
 				item: "botania:prism"
 			}]
+			description: [
+				"Just equip a lens inside."
+				"More information is available in the Lexica Botania."
+			]
+			id: "01466AA75BC97D89"
+			x: 1.5d
+			y: -4.5d
 			rewards: [{
 				id: "5AC84DDED15682B6"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Changes Mana Bursts effects on the fly."
+			dependencies: ["479CCC7995B0C0D4"]
 		}
 		{
-			x: 2.5d
-			y: -4.5d
-			subtitle: "Can change Mana Burst's color or behavior."
-			description: ["Check out the Lexica Botania for more info about lenses."]
-			dependencies: ["1CE364B83E30A5F9"]
-			id: "479CCC7995B0C0D4"
 			tasks: [{
 				id: "7D021966984E6630"
 				type: "item"
 				item: "botania:lens_normal"
 			}]
+			description: ["Check out the Lexica Botania for more info about lenses."]
+			id: "479CCC7995B0C0D4"
+			x: 2.5d
+			y: -4.5d
 			rewards: [{
 				id: "6E075ACCC0634FA5"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Can change Mana Burst's color or behavior."
+			dependencies: ["1CE364B83E30A5F9"]
 		}
 		{
-			x: 8.0d
-			y: -2.5d
-			subtitle: "A proof that Botania is a tech mod."
-			description: ["Transforms Mana into Energy, at a 1:1 ratio."]
-			dependencies: ["01200B72145FDADD"]
-			id: "0321A7B6265CEB0C"
 			tasks: [{
 				id: "78FB5433FA79DBAF"
 				type: "item"
 				item: "botania:mana_fluxfield"
 			}]
+			description: ["Transforms Mana into Energy, at a 1:1 ratio."]
+			id: "0321A7B6265CEB0C"
+			x: 8.0d
+			y: -2.5d
 			rewards: [{
 				id: "3EDA83AE008DB029"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A proof that Botania is a tech mod."
+			dependencies: ["01200B72145FDADD"]
 		}
 		{
-			title: "Improved Lexica Botania"
-			x: 5.0d
-			y: 3.0d
-			description: ["Just throw your Lexica Botania through the portal to get the updated variant back. This contains more chapters."]
-			dependencies: ["49D0F5D9196D9E2A"]
-			id: "145F11A416AEAB22"
 			tasks: [{
 				id: "194FD96B0AA1693C"
 				type: "item"
@@ -3501,165 +3496,166 @@
 					}
 				}
 			}]
+			description: ["Just throw your Lexica Botania through the portal to get the updated variant back. This contains more chapters."]
+			id: "145F11A416AEAB22"
+			x: 5.0d
+			y: 3.0d
+			title: "Improved Lexica Botania"
 			rewards: [{
 				id: "5F78C9E6373CD537"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["49D0F5D9196D9E2A"]
 		}
 		{
-			x: 1.5d
-			y: -2.5d
-			description: ["Outputs a redstone signal if a mana burst flows through it."]
-			dependencies: ["718CFFBDA0ABEF28"]
-			id: "5B30CD81857C59F9"
 			tasks: [{
 				id: "2B5E18F2858E1D5D"
 				type: "item"
 				item: "botania:mana_detector"
 			}]
+			description: ["Outputs a redstone signal if a mana burst flows through it."]
+			id: "5B30CD81857C59F9"
+			x: 1.5d
+			y: -2.5d
 			rewards: [{
 				id: "1F447F076AD8E509"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["718CFFBDA0ABEF28"]
 		}
 		{
-			x: 0.5d
-			y: -2.5d
-			subtitle: "Accepts Mana and spreads it equally between 4 Mana Pools connected to it."
-			description: ["Useful for storing more Mana before getting Sparks."]
-			dependencies: ["5B30CD81857C59F9"]
-			id: "2D3ADCD4FACF0124"
 			tasks: [{
 				id: "7617CB419BFB167E"
 				type: "item"
 				item: "botania:mana_distributor"
 			}]
+			description: ["Useful for storing more Mana before getting Sparks."]
+			id: "2D3ADCD4FACF0124"
+			x: 0.5d
+			y: -2.5d
 			rewards: [{
 				id: "2793E3AF6A860743"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Accepts Mana and spreads it equally between 4 Mana Pools connected to it."
+			dependencies: ["5B30CD81857C59F9"]
 		}
 		{
-			x: -0.5d
-			y: -2.5d
-			subtitle: "Voids any Mana given to it."
-			description: ["Not a tile entity - that means you can push it with Pistons!"]
-			dependencies: ["2D3ADCD4FACF0124"]
-			id: "600B2F8628F59093"
 			tasks: [{
 				id: "235E47CD19D99EED"
 				type: "item"
 				item: "botania:mana_void"
 			}]
+			description: ["Not a tile entity - that means you can push it with Pistons!"]
+			id: "600B2F8628F59093"
+			x: -0.5d
+			y: -2.5d
 			rewards: [{
 				id: "49AA1832DCBD5A17"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Voids any Mana given to it."
+			dependencies: ["2D3ADCD4FACF0124"]
 		}
 		{
-			x: 19.0d
-			y: -2.0d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "62AC79636FC81F6C"
 			tasks: [{
 				id: "2511F6869258BCB0"
 				type: "item"
 				item: "botania:dirt_rod"
 			}]
+			id: "62AC79636FC81F6C"
+			x: 19.0d
+			y: -2.0d
 			rewards: [{
 				id: "692E8784C0299F61"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 20.0d
-			y: -2.0d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "734EC0287E5E5B25"
 			tasks: [{
 				id: "210B0BB9B3B31279"
 				type: "item"
 				item: "botania:skydirt_rod"
 			}]
+			id: "734EC0287E5E5B25"
+			x: 20.0d
+			y: -2.0d
 			rewards: [{
 				id: "27092A1C23A0D7BF"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 18.0d
-			y: -2.0d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "330BAA73E6933965"
 			tasks: [{
 				id: "5BD071AB03C7C617"
 				type: "item"
 				item: "botania:terraform_rod"
 			}]
+			id: "330BAA73E6933965"
+			x: 18.0d
+			y: -2.0d
 			rewards: [{
 				id: "1BA9270F126A4A7E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 19.0d
-			y: -3.0d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "6EC8E605BEB14EF3"
 			tasks: [{
 				id: "5960D7931FB552C4"
 				type: "item"
 				item: "botania:cobble_rod"
 			}]
+			id: "6EC8E605BEB14EF3"
+			x: 19.0d
+			y: -3.0d
 			rewards: [{
 				id: "19C0AD2F58E0CE77"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 19.0d
-			y: -1.0d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "06772862A436D231"
 			tasks: [{
 				id: "5B16328A01B0007C"
 				type: "item"
 				item: "botania:water_rod"
 			}]
+			id: "06772862A436D231"
+			x: 19.0d
+			y: -1.0d
 			rewards: [{
 				id: "6BAA581EB6C6120C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 20.0d
-			y: -1.0d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "73F185F69E6B0C66"
 			tasks: [{
 				id: "296F7791D1AD5B4A"
 				type: "item"
@@ -3669,109 +3665,109 @@
 					tag: { }
 				}
 			}]
+			id: "73F185F69E6B0C66"
+			x: 20.0d
+			y: -1.0d
 			rewards: [{
 				id: "5277D92EC5C613F8"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 18.0d
-			y: -1.0d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "0252740820CB59C9"
 			tasks: [{
 				id: "46EA7149C75AA348"
 				type: "item"
 				item: "botania:fire_rod"
 			}]
+			id: "0252740820CB59C9"
+			x: 18.0d
+			y: -1.0d
 			rewards: [{
 				id: "7519787E3429BBF1"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 18.0d
-			y: -3.0d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "099CBB1A1652CD6D"
 			tasks: [{
 				id: "7F493C669DC28CD8"
 				type: "item"
 				item: "botania:divining_rod"
 			}]
+			id: "099CBB1A1652CD6D"
+			x: 18.0d
+			y: -3.0d
 			rewards: [{
 				id: "23765AA700D609FD"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 20.0d
-			y: -3.0d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "49B1A4D8883C6764"
 			tasks: [{
 				id: "219D731E7D4A38B9"
 				type: "item"
 				item: "botania:smelt_rod"
 			}]
+			id: "49B1A4D8883C6764"
+			x: 20.0d
+			y: -3.0d
 			rewards: [{
 				id: "08D721D80D9C59AA"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 21.0d
-			y: -2.0d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "0403AC9E6CDB36B6"
 			tasks: [{
 				id: "4DB40A61BAAFD3E5"
 				type: "item"
 				item: "botania:exchange_rod"
 			}]
+			id: "0403AC9E6CDB36B6"
+			x: 21.0d
+			y: -2.0d
 			rewards: [{
 				id: "1E84FFCBB1F4A70D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 19.0d
-			y: -4.0d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "6DDB5989EC24BB03"
 			tasks: [{
 				id: "144BAA0654F24F51"
 				type: "item"
 				item: "botania:rainbow_rod"
 			}]
+			id: "6DDB5989EC24BB03"
+			x: 19.0d
+			y: -4.0d
 			rewards: [{
 				id: "406A2BC646C487C9"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 17.0d
-			y: -2.0d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "11196E016236444D"
 			tasks: [{
 				id: "4BC1E47F6FFAE0DA"
 				type: "item"
@@ -3786,41 +3782,46 @@
 					}
 				}
 			}]
+			id: "11196E016236444D"
+			x: 17.0d
+			y: -2.0d
 			rewards: [{
 				id: "658E7AFC3B288A0C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 19.0d
-			y: 0.0d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "4792FA38BFC257DB"
 			tasks: [{
 				id: "5D38187C4B4A9208"
 				type: "item"
 				item: "botania:missile_rod"
 			}]
+			id: "4792FA38BFC257DB"
+			x: 19.0d
+			y: 0.0d
 			rewards: [{
 				id: "1EA26F438AA19226"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 1.0d
-			y: 4.0d
-			dependencies: ["4F5A513E14904BDA"]
-			id: "6E32A1DDD61C3268"
 			tasks: [{
 				id: "3B5A88EBB3D6EB0D"
 				type: "item"
 				item: "botania:record_gaia_1"
 			}]
+			dependencies: ["4F5A513E14904BDA"]
+			id: "6E32A1DDD61C3268"
+			y: 4.0d
+			x: 1.0d
 			rewards: [{
 				id: "7540593A7F548BE3"
 				type: "random"
@@ -3829,15 +3830,15 @@
 			}]
 		}
 		{
-			x: 0.0d
-			y: 6.0d
-			dependencies: ["6C892E06A15C3774"]
-			id: "1F6E3BBFDE904444"
 			tasks: [{
 				id: "789D935650F03624"
 				type: "item"
 				item: "botania:record_gaia_2"
 			}]
+			dependencies: ["6C892E06A15C3774"]
+			id: "1F6E3BBFDE904444"
+			y: 6.0d
+			x: 0.0d
 			rewards: [{
 				id: "29EEE774EB91F0BE"
 				type: "random"
@@ -3846,101 +3847,96 @@
 			}]
 		}
 		{
-			x: 15.0d
-			y: 7.0d
-			hide_dependency_lines: true
-			dependencies: ["01200B72145FDADD"]
-			id: "33383FED4493F850"
 			tasks: [{
 				id: "530A7B89B07C42B9"
 				type: "item"
 				item: "botania:mining_ring"
 			}]
+			id: "33383FED4493F850"
+			x: 15.0d
+			y: 7.0d
 			rewards: [{
 				id: "069B022CE8686B01"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["01200B72145FDADD"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 16.0d
-			y: 7.0d
-			hide_dependency_lines: true
-			dependencies: ["01200B72145FDADD"]
-			id: "28AD26E5C7969EDF"
 			tasks: [{
 				id: "3A68D8330CB9EA97"
 				type: "item"
 				item: "botania:dodge_ring"
 			}]
+			id: "28AD26E5C7969EDF"
+			x: 16.0d
+			y: 7.0d
 			rewards: [{
 				id: "2D1610AAC9D0B0F6"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["01200B72145FDADD"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 14.0d
-			y: 7.0d
-			hide_dependency_lines: true
-			dependencies: ["01200B72145FDADD"]
-			id: "3B6B666EC99618E0"
 			tasks: [{
 				id: "2139BDDFE1A26FC5"
 				type: "item"
 				item: "botania:swap_ring"
 			}]
+			id: "3B6B666EC99618E0"
+			x: 14.0d
+			y: 7.0d
 			rewards: [{
 				id: "5C3A8EA3C839ECD2"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["01200B72145FDADD"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 15.0d
-			y: 6.0d
-			hide_dependency_lines: true
-			dependencies: ["01200B72145FDADD"]
-			id: "08DFEC6DD7EECA91"
 			tasks: [{
 				id: "260241C41438DC40"
 				type: "item"
 				item: "botania:water_ring"
 			}]
+			id: "08DFEC6DD7EECA91"
+			x: 15.0d
+			y: 6.0d
 			rewards: [{
 				id: "6884925B0B8051CA"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["01200B72145FDADD"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 15.0d
-			y: 8.0d
-			hide_dependency_lines: true
-			dependencies: ["01200B72145FDADD"]
-			id: "30BB9E0BBC84742B"
 			tasks: [{
 				id: "199B6E697B3AD171"
 				type: "item"
 				item: "botania:magnet_ring"
 			}]
+			id: "30BB9E0BBC84742B"
+			x: 15.0d
+			y: 8.0d
 			rewards: [{
 				id: "7991882319A36E8B"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["01200B72145FDADD"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 14.0d
-			y: 6.0d
-			hide_dependency_lines: true
-			dependencies: ["006D707637E3F606"]
-			id: "684BEB36DEF19655"
 			tasks: [{
 				id: "0194EB7173A3C2EA"
 				type: "item"
@@ -3957,19 +3953,19 @@
 					}
 				}
 			}]
+			id: "684BEB36DEF19655"
+			x: 14.0d
+			y: 6.0d
 			rewards: [{
 				id: "28D2DB90B8F8A35D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["006D707637E3F606"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 16.0d
-			y: 6.0d
-			hide_dependency_lines: true
-			dependencies: ["006D707637E3F606"]
-			id: "61971EA5F25E27ED"
 			tasks: [{
 				id: "1617D84BBDFA815C"
 				type: "item"
@@ -3986,17 +3982,24 @@
 					}
 				}
 			}]
+			id: "61971EA5F25E27ED"
+			x: 16.0d
+			y: 6.0d
 			rewards: [{
 				id: "723CBA5B8B49569E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["006D707637E3F606"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 1.0d
-			y: 7.0d
-			subtitle: "Gives 1 out of 6 Ancient Relics."
+			tasks: [{
+				id: "155F5CC814C7A1DC"
+				type: "item"
+				item: "botania:dice"
+			}]
 			description: [
 				"If you already got one of the Relics, then upon another dice roll you will get 1 out of 5 different Relics, and so on..."
 				""
@@ -4004,88 +4007,89 @@
 				""
 				"If you already rolled all the Relics, don't worry - additional Dice can give you some valuable resources!"
 			]
-			dependencies: ["6C892E06A15C3774"]
 			id: "0261B1AB2F3BF7F3"
-			tasks: [{
-				id: "155F5CC814C7A1DC"
-				type: "item"
-				item: "botania:dice"
-			}]
+			x: 1.0d
+			y: 7.0d
 			rewards: [{
 				id: "3282CD8B987F4F18"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Gives 1 out of 6 Ancient Relics."
+			dependencies: ["6C892E06A15C3774"]
 		}
 		{
-			x: 0.0d
-			y: 8.0d
-			subtitle: "Unlimited food."
-			description: ["You can eat this infinitely, as long as you have Mana."]
-			dependencies: ["0261B1AB2F3BF7F3"]
-			id: "767D778A9A25D73E"
 			tasks: [{
 				id: "129797F8FAFCBE17"
 				type: "item"
 				item: "botania:infinite_fruit"
 				match_nbt: false
 			}]
+			description: ["You can eat this infinitely, as long as you have Mana."]
+			id: "767D778A9A25D73E"
+			x: 0.0d
+			y: 8.0d
 			rewards: [{
 				id: "1E42599B941033FF"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Unlimited food."
+			dependencies: ["0261B1AB2F3BF7F3"]
 		}
 		{
-			x: 1.0d
-			y: 8.0d
-			subtitle: "Is it an anime?"
-			description: ["Will shoot magical keys from behind yourself, that will explode upon impact."]
-			dependencies: ["0261B1AB2F3BF7F3"]
-			id: "340F16084C940F53"
 			tasks: [{
 				id: "2D0C2B7DF6538388"
 				type: "item"
 				item: "botania:king_key"
 				match_nbt: false
 			}]
+			description: ["Will shoot magical keys from behind yourself, that will explode upon impact."]
+			id: "340F16084C940F53"
+			x: 1.0d
+			y: 8.0d
 			rewards: [{
 				id: "7CAD8B5E2883AD2A"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Is it an anime?"
+			dependencies: ["0261B1AB2F3BF7F3"]
 		}
 		{
-			x: 2.0d
-			y: 8.0d
-			subtitle: "A replica of Flugel's original ability."
-			description: [
-				"Can memorize one location per dimension (Sneak-Right Click on a block to set the location, then by holding Right Click you can warp to that location)."
-				""
-				"Having this in you inventory also allows to fly with Flugel Tiara even with an empty flight bar, but at a higher Mana cost."
-			]
-			dependencies: ["0261B1AB2F3BF7F3"]
-			id: "0641EE252CD065A2"
 			tasks: [{
 				id: "11ECFE184F61AD41"
 				type: "item"
 				item: "botania:flugel_eye"
 				match_nbt: false
 			}]
+			description: [
+				"Can memorize one location per dimension (Sneak-Right Click on a block to set the location, then by holding Right Click you can warp to that location)."
+				""
+				"Having this in you inventory also allows to fly with Flugel Tiara even with an empty flight bar, but at a higher Mana cost."
+			]
+			id: "0641EE252CD065A2"
+			x: 2.0d
+			y: 8.0d
 			rewards: [{
 				id: "5A066A08BEEBC61F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A replica of Flugel's original ability."
+			dependencies: ["0261B1AB2F3BF7F3"]
 		}
 		{
-			x: 1.0d
-			y: 9.0d
-			subtitle: "The Thunder god's ability."
+			tasks: [{
+				id: "4D1EB658C515A112"
+				type: "item"
+				item: "botania:thor_ring"
+				match_nbt: false
+			}]
 			description: [
 				"Drastically increased Terra Shatterer's AoE."
 				""
@@ -4097,78 +4101,75 @@
 				"> S: 9x9x9,"
 				"> SS: 11x11x11."
 			]
-			hide_dependency_lines: true
-			dependencies: ["0261B1AB2F3BF7F3"]
 			id: "36EE02CA34CA5295"
-			tasks: [{
-				id: "4D1EB658C515A112"
-				type: "item"
-				item: "botania:thor_ring"
-				match_nbt: false
-			}]
+			x: 1.0d
+			y: 9.0d
 			rewards: [{
 				id: "5D07C18B5ECD45EE"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The Thunder god's ability."
+			dependencies: ["0261B1AB2F3BF7F3"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 2.0d
-			y: 9.0d
-			subtitle: "The Principal god's ability."
-			description: ["When equipped, grants +20 Health and immunity to fall damage, fire damage, drowning, suffocating and starving."]
-			hide_dependency_lines: true
-			dependencies: ["0261B1AB2F3BF7F3"]
-			id: "640A1804DC116D54"
 			tasks: [{
 				id: "2BF6576D5732AAB6"
 				type: "item"
 				item: "botania:odin_ring"
 				match_nbt: false
 			}]
+			description: ["When equipped, grants +20 Health and immunity to fall damage, fire damage, drowning, suffocating and starving."]
+			id: "640A1804DC116D54"
+			x: 2.0d
+			y: 9.0d
 			rewards: [{
 				id: "5F330B7765723657"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The Principal god's ability."
+			dependencies: ["0261B1AB2F3BF7F3"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 0.0d
-			y: 9.0d
-			subtitle: "The Trickster god's ability."
-			description: [
-				"You can choose multiple blocks by Sneak-Right Clicking with this ring in hand."
-				""
-				"Then, after equipping, all actions (placing and breaking blocks) are reflected across all chosen locations."
-			]
-			hide_dependency_lines: true
-			dependencies: ["0261B1AB2F3BF7F3"]
-			id: "60C80EB4047BDA16"
 			tasks: [{
 				id: "232362976E59F378"
 				type: "item"
 				item: "botania:loki_ring"
 				match_nbt: false
 			}]
+			description: [
+				"You can choose multiple blocks by Sneak-Right Clicking with this ring in hand."
+				""
+				"Then, after equipping, all actions (placing and breaking blocks) are reflected across all chosen locations."
+			]
+			id: "60C80EB4047BDA16"
+			x: 0.0d
+			y: 9.0d
 			rewards: [{
 				id: "5695B1B8B127BFF3"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The Trickster god's ability."
+			dependencies: ["0261B1AB2F3BF7F3"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 0.0d
-			y: 7.0d
-			dependencies: ["6C892E06A15C3774"]
-			id: "2DBF539424CF616F"
 			tasks: [{
 				id: "2B28737EB6634138"
 				type: "item"
 				item: "botania:pinkinator"
 			}]
+			dependencies: ["6C892E06A15C3774"]
+			id: "2DBF539424CF616F"
+			y: 7.0d
+			x: 0.0d
 			rewards: [{
 				id: "7F24FD69445675C8"
 				type: "random"
@@ -4177,65 +4178,60 @@
 			}]
 		}
 		{
-			x: 9.0d
-			y: 9.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "4C792DE04121F766"
 			tasks: [{
 				id: "295CA389EC066A3A"
 				type: "item"
 				item: "botania:bauble_box"
 			}]
+			id: "4C792DE04121F766"
+			x: 9.0d
+			y: 9.0d
 			rewards: [{
 				id: "2948D50C662BB17D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 10.0d
-			y: 6.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "1C7CADAA45091921"
 			tasks: [{
 				id: "5E0BD578559768FE"
 				type: "item"
 				item: "botania:travel_belt"
 			}]
+			id: "1C7CADAA45091921"
+			x: 10.0d
+			y: 6.0d
 			rewards: [{
 				id: "70C4227C261DCE33"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 11.0d
-			y: 6.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "4E34C24AFF391781"
 			tasks: [{
 				id: "3AD8D6E7EAF64822"
 				type: "item"
 				item: "botania:speed_up_belt"
 			}]
+			id: "4E34C24AFF391781"
+			x: 11.0d
+			y: 6.0d
 			rewards: [{
 				id: "56BC701A1D0883E3"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 12.0d
-			y: 6.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "04AD13AC8BE8259B"
 			tasks: [{
 				id: "65F9331E51448E51"
 				type: "item"
@@ -4252,109 +4248,109 @@
 					}
 				}
 			}]
+			id: "04AD13AC8BE8259B"
+			x: 12.0d
+			y: 6.0d
 			rewards: [{
 				id: "43C9CDE9BC034099"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 13.0d
-			y: 6.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "6FD4CFBBA3BFDE69"
 			tasks: [{
 				id: "5CBAA1C5A4D8D193"
 				type: "item"
 				item: "botania:super_travel_belt"
 			}]
+			id: "6FD4CFBBA3BFDE69"
+			x: 13.0d
+			y: 6.0d
 			rewards: [{
 				id: "55FBD17BFF776BA5"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 10.0d
-			y: 7.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "03A7D9C18E567825"
 			tasks: [{
 				id: "2DD3C9656A4606AD"
 				type: "item"
 				item: "botania:invisibility_cloak"
 			}]
+			id: "03A7D9C18E567825"
+			x: 10.0d
+			y: 7.0d
 			rewards: [{
 				id: "6EC7CFF1D2EE924B"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 11.0d
-			y: 7.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "71CDFBF7A42FF469"
 			tasks: [{
 				id: "49AC377D3EB1ABF4"
 				type: "item"
 				item: "botania:balance_cloak"
 			}]
+			id: "71CDFBF7A42FF469"
+			x: 11.0d
+			y: 7.0d
 			rewards: [{
 				id: "07B9102460B1845E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 12.0d
-			y: 7.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "2FE0444BAB9D297B"
 			tasks: [{
 				id: "3F57E4138AA4EFD2"
 				type: "item"
 				item: "botania:unholy_cloak"
 			}]
+			id: "2FE0444BAB9D297B"
+			x: 12.0d
+			y: 7.0d
 			rewards: [{
 				id: "68F3F3134D2793F9"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 13.0d
-			y: 7.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "6C55F97745E4C565"
 			tasks: [{
 				id: "6FAB518401079705"
 				type: "item"
 				item: "botania:holy_cloak"
 			}]
+			id: "6C55F97745E4C565"
+			x: 13.0d
+			y: 7.0d
 			rewards: [{
 				id: "765B81FF9F9C7EA6"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 9.0d
-			y: 7.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "2CE5629A34B9CE5E"
 			tasks: [{
 				id: "3F16644588877441"
 				type: "item"
@@ -4364,19 +4360,19 @@
 					tag: { }
 				}
 			}]
+			id: "2CE5629A34B9CE5E"
+			x: 9.0d
+			y: 7.0d
 			rewards: [{
 				id: "44CA736254020F3C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 7.0d
-			y: 6.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "0B2D4775EB017CCC"
 			tasks: [{
 				id: "2E8A5F82A6E1EB33"
 				type: "item"
@@ -4388,181 +4384,181 @@
 					}
 				}
 			}]
+			id: "0B2D4775EB017CCC"
+			x: 7.0d
+			y: 6.0d
 			rewards: [{
 				id: "55AEB9B529626450"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 8.0d
-			y: 7.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "26ADB42F6ECD72D0"
 			tasks: [{
 				id: "10EA96EB49141FC3"
 				type: "item"
 				item: "botania:astrolabe"
 			}]
+			id: "26ADB42F6ECD72D0"
+			x: 8.0d
+			y: 7.0d
 			rewards: [{
 				id: "47124AEE7CDFA169"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 8.0d
-			y: 6.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "0E68037B5FB515E0"
 			tasks: [{
 				id: "7A0A163A5437AA67"
 				type: "item"
 				item: "botania:sextant"
 			}]
+			id: "0E68037B5FB515E0"
+			x: 8.0d
+			y: 6.0d
 			rewards: [{
 				id: "35888BF3CB434C2B"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 10.0d
-			y: 9.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "38AB76E38DF2BE6A"
 			tasks: [{
 				id: "3BE45B4827BB43E3"
 				type: "item"
 				item: "botania:itemfinder"
 			}]
+			id: "38AB76E38DF2BE6A"
+			x: 10.0d
+			y: 9.0d
 			rewards: [{
 				id: "09338CE38699CC57"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 11.0d
-			y: 9.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "2BEEF68B5912AF4F"
 			tasks: [{
 				id: "00D55C27E03C6154"
 				type: "item"
 				item: "botania:diva_charm"
 			}]
+			id: "2BEEF68B5912AF4F"
+			x: 11.0d
+			y: 9.0d
 			rewards: [{
 				id: "28539FAADD742902"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 13.0d
-			y: 9.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "52636F1E33D91CA3"
 			tasks: [{
 				id: "49E09972E2986C6F"
 				type: "item"
 				item: "botania:goddess_charm"
 			}]
+			id: "52636F1E33D91CA3"
+			x: 13.0d
+			y: 9.0d
 			rewards: [{
 				id: "7B8EC9A4B90C1318"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 10.0d
-			y: 8.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "6E45FD4C45D4261A"
 			tasks: [{
 				id: "7F9B9B6333924BFC"
 				type: "item"
 				item: "botania:tiny_planet"
 			}]
+			id: "6E45FD4C45D4261A"
+			x: 10.0d
+			y: 8.0d
 			rewards: [{
 				id: "48B08391FEF7480A"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 12.0d
-			y: 8.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "5AE2CA8248591BFF"
 			tasks: [{
 				id: "6C4A08D7F0DDE3FA"
 				type: "item"
 				item: "botania:monocle"
 			}]
+			id: "5AE2CA8248591BFF"
+			x: 12.0d
+			y: 8.0d
 			rewards: [{
 				id: "27874D315E5A18AA"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 12.0d
-			y: 9.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "5AFDB8923ECA400D"
 			tasks: [{
 				id: "54A9A1A799895A4F"
 				type: "item"
 				item: "botania:third_eye"
 			}]
+			id: "5AFDB8923ECA400D"
+			x: 12.0d
+			y: 9.0d
 			rewards: [{
 				id: "3501516087D617BB"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 11.0d
-			y: 8.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "43FD9F2E7F11F4B4"
 			tasks: [{
 				id: "5B43B948EB83B7A3"
 				type: "item"
 				item: "botania:black_hole_talisman"
 			}]
+			id: "43FD9F2E7F11F4B4"
+			x: 11.0d
+			y: 8.0d
 			rewards: [{
 				id: "21CC685470BDD09E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 13.0d
-			y: 8.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "16661CCB81E6BD48"
 			tasks: [{
 				id: "2D5B5F1B0C09DBA2"
 				type: "item"
@@ -4574,149 +4570,154 @@
 					}
 				}
 			}]
+			id: "16661CCB81E6BD48"
+			x: 13.0d
+			y: 8.0d
 			rewards: [{
 				id: "74A4AD2DAC23BDC9"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 7.0d
-			y: 7.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "388F97E8D5E152A0"
 			tasks: [{
 				id: "0D833CA32C782F32"
 				type: "item"
 				item: "botania:cacophonium"
 			}]
+			id: "388F97E8D5E152A0"
+			x: 7.0d
+			y: 7.0d
 			rewards: [{
 				id: "3F805EEBC2C627E7"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 9.0d
-			y: 6.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "602B626B4FE41A4A"
 			tasks: [{
 				id: "7632D27F6EEFEDA1"
 				type: "item"
 				item: "botania:flower_bag"
 			}]
+			id: "602B626B4FE41A4A"
+			x: 9.0d
+			y: 6.0d
 			rewards: [{
 				id: "034642BF43FF6E00"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 8.0d
-			y: 8.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "48DAFE450A14D7FE"
 			tasks: [{
 				id: "5CCF28FC366025A8"
 				type: "item"
 				item: "botania:cloud_pendant"
 			}]
+			id: "48DAFE450A14D7FE"
+			x: 8.0d
+			y: 8.0d
 			rewards: [{
 				id: "282613656097CDA9"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 8.0d
-			y: 9.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "28D7382DC011FD94"
 			tasks: [{
 				id: "13BDEEBC0334D101"
 				type: "item"
 				item: "botania:super_cloud_pendant"
 			}]
+			id: "28D7382DC011FD94"
+			x: 8.0d
+			y: 9.0d
 			rewards: [{
 				id: "71252508EFCEAC84"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 7.0d
-			y: 8.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "28554D891EE74B0C"
 			tasks: [{
 				id: "1DC30B95CB92FC72"
 				type: "item"
 				item: "botania:lava_pendant"
 			}]
+			id: "28554D891EE74B0C"
+			x: 7.0d
+			y: 8.0d
 			rewards: [{
 				id: "24DEA576D3259F22"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 7.0d
-			y: 9.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "3BCECE610CA260B9"
 			tasks: [{
 				id: "3A24566E4F3345FB"
 				type: "item"
 				item: "botania:super_lava_pendant"
 			}]
+			id: "3BCECE610CA260B9"
+			x: 7.0d
+			y: 9.0d
 			rewards: [{
 				id: "27F255988D18350C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 9.0d
-			y: 8.0d
-			hide_dependency_lines: true
-			dependencies: ["7D112B8FC4531A7E"]
-			id: "36EEA1400B28AEEB"
 			tasks: [{
 				id: "02EBD017A7B17299"
 				type: "item"
 				item: "botania:ice_pendant"
 			}]
+			id: "36EEA1400B28AEEB"
+			x: 9.0d
+			y: 8.0d
 			rewards: [{
 				id: "34997E15E140BD73"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7D112B8FC4531A7E"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 16.0d
-			y: 9.0d
-			dependencies: ["5AA730044BE9D730"]
-			id: "318553FB59CFA5E6"
 			tasks: [{
 				id: "27B0207FB98FD37B"
 				type: "item"
 				item: "botania:mana_ring_greater"
 			}]
+			dependencies: ["5AA730044BE9D730"]
+			id: "318553FB59CFA5E6"
+			y: 9.0d
+			x: 16.0d
 			rewards: [{
 				id: "650EC4514482FBAF"
 				type: "random"
@@ -4725,15 +4726,15 @@
 			}]
 		}
 		{
-			x: 15.0d
-			y: 9.0d
-			dependencies: ["30BB9E0BBC84742B"]
-			id: "6A6E4403428E103A"
 			tasks: [{
 				id: "167060222B51511D"
 				type: "item"
 				item: "botania:magnet_ring_greater"
 			}]
+			dependencies: ["30BB9E0BBC84742B"]
+			id: "6A6E4403428E103A"
+			y: 9.0d
+			x: 15.0d
 			rewards: [{
 				id: "46C207816EE91F9B"
 				type: "random"
@@ -4742,15 +4743,15 @@
 			}]
 		}
 		{
-			x: 14.0d
-			y: 9.0d
-			dependencies: ["2EEB7BBE8DFA13DB"]
-			id: "195F3C7EA2756B45"
 			tasks: [{
 				id: "6EFA9C6E0151C1DC"
 				type: "item"
 				item: "botania:aura_ring_greater"
 			}]
+			dependencies: ["2EEB7BBE8DFA13DB"]
+			id: "195F3C7EA2756B45"
+			y: 9.0d
+			x: 14.0d
 			rewards: [{
 				id: "1AE17C529C7FBA37"
 				type: "random"
@@ -4759,41 +4760,26 @@
 			}]
 		}
 		{
-			title: "Floral Fertilizer"
-			x: 4.5d
-			y: -1.5d
-			subtitle: "Use it on a Grass Block to make it flourish with different Mystical Flowers!"
-			dependencies: ["06796341AB3CFBB4"]
-			id: "358776C4E9A01BCC"
 			tasks: [{
 				id: "0F2F35262721F3A7"
 				type: "item"
 				item: "botania:fertilizer"
 				count: 16L
 			}]
+			id: "358776C4E9A01BCC"
+			x: 4.5d
+			y: -1.5d
+			title: "Floral Fertilizer"
 			rewards: [{
 				id: "4512F9C2BB4B1C3D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Use it on a Grass Block to make it flourish with different Mystical Flowers!"
+			dependencies: ["06796341AB3CFBB4"]
 		}
 		{
-			title: "Spark Augments"
-			x: 3.0d
-			y: 6.0d
-			subtitle: "Control the Mana flow on the Spark Network!"
-			description: [
-				"> Dominant - a Spark will pull Mana from other pools to itself."
-				""
-				"> Recessive - a Spark will push Mana to other pools from itself."
-				""
-				"> Dispersive - will charge nearby players' Mana Tablets and Rings with Mana."
-				""
-				"> Isolated - Spark won't interact with Dominant or Recessive Sparks, but will still send Mana to Terrestrial Agglomeration Plates and Mana Enchanters."
-			]
-			dependencies: ["006D707637E3F606"]
-			id: "427099DD01253700"
 			tasks: [
 				{
 					id: "12C05D04C45F155D"
@@ -4816,43 +4802,57 @@
 					item: "botania:spark_upgrade_isolated"
 				}
 			]
+			description: [
+				"> Dominant - a Spark will pull Mana from other pools to itself."
+				""
+				"> Recessive - a Spark will push Mana to other pools from itself."
+				""
+				"> Dispersive - will charge nearby players' Mana Tablets and Rings with Mana."
+				""
+				"> Isolated - Spark won't interact with Dominant or Recessive Sparks, but will still send Mana to Terrestrial Agglomeration Plates and Mana Enchanters."
+			]
+			id: "427099DD01253700"
+			x: 3.0d
+			y: 6.0d
+			title: "Spark Augments"
+			subtitle: "Control the Mana flow on the Spark Network!"
+			dependencies: ["006D707637E3F606"]
 		}
 		{
-			x: 14.0d
-			y: 4.5d
-			hide_dependency_lines: true
-			dependencies: ["278D27920CB07C59"]
-			id: "4DD2393E9AADE210"
 			tasks: [{
 				id: "2ED308B27E911759"
 				type: "item"
 				item: "botania:rune_greed"
 			}]
+			id: "4DD2393E9AADE210"
+			x: 14.0d
+			y: 4.5d
 			rewards: [{
 				id: "1560E7152E31DEE9"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["278D27920CB07C59"]
+			hide_dependency_lines: true
 		}
 		{
-			title: "Also Mana on Rails?"
-			icon: "create:minecart_contraption"
-			x: 12.0d
-			y: -4.5d
-			subtitle: "... or maybe rather - Mana on Contraptions?"
+			tasks: [{
+				id: "7AEDD960544BB1D3"
+				type: "checkmark"
+			}]
 			description: [
 				"{image:kubejs:textures/item/mana_contraption.png width:100 height:100 align:1}"
 				""
 				"The only downside is, that you need to disassemble the Contraption to load and unload Mana."
 			]
-			dependencies: ["45AC772575502EB6"]
 			id: "379274D6D08ECCEE"
-			tasks: [{
-				id: "7AEDD960544BB1D3"
-				type: "checkmark"
-			}]
+			icon: "create:minecart_contraption"
+			x: 12.0d
+			y: -4.5d
+			title: "Also Mana on Rails?"
+			subtitle: "... or maybe rather - Mana on Contraptions?"
+			dependencies: ["45AC772575502EB6"]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/conjuring.snbt
+++ b/config/ftbquests/quests/chapters/conjuring.snbt
@@ -1,39 +1,40 @@
 {
-	id: "6486CFAD73CBEFBA"
+	quest_links: [ ]
+	default_hide_dependency_lines: false
 	group: "76C22988F9A7C9CE"
-	order_index: 6
+	id: "6486CFAD73CBEFBA"
 	filename: "conjuring"
-	title: "Conjuring"
+	default_quest_shape: "square"
 	icon: {
 		id: "conjuring:enchiridion"
 		Count: 1b
 		tag: { }
 	}
-	default_quest_shape: "square"
-	default_hide_dependency_lines: false
+	title: "Conjuring"
 	images: [{
-		x: -10.5d
-		y: -1.0d
-		width: 3.0d
-		height: 3.0d
 		rotation: 0.0d
 		image: "conjuring:textures/item/enchiridion.png"
-		hover: [ ]
+		width: 3.0d
 		click: ""
-		dev: false
+		hover: [ ]
+		x: -10.5d
+		y: -1.0d
 		corner: false
+		dev: false
+		height: 3.0d
 	}]
+	order_index: 6
 	quests: [
 		{
-			x: -2.5d
-			y: -1.0d
-			dependencies: ["61DB1ACC5AB23AFA"]
-			id: "04B7A90A9A260CC3"
 			tasks: [{
 				id: "5AD216578C6CD5BE"
 				type: "item"
 				item: "conjuring:gem_socket"
 			}]
+			dependencies: ["61DB1ACC5AB23AFA"]
+			id: "04B7A90A9A260CC3"
+			y: -1.0d
+			x: -2.5d
 			rewards: [{
 				id: "633AF0EF5C55D78F"
 				type: "loot"
@@ -41,9 +42,11 @@
 			}]
 		}
 		{
-			title: "Basic Gem Tinkering"
-			x: -3.0d
-			y: -2.5d
+			tasks: [{
+				id: "763861624BBCCEC6"
+				type: "item"
+				item: "conjuring:gem_tinkerer"
+			}]
 			description: [
 				"The different charm aspects will influence a Conjurer in the following ways:"
 				""
@@ -55,41 +58,45 @@
 				""
 				"Ignorance: Increases the amount of creatures in close vicinity the Conjurer ignores when judging how many new ones to summon."
 			]
-			dependencies: ["12153697CC677412"]
 			id: "61DB1ACC5AB23AFA"
-			tasks: [{
-				id: "763861624BBCCEC6"
-				type: "item"
-				item: "conjuring:gem_tinkerer"
-			}]
+			x: -3.0d
+			y: -2.5d
+			title: "Basic Gem Tinkering"
 			rewards: [{
 				id: "732CB90B4CC399F6"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["12153697CC677412"]
 		}
 		{
-			x: -7.5d
-			y: -4.0d
-			subtitle: "Craft a Soulfire Forge."
-			description: ["The first piece of equipment one shall create is the Soulfire Forge, required to form the elementary Soul Composite Materials."]
-			dependencies: ["00E561B037BFF9B4"]
-			id: "0E908723F937FD89"
 			tasks: [{
 				id: "1A6A427027AF0958"
 				type: "item"
 				item: "conjuring:soulfire_forge"
 			}]
+			description: ["The first piece of equipment one shall create is the Soulfire Forge, required to form the elementary Soul Composite Materials."]
+			id: "0E908723F937FD89"
+			x: -7.5d
+			y: -4.0d
 			rewards: [{
 				id: "6418BC43F10BD732"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Craft a Soulfire Forge."
+			dependencies: ["00E561B037BFF9B4"]
 		}
 		{
-			x: -9.0d
-			y: -4.0d
-			subtitle: "The practice of conjuration."
+			tasks: [{
+				id: "1CC8E36B0C6BE2DF"
+				type: "item"
+				item: {
+					id: "conjuring:enchiridion"
+					Count: 1b
+					tag: { }
+				}
+			}]
 			description: [
 				"To start out in the practice of conjuration, a basic supply of Netherite Scrap and some Conjuration Essence is required."
 				""
@@ -106,31 +113,12 @@
 				"These prestigious instruments can be enhanced through Advanced Gem Tinkering."
 				"Crafting them however, requires the Ritual of Weaving to be carried out."
 			]
+			subtitle: "The practice of conjuration."
 			id: "00E561B037BFF9B4"
-			tasks: [{
-				id: "1CC8E36B0C6BE2DF"
-				type: "item"
-				item: {
-					id: "conjuring:enchiridion"
-					Count: 1b
-					tag: { }
-				}
-			}]
+			y: -4.0d
+			x: -9.0d
 		}
 		{
-			x: -6.0d
-			y: -8.5d
-			description: [
-				"A Stabilized Conjuring Focus which is reinforced with Soul Slices is exponentially more powerful."
-				""
-				"Once inserted into a Conjurer, it will start mimicking a player's presence, practically allowing for perpetual summoning."
-				""
-				"Considering how expensive a Stabilized Focus is, cleaning and reusing it might seen practical."
-				""
-				"To accomplish this, one can utilize Distilled Spirit."
-			]
-			dependencies: ["645B10BF6FCDE303"]
-			id: "5AC0C2202D65449C"
 			tasks: [{
 				id: "507901397293C1E6"
 				type: "item"
@@ -140,56 +128,78 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"A Stabilized Conjuring Focus which is reinforced with Soul Slices is exponentially more powerful."
+				""
+				"Once inserted into a Conjurer, it will start mimicking a player's presence, practically allowing for perpetual summoning."
+				""
+				"Considering how expensive a Stabilized Focus is, cleaning and reusing it might seen practical."
+				""
+				"To accomplish this, one can utilize Distilled Spirit."
+			]
+			id: "5AC0C2202D65449C"
+			x: -6.0d
+			y: -8.5d
 			rewards: [{
 				id: "0CFCF3549FA644E5"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["645B10BF6FCDE303"]
 		}
 		{
-			x: -6.0d
-			y: -4.0d
-			subtitle: "Vitally important in any and all endeavours involving summoning."
-			description: ["Being composed mostly of basic metals it is quite sturdy and could also prove handy in the creation of tools."]
-			dependencies: ["0E908723F937FD89"]
-			id: "0F91A0EC16EBBBBB"
 			tasks: [{
 				id: "68E63E56E52EA132"
 				type: "item"
 				item: "conjuring:soul_alloy"
 			}]
+			description: ["Being composed mostly of basic metals it is quite sturdy and could also prove handy in the creation of tools."]
+			id: "0F91A0EC16EBBBBB"
+			x: -6.0d
+			y: -4.0d
 			rewards: [{
 				id: "788B845CAF39216D"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Vitally important in any and all endeavours involving summoning."
+			dependencies: ["0E908723F937FD89"]
 		}
 		{
-			x: -6.0d
-			y: -7.0d
-			subtitle: "Extraordinary powers facilitate the creation of ever stronger instruments."
-			description: [
-				"A blend of Conjuration Essence and Iron Ingots adorned with a Nether Star the Soul Slice is a formidable material."
-				""
-				"Its extraordinary powers facilitate the creation of ever stronger instruments, like the Stabilized Conjuring Focus."
-			]
-			dependencies: ["123117C7D38E3ED8"]
-			id: "645B10BF6FCDE303"
 			tasks: [{
 				id: "7665D64C554FEF12"
 				type: "item"
 				item: "conjuring:soul_slice"
 			}]
+			description: [
+				"A blend of Conjuration Essence and Iron Ingots adorned with a Nether Star the Soul Slice is a formidable material."
+				""
+				"Its extraordinary powers facilitate the creation of ever stronger instruments, like the Stabilized Conjuring Focus."
+			]
+			id: "645B10BF6FCDE303"
+			x: -6.0d
+			y: -7.0d
 			rewards: [{
 				id: "5AB2151A2D120123"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Extraordinary powers facilitate the creation of ever stronger instruments."
+			dependencies: ["123117C7D38E3ED8"]
 		}
 		{
-			x: 1.5d
-			y: -1.0d
-			subtitle: "The Soul Alloy Sword is a contribution to the warrior who possess it."
+			tasks: [{
+				id: "2591D7BB6E0558AD"
+				type: "item"
+				item: {
+					id: "conjuring:soul_alloy_sword"
+					Count: 1b
+					tag: {
+						Damage: 0
+						Modifiers: { }
+					}
+				}
+			}]
 			description: [
 				"It's ability launches five beams, which normally deal 20% of that sword's attack damage each."
 				""
@@ -203,13 +213,23 @@
 				""
 				"Ignorance: Ignores a specific amount of armor per gem fitted."
 			]
-			dependencies: ["482E9E6D0DBEDA9F"]
 			id: "389463636AC92D4A"
+			x: 1.5d
+			y: -1.0d
+			rewards: [{
+				id: "3002B2E585C3347B"
+				type: "loot"
+				table_id: 13756307348121783L
+			}]
+			subtitle: "The Soul Alloy Sword is a contribution to the warrior who possess it."
+			dependencies: ["482E9E6D0DBEDA9F"]
+		}
+		{
 			tasks: [{
-				id: "2591D7BB6E0558AD"
+				id: "1F46AEE4412AF0ED"
 				type: "item"
 				item: {
-					id: "conjuring:soul_alloy_sword"
+					id: "conjuring:soul_alloy_pickaxe"
 					Count: 1b
 					tag: {
 						Damage: 0
@@ -217,16 +237,6 @@
 					}
 				}
 			}]
-			rewards: [{
-				id: "3002B2E585C3347B"
-				type: "loot"
-				table_id: 13756307348121783L
-			}]
-		}
-		{
-			x: 0.5d
-			y: -1.0d
-			subtitle: "The perilous pickaxe of choice."
 			description: [
 				"Right-clicking will coerce it to send out a beam which vein-mines any ores it touches."
 				""
@@ -240,13 +250,23 @@
 				""
 				"Ignorance: Ignores a small amount of durability loss when using the tool. Stacks with Unbreaking."
 			]
-			dependencies: ["482E9E6D0DBEDA9F"]
 			id: "3D6141DCD667189D"
+			x: 0.5d
+			y: -1.0d
+			rewards: [{
+				id: "3740E294EF2C744D"
+				type: "loot"
+				table_id: 13756307348121783L
+			}]
+			subtitle: "The perilous pickaxe of choice."
+			dependencies: ["482E9E6D0DBEDA9F"]
+		}
+		{
 			tasks: [{
-				id: "1F46AEE4412AF0ED"
+				id: "7508FC98B04197D9"
 				type: "item"
 				item: {
-					id: "conjuring:soul_alloy_pickaxe"
+					id: "conjuring:soul_alloy_hatchet"
 					Count: 1b
 					tag: {
 						Damage: 0
@@ -254,16 +274,6 @@
 					}
 				}
 			}]
-			rewards: [{
-				id: "3740E294EF2C744D"
-				type: "loot"
-				table_id: 13756307348121783L
-			}]
-		}
-		{
-			x: 2.5d
-			y: -1.0d
-			subtitle: "A powerful tool, both in damage and the Soul Feller ability."
 			description: [
 				"Upon right-clicking, a destructive beam is emitted that will obliterate any logs on contact."
 				""
@@ -277,13 +287,23 @@
 				""
 				"Ignorance: Ignores a small amount of durability loss when using the tool. Stacks with Unbreaking."
 			]
-			dependencies: ["482E9E6D0DBEDA9F"]
 			id: "5CD85868465A7E9B"
+			x: 2.5d
+			y: -1.0d
+			rewards: [{
+				id: "3E2773F64CB289B4"
+				type: "loot"
+				table_id: 13756307348121783L
+			}]
+			subtitle: "A powerful tool, both in damage and the Soul Feller ability."
+			dependencies: ["482E9E6D0DBEDA9F"]
+		}
+		{
 			tasks: [{
-				id: "7508FC98B04197D9"
+				id: "30C4673B6D235BDE"
 				type: "item"
 				item: {
-					id: "conjuring:soul_alloy_hatchet"
+					id: "conjuring:soul_alloy_shovel"
 					Count: 1b
 					tag: {
 						Damage: 0
@@ -291,16 +311,6 @@
 					}
 				}
 			}]
-			rewards: [{
-				id: "3E2773F64CB289B4"
-				type: "loot"
-				table_id: 13756307348121783L
-			}]
-		}
-		{
-			x: 3.5d
-			y: -1.0d
-			subtitle: "While the shovel sees little use normally, the ability of it is likely to become a good friend."
 			description: [
 				"When used it will seek out any items around and bring them back to it's caller."
 				""
@@ -314,30 +324,23 @@
 				""
 				"Ignorance: Ignores a small amount of durability loss when using the tool. Stacks with Unbreaking."
 			]
-			dependencies: ["482E9E6D0DBEDA9F"]
 			id: "765F6E10ED3E1A1F"
-			tasks: [{
-				id: "30C4673B6D235BDE"
-				type: "item"
-				item: {
-					id: "conjuring:soul_alloy_shovel"
-					Count: 1b
-					tag: {
-						Damage: 0
-						Modifiers: { }
-					}
-				}
-			}]
+			x: 3.5d
+			y: -1.0d
 			rewards: [{
 				id: "0F59C9A2142B0DE1"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "While the shovel sees little use normally, the ability of it is likely to become a good friend."
+			dependencies: ["482E9E6D0DBEDA9F"]
 		}
 		{
-			x: -6.0d
-			y: -5.5d
-			subtitle: "Basic substance involved in summoning."
+			tasks: [{
+				id: "714CBC4CB6DB728A"
+				type: "item"
+				item: "conjuring:conjuration_essence"
+			}]
 			description: [
 				"While being the most basic substance involved in summoning, is still of utmost importance."
 				""
@@ -345,63 +348,63 @@
 				""
 				"One can obtain some essence of their own from breaking ordinary spawners as well as plundering chests."
 			]
-			dependencies: ["0E908723F937FD89"]
 			id: "123117C7D38E3ED8"
-			tasks: [{
-				id: "714CBC4CB6DB728A"
-				type: "item"
-				item: "conjuring:conjuration_essence"
-			}]
+			x: -6.0d
+			y: -5.5d
 			rewards: [{
 				id: "6944EA4B397D995C"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Basic substance involved in summoning."
+			dependencies: ["0E908723F937FD89"]
 		}
 		{
-			x: -3.0d
-			y: -4.0d
-			subtitle: "Smash Conjuration Essence on stone for 4 pieces of Lesser Conjuration Essence."
-			description: ["For when a less concentrated material is required, simply right-clicking some essence on any stone-like surface smashes it into 4 pieces of Lesser Conjuration Essence."]
-			dependencies: ["43304C008E8A700B"]
-			id: "12153697CC677412"
 			tasks: [{
 				id: "5D56B9D6B720A4DE"
 				type: "item"
 				item: "conjuring:lesser_conjuration_essence"
 			}]
+			description: ["For when a less concentrated material is required, simply right-clicking some essence on any stone-like surface smashes it into 4 pieces of Lesser Conjuration Essence."]
+			id: "12153697CC677412"
+			x: -3.0d
+			y: -4.0d
 			rewards: [{
 				id: "6AAD9611B759D03A"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Smash Conjuration Essence on stone for 4 pieces of Lesser Conjuration Essence."
+			dependencies: ["43304C008E8A700B"]
 		}
 		{
-			x: -6.0d
-			y: -2.5d
-			subtitle: "Commanding the powerful contraptions involved in conjuration."
-			description: [
-				"Commanding the powerful contraptions involved in conjuration is no easy task and as such, the Conjuring Scepter is required to interact with most of them."
-				""
-				"The very basic act of mounting a Nether Star on a Blaze Rod has apparently greatly improved their magical abilities, making the usage of most runic machinery a breeze."
-			]
-			dependencies: ["0E908723F937FD89"]
-			id: "55FE66A0CBE3C520"
 			tasks: [{
 				id: "21FA46FF3840E447"
 				type: "item"
 				item: "conjuring:conjuring_scepter"
 			}]
+			description: [
+				"Commanding the powerful contraptions involved in conjuration is no easy task and as such, the Conjuring Scepter is required to interact with most of them."
+				""
+				"The very basic act of mounting a Nether Star on a Blaze Rod has apparently greatly improved their magical abilities, making the usage of most runic machinery a breeze."
+			]
+			id: "55FE66A0CBE3C520"
+			x: -6.0d
+			y: -2.5d
 			rewards: [{
 				id: "4A98520164393F60"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Commanding the powerful contraptions involved in conjuration."
+			dependencies: ["0E908723F937FD89"]
 		}
 		{
-			x: -6.0d
-			y: 0.5d
-			subtitle: "A reliable long-term solution for Conjuration Essence."
+			tasks: [{
+				id: "6B73E673A80B0705"
+				type: "item"
+				item: "conjuring:superior_conjuring_scepter"
+			}]
 			description: [
 				"There may come a point at which one runs out of Conjuration Essence. "
 				""
@@ -413,23 +416,23 @@
 				""
 				"Additionally, the scepter is capable of instantly finishing any process in the Soulfire Forge by right-clicking."
 			]
-			dependencies: ["651E1703E4D6A7F3"]
 			id: "7CB1A19C567DE84C"
-			tasks: [{
-				id: "6B73E673A80B0705"
-				type: "item"
-				item: "conjuring:superior_conjuring_scepter"
-			}]
+			x: -6.0d
+			y: 0.5d
 			rewards: [{
 				id: "5B2E49E9BB27216C"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A reliable long-term solution for Conjuration Essence."
+			dependencies: ["651E1703E4D6A7F3"]
 		}
 		{
-			title: "Ritual of Extraction"
-			x: 1.5d
-			y: -4.5d
+			tasks: [{
+				id: "3666880CAA50A00D"
+				type: "item"
+				item: "conjuring:soul_funnel"
+			}]
 			description: [
 				"Knowing how to perform the Ritual of Extraction is easily one of the most important skills involved in summoning."
 				""
@@ -447,23 +450,23 @@
 				""
 				"This will make it possible to commence the ritual by right-clicking the Soul Funnel with a Conjuring Scepter. "
 			]
-			dependencies: ["1866FF6B9D5AE777"]
 			id: "147BCF7E6F4944A2"
-			tasks: [{
-				id: "3666880CAA50A00D"
-				type: "item"
-				item: "conjuring:soul_funnel"
-			}]
+			x: 1.5d
+			y: -4.5d
+			title: "Ritual of Extraction"
 			rewards: [{
 				id: "78A79979DB967D26"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["1866FF6B9D5AE777"]
 		}
 		{
-			title: "Ritual of Weaving"
-			x: 1.5d
-			y: -3.5d
+			tasks: [{
+				id: "2AEE7687908351FC"
+				type: "item"
+				item: "conjuring:soul_weaver"
+			}]
 			description: [
 				"Some crafting processes, like those involved in fabricating Soul Alloy Tools, can be very involved and consequently require the Ritual of Weaving to be carried out."
 				""
@@ -473,23 +476,23 @@
 				""
 				"In the final step, the Soul Weaver has to be loaded with Conjuration Essence and subsequently right-clicked with a Conjuration Scepter to commence the ritual."
 			]
-			dependencies: ["1866FF6B9D5AE777"]
 			id: "482E9E6D0DBEDA9F"
-			tasks: [{
-				id: "2AEE7687908351FC"
-				type: "item"
-				item: "conjuring:soul_weaver"
-			}]
+			x: 1.5d
+			y: -3.5d
+			title: "Ritual of Weaving"
 			rewards: [{
 				id: "32178DCACFFBAEA4"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["1866FF6B9D5AE777"]
 		}
 		{
-			x: -4.5d
-			y: -4.0d
-			subtitle: "Mob spawner in red disguise?"
+			tasks: [{
+				id: "513F4BFBDB849D3F"
+				type: "item"
+				item: "conjuring:conjurer"
+			}]
 			description: [
 				"To the untrained eye, a Conjurer may look remarkably similar to a normal monster spawner."
 				""
@@ -503,26 +506,27 @@
 				""
 				"A final feature of the Conjurer one should keep in mind is that, when confronted with a redstone signal, it will promptly seize operation."
 			]
-			dependencies: [
-				"0F91A0EC16EBBBBB"
-				"123117C7D38E3ED8"
-				"55FE66A0CBE3C520"
-			]
 			id: "43304C008E8A700B"
-			tasks: [{
-				id: "513F4BFBDB849D3F"
-				type: "item"
-				item: "conjuring:conjurer"
-			}]
+			x: -4.5d
+			y: -4.0d
 			rewards: [{
 				id: "365F4B31BC3B4063"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Mob spawner in red disguise?"
+			dependencies: [
+				"0F91A0EC16EBBBBB"
+				"123117C7D38E3ED8"
+				"55FE66A0CBE3C520"
+			]
 		}
 		{
-			x: -0.5d
-			y: -1.0d
+			tasks: [{
+				id: "26EDCAA58BEDC06A"
+				type: "item"
+				item: "conjuring:distilled_spirit"
+			}]
 			description: [
 				"This freakish fluid is obtained by imbuing four pieces of Conjuration Essence into a plain old glass bottle using a Soul Weaver."
 				""
@@ -530,25 +534,17 @@
 				""
 				"Finally, a simple right-click with a Conjuring Scepter will suffice to extract the soul."
 			]
-			dependencies: ["482E9E6D0DBEDA9F"]
 			id: "01B6FAE48DFC7B5D"
-			tasks: [{
-				id: "26EDCAA58BEDC06A"
-				type: "item"
-				item: "conjuring:distilled_spirit"
-			}]
+			x: -0.5d
+			y: -1.0d
 			rewards: [{
 				id: "05B2E1661FE80B9F"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["482E9E6D0DBEDA9F"]
 		}
 		{
-			title: "Aspect Gems"
-			x: -3.5d
-			y: -1.0d
-			dependencies: ["61DB1ACC5AB23AFA"]
-			id: "4D12C2B99A11FC06"
 			tasks: [
 				{
 					id: "124E9000EEF740C3"
@@ -571,21 +567,18 @@
 					item: "conjuring:scope_gem"
 				}
 			]
+			id: "4D12C2B99A11FC06"
+			x: -3.5d
+			y: -1.0d
+			title: "Aspect Gems"
 			rewards: [{
 				id: "758AA3DA9243E6CE"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["61DB1ACC5AB23AFA"]
 		}
 		{
-			title: "Charms"
-			x: -3.0d
-			y: 0.5d
-			dependencies: [
-				"4D12C2B99A11FC06"
-				"04B7A90A9A260CC3"
-			]
-			id: "52ED7FEFB4862043"
 			tasks: [
 				{
 					id: "098643AC49423F55"
@@ -608,16 +601,30 @@
 					item: "conjuring:scope_charm"
 				}
 			]
+			id: "52ED7FEFB4862043"
+			x: -3.0d
+			y: 0.5d
+			title: "Charms"
 			rewards: [{
 				id: "5870FEAC800943C7"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: [
+				"4D12C2B99A11FC06"
+				"04B7A90A9A260CC3"
+			]
 		}
 		{
-			x: -1.5d
-			y: -4.0d
-			subtitle: "Safely contain the inner construct of a certain soul type."
+			tasks: [{
+				id: "4F87EE41560AB292"
+				type: "item"
+				item: {
+					id: "conjuring:conjuring_focus"
+					Count: 1b
+					tag: { }
+				}
+			}]
 			description: [
 				"Souls are complex entities and therefore containing them is certainly no easy task."
 				""
@@ -629,27 +636,24 @@
 				""
 				"To trap a soul inside a focus, one shall seek to perform a Ritual of Extraction."
 			]
-			dependencies: ["12153697CC677412"]
 			id: "6AEEA39ABC54E7C4"
-			tasks: [{
-				id: "4F87EE41560AB292"
-				type: "item"
-				item: {
-					id: "conjuring:conjuring_focus"
-					Count: 1b
-					tag: { }
-				}
-			}]
+			x: -1.5d
+			y: -4.0d
 			rewards: [{
 				id: "14EC64E36638B743"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Safely contain the inner construct of a certain soul type."
+			dependencies: ["12153697CC677412"]
 		}
 		{
-			title: "Ritual Basics"
-			x: 0.0d
-			y: -4.0d
+			tasks: [{
+				id: "0E36C158AEC8A73A"
+				type: "item"
+				item: "conjuring:blackstone_pedestal"
+				count: 4L
+			}]
 			description: [
 				"Seeing as Gilded Blackstone has some peculiar magical properties, it seems perfectly reasonable to construct a pedestal out of it."
 				""
@@ -659,30 +663,27 @@
 				""
 				"This is accomplished by right-clicking first a pedestal and then the corresponding ritual core, all while wielding a Conjuring Scepter of any kind."
 			]
-			dependencies: ["6AEEA39ABC54E7C4"]
 			id: "1866FF6B9D5AE777"
-			tasks: [{
-				id: "0E36C158AEC8A73A"
-				type: "item"
-				item: "conjuring:blackstone_pedestal"
-				count: 4L
-			}]
+			x: 0.0d
+			y: -4.0d
+			title: "Ritual Basics"
 			rewards: [{
 				id: "29C9136D229DD029"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["6AEEA39ABC54E7C4"]
 		}
 		{
-			x: -6.0d
-			y: -1.0d
-			dependencies: ["55FE66A0CBE3C520"]
-			id: "651E1703E4D6A7F3"
 			tasks: [{
 				id: "65CC3667BE68F75F"
 				type: "item"
 				item: "conjuring:soul_rod"
 			}]
+			dependencies: ["55FE66A0CBE3C520"]
+			id: "651E1703E4D6A7F3"
+			y: -1.0d
+			x: -6.0d
 			rewards: [{
 				id: "1E740640A0415092"
 				type: "loot"
@@ -690,5 +691,4 @@
 			}]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/deep_mob_learning.snbt
+++ b/config/ftbquests/quests/chapters/deep_mob_learning.snbt
@@ -1,17 +1,24 @@
 {
-	id: "36C36FC0225A052C"
-	group: "76C22988F9A7C9CE"
-	order_index: 5
-	filename: "deep_mob_learning"
-	title: "Deep Mob Learning"
-	icon: "dml-refabricated:deep_learner"
-	default_quest_shape: "square"
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "76C22988F9A7C9CE"
+	id: "36C36FC0225A052C"
+	filename: "deep_mob_learning"
+	default_quest_shape: "square"
+	icon: "dml-refabricated:deep_learner"
+	title: "Deep Mob Learning"
+	order_index: 5
 	quests: [
 		{
-			x: -9.5d
-			y: -2.5d
-			subtitle: "To get started with the mod you will need a Blank Data Model."
+			tasks: [{
+				id: "6FD0D261E90790A2"
+				type: "item"
+				item: {
+					id: "dml-refabricated:data_model"
+					Count: 1b
+					tag: { }
+				}
+			}]
 			description: [
 				"A blank data model does absolutely nothing, you will need to bound it with a Category."
 				""
@@ -46,27 +53,23 @@
 				"- Poseidon Children"
 				"Groups ocean mobs."
 			]
-			dependencies: ["394DCDE468051067"]
 			id: "2EA2885C13B2C158"
-			tasks: [{
-				id: "6FD0D261E90790A2"
-				type: "item"
-				item: {
-					id: "dml-refabricated:data_model"
-					Count: 1b
-					tag: { }
-				}
-			}]
+			x: -9.5d
+			y: -2.5d
 			rewards: [{
 				id: "2A43BE265ABEC909"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "To get started with the mod you will need a Blank Data Model."
+			dependencies: ["394DCDE468051067"]
 		}
 		{
-			x: -6.5d
-			y: -2.5d
-			subtitle: "Collect data about the mobs you want to learn."
+			tasks: [{
+				id: "1F74315ED1FF9FCB"
+				type: "item"
+				item: "dml-refabricated:deep_learner"
+			}]
 			description: [
 				"Right-click with it and you will be presented to its GUI."
 				""
@@ -80,23 +83,23 @@
 				""
 				"Just keep killing mobs and you will notice the Data Amount of your Data Models getting higher, and its Tier will be higher too."
 			]
-			dependencies: ["0CCCC61B10044F46"]
 			id: "5A7277E2D1A1C51D"
-			tasks: [{
-				id: "1F74315ED1FF9FCB"
-				type: "item"
-				item: "dml-refabricated:deep_learner"
-			}]
+			x: -6.5d
+			y: -2.5d
 			rewards: [{
 				id: "2BE95BADFA9C8930"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Collect data about the mobs you want to learn."
+			dependencies: ["0CCCC61B10044F46"]
 		}
 		{
-			x: -3.5d
-			y: -2.5d
-			subtitle: "Craft a Trial Keystone."
+			tasks: [{
+				id: "1CAE14E935895EEE"
+				type: "item"
+				item: "dml-refabricated:trial_keystone"
+			}]
 			description: [
 				"The Trial Key used in the crafting has no effect, so I's suggest you to use an Unbound one to avoid loosing your precious data."
 				""
@@ -108,23 +111,27 @@
 				""
 				"To get started, get a bound Trial Key and click in the Trial Keystone!"
 			]
-			dependencies: ["2EF788D6F29C5EDA"]
 			id: "01D568488C874E51"
-			tasks: [{
-				id: "1CAE14E935895EEE"
-				type: "item"
-				item: "dml-refabricated:trial_keystone"
-			}]
+			x: -3.5d
+			y: -2.5d
 			rewards: [{
 				id: "0395867049AA29C8"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Craft a Trial Keystone."
+			dependencies: ["2EF788D6F29C5EDA"]
 		}
 		{
-			x: -5.0d
-			y: -2.5d
-			subtitle: "Challenge to a fight!"
+			tasks: [{
+				id: "1712246FD3D1B782"
+				type: "item"
+				item: {
+					id: "dml-refabricated:trial_key"
+					Count: 1b
+					tag: { }
+				}
+			}]
 			description: [
 				"Trial Keys are what you will be using to getting the attention of the System Glitch and challenging it to a fight."
 				""
@@ -138,27 +145,23 @@
 				""
 				"You may have noticed that your Trial Key also has a \"Affixes\" list. Those are special effects that can occur during the trial. Some of them may help you, some of them not."
 			]
-			dependencies: ["5A7277E2D1A1C51D"]
 			id: "2EF788D6F29C5EDA"
-			tasks: [{
-				id: "1712246FD3D1B782"
-				type: "item"
-				item: {
-					id: "dml-refabricated:trial_key"
-					Count: 1b
-					tag: { }
-				}
-			}]
+			x: -5.0d
+			y: -2.5d
 			rewards: [{
 				id: "51F8CDFE8B1CCB36"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Challenge to a fight!"
+			dependencies: ["5A7277E2D1A1C51D"]
 		}
 		{
-			x: -12.0d
-			y: 0.5d
-			subtitle: "Turn Pristine Matter into loot!"
+			tasks: [{
+				id: "26F16521AC49E60B"
+				type: "item"
+				item: "dml-refabricated:loot_fabricator"
+			}]
 			description: [
 				"Loot Fabricator is the machine you will be using to turn Pristine Matter into something useful."
 				""
@@ -170,23 +173,23 @@
 				""
 				"You can input and extract items to/from the Loot Fabricator by using hoppers or pipes."
 			]
-			dependencies: ["7CB1D7180312E135"]
 			id: "22AED97627B96620"
-			tasks: [{
-				id: "26F16521AC49E60B"
-				type: "item"
-				item: "dml-refabricated:loot_fabricator"
-			}]
+			x: -12.0d
+			y: 0.5d
 			rewards: [{
 				id: "601B95CDEEBD475B"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Turn Pristine Matter into loot!"
+			dependencies: ["7CB1D7180312E135"]
 		}
 		{
-			x: -2.0d
-			y: -2.5d
-			subtitle: "Kill System Glitch, gather Matrix Fragments and craft a Glitch Ingot."
+			tasks: [{
+				id: "763F3B0C76A6CB16"
+				type: "item"
+				item: "dml-refabricated:glitch_ingot"
+			}]
 			description: [
 				"As I said before, you will be facing the System Glitch at your fight, but it is not alone!"
 				""
@@ -198,27 +201,18 @@
 				""
 				"Those ingots alone are completely useless. But maybe if you combine with a piece of netherite armor you will get something useful. Try doing it in the Smithing Table."
 			]
-			dependencies: ["01D568488C874E51"]
 			id: "3F69B97A783AC81C"
-			tasks: [{
-				id: "763F3B0C76A6CB16"
-				type: "item"
-				item: "dml-refabricated:glitch_ingot"
-			}]
+			x: -2.0d
+			y: -2.5d
 			rewards: [{
 				id: "01DD1F65D5A323BD"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Kill System Glitch, gather Matrix Fragments and craft a Glitch Ingot."
+			dependencies: ["01D568488C874E51"]
 		}
 		{
-			title: "Data Models"
-			x: -8.0d
-			y: -2.5d
-			subtitle: "Craft a Data Model of choice."
-			description: ["Data Models are chips where you will store the information of mobs you learn."]
-			dependencies: ["2EA2885C13B2C158"]
-			id: "0CCCC61B10044F46"
 			tasks: [{
 				id: "4A4F270C7B4CB954"
 				type: "item"
@@ -277,16 +271,25 @@
 					}
 				}
 			}]
+			description: ["Data Models are chips where you will store the information of mobs you learn."]
+			id: "0CCCC61B10044F46"
+			x: -8.0d
+			y: -2.5d
+			title: "Data Models"
 			rewards: [{
 				id: "1B4D0D7590B856A4"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Craft a Data Model of choice."
+			dependencies: ["2EA2885C13B2C158"]
 		}
 		{
-			x: -10.0d
-			y: 0.5d
-			subtitle: "Now that you have some Data Models that are leveled up to at least Basic tier, we can move on to the good stuff."
+			tasks: [{
+				id: "79866817A5588058"
+				type: "item"
+				item: "dmlsimulacrum:simulation_chamber"
+			}]
 			description: [
 				"Provide the Simulation Chamber with energy and place some Polymer Clay in the top right slot that has an E in it."
 				""
@@ -302,23 +305,23 @@
 				""
 				"For example, an Enderman Data Model produces Extraterrestrial Matter. Holding shift while hovering your mouse over a Data Model will tell you what kind of Data Model it is."
 			]
-			dependencies: ["7CB1D7180312E135"]
 			id: "0DEE3926C25C2221"
-			tasks: [{
-				id: "79866817A5588058"
-				type: "item"
-				item: "dmlsimulacrum:simulation_chamber"
-			}]
+			x: -10.0d
+			y: 0.5d
 			rewards: [{
 				id: "107F3399260A39C4"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Now that you have some Data Models that are leveled up to at least Basic tier, we can move on to the good stuff."
+			dependencies: ["7CB1D7180312E135"]
 		}
 		{
-			x: -11.0d
-			y: 0.5d
-			subtitle: "Upgrade your armor!"
+			tasks: [{
+				id: "195D1CB694FDCF69"
+				type: "item"
+				item: "dml-refabricated:matter_condenser"
+			}]
 			description: [
 				"Grab a bit of Pristine Matter and start filling your Matter Condenser with the armor piece you want to upgrade and the matter."
 				""
@@ -326,57 +329,54 @@
 				""
 				"The armor protection amounts will be increasing as the armor tier increases too. Soon there will be some sick extra features about that"
 			]
-			dependencies: ["7CB1D7180312E135"]
 			id: "6F9393A8015541A8"
-			tasks: [{
-				id: "195D1CB694FDCF69"
-				type: "item"
-				item: "dml-refabricated:matter_condenser"
-			}]
+			x: -11.0d
+			y: 0.5d
 			rewards: [{
 				id: "1744FE1986CFACE1"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Upgrade your armor!"
+			dependencies: ["7CB1D7180312E135"]
 		}
 		{
-			x: -11.0d
-			y: -1.0d
-			subtitle: "Craft a Soot Machine Casing."
-			dependencies: ["394DCDE468051067"]
-			id: "7CB1D7180312E135"
 			tasks: [{
 				id: "6C44B445254F46B8"
 				type: "item"
 				item: "dml-refabricated:machine_casing"
 			}]
+			id: "7CB1D7180312E135"
+			x: -11.0d
+			y: -1.0d
 			rewards: [{
 				id: "2C2031F8B50172C0"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Craft a Soot Machine Casing."
+			dependencies: ["394DCDE468051067"]
 		}
 		{
-			x: -11.0d
-			y: -2.5d
-			subtitle: "Rub your redstone on a block of coal."
+			tasks: [{
+				id: "5EEB04255651FBAE"
+				type: "item"
+				item: "dml-refabricated:soot_redstone"
+			}]
 			description: [
 				"To progress in Deep Mob Learning you will need Soot-covered Redstone. Those are created by punching redstone against a Coal Block."
 				""
 				"This is a key ingredient."
 			]
 			id: "394DCDE468051067"
-			tasks: [{
-				id: "5EEB04255651FBAE"
-				type: "item"
-				item: "dml-refabricated:soot_redstone"
-			}]
+			x: -11.0d
+			y: -2.5d
 			rewards: [{
 				id: "2BFFE5842B51C9B2"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Rub your redstone on a block of coal."
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/electricity_age.snbt
+++ b/config/ftbquests/quests/chapters/electricity_age.snbt
@@ -1,19 +1,16 @@
 {
-	id: "272EF529D7C16EE9"
-	group: "38633DD49534BFCD"
-	order_index: 3
-	filename: "electricity_age"
-	title: "Electricity Age"
-	icon: "modern_industrialization:singularity"
-	default_quest_shape: ""
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "38633DD49534BFCD"
+	id: "272EF529D7C16EE9"
+	filename: "electricity_age"
+	default_quest_shape: ""
+	icon: "modern_industrialization:singularity"
+	title: "Electricity Age"
+	order_index: 3
 	quests: [
 		{
-			title: "The Electric Age!"
-			x: -13.0d
-			y: 0.5d
-			shape: "gear"
-			subtitle: "Basics of Electricity"
+			size: 1.5d
 			description: [
 				"Electric machines work exactly the same as steam machines, except that they require electricity instead of steam and they progressively overclock recipes up to 32 EU/t."
 				""
@@ -23,15 +20,11 @@
 				""
 				"But Assemblers are very expensive at first, so bulk-crafting is key!"
 			]
-			dependencies: ["43F43FB0B9ED0818"]
-			size: 1.5d
 			id: "19E5E31614FE485E"
-			tasks: [{
-				id: "33A196551A047E54"
-				type: "item"
-				item: "modern_industrialization:analog_circuit"
-				count: 2L
-			}]
+			x: -13.0d
+			y: 0.5d
+			shape: "gear"
+			title: "The Electric Age!"
 			rewards: [
 				{
 					id: "0C7F9145B4CC4C35"
@@ -52,19 +45,25 @@
 					table_id: 13756307348121783L
 				}
 			]
+			subtitle: "Basics of Electricity"
+			dependencies: ["43F43FB0B9ED0818"]
+			tasks: [{
+				id: "33A196551A047E54"
+				type: "item"
+				item: "modern_industrialization:analog_circuit"
+				count: 2L
+			}]
 		}
 		{
-			x: -11.5d
-			y: 1.5d
-			subtitle: "The first machine you'll want to make a lot of!"
-			description: ["The Assembler allows you to automate almost all recipes, up to 3 per Assembler if you use slot locking."]
-			dependencies: ["19E5E31614FE485E"]
-			id: "79F4B68189C05A25"
 			tasks: [{
 				id: "651D4E443F87E715"
 				type: "item"
 				item: "modern_industrialization:assembler"
 			}]
+			description: ["The Assembler allows you to automate almost all recipes, up to 3 per Assembler if you use slot locking."]
+			id: "79F4B68189C05A25"
+			x: -11.5d
+			y: 1.5d
 			rewards: [
 				{
 					id: "2E44F161981497D4"
@@ -78,27 +77,10 @@
 					table_id: 13756307348121783L
 				}
 			]
+			subtitle: "The first machine you'll want to make a lot of!"
+			dependencies: ["19E5E31614FE485E"]
 		}
 		{
-			icon: "modern_industrialization:large_steam_boiler"
-			x: -11.5d
-			y: -0.5d
-			subtitle: "An upgraded version of the smaller Bronze and Steel Boilers."
-			description: [
-				"It uses fuels 8 times faster than the Furnace, but it produces 256 mb/t of Steam when fully heated. Don't forget Water or it won't work!"
-				""
-				"The main block you'll need is the Bronze Plated Bricks, but you'll also need Bronze Pipe Machine Casings and Heatproof Machine Casings."
-				""
-				"The Large Steam Boiler is comprised of one layer of Heatproof Machine Casings and three layers of Bronze Plated Bricks."
-				""
-				"The controller goes on the second layer (i.e. the first layer of Bronze Plated Bricks)."
-				""
-				"The two middle blocks are Bronze Pipe Machine Casings."
-				""
-				"Hatches must be placed on the bottom layer."
-			]
-			dependencies: ["19E5E31614FE485E"]
-			id: "2F6ED192CC3A9AF4"
 			tasks: [
 				{
 					id: "7D1063975B5EA66E"
@@ -124,17 +106,38 @@
 					count: 9L
 				}
 			]
+			description: [
+				"It uses fuels 8 times faster than the Furnace, but it produces 256 mb/t of Steam when fully heated. Don't forget Water or it won't work!"
+				""
+				"The main block you'll need is the Bronze Plated Bricks, but you'll also need Bronze Pipe Machine Casings and Heatproof Machine Casings."
+				""
+				"The Large Steam Boiler is comprised of one layer of Heatproof Machine Casings and three layers of Bronze Plated Bricks."
+				""
+				"The controller goes on the second layer (i.e. the first layer of Bronze Plated Bricks)."
+				""
+				"The two middle blocks are Bronze Pipe Machine Casings."
+				""
+				"Hatches must be placed on the bottom layer."
+			]
+			icon: "modern_industrialization:large_steam_boiler"
+			id: "2F6ED192CC3A9AF4"
+			x: -11.5d
+			y: -0.5d
 			rewards: [{
 				id: "66C0E34F6FD976C3"
 				type: "item"
 				item: "modern_industrialization:white_fluid_pipe"
 				count: 16
 			}]
+			subtitle: "An upgraded version of the smaller Bronze and Steel Boilers."
+			dependencies: ["19E5E31614FE485E"]
 		}
 		{
-			x: -11.5d
-			y: 0.5d
-			subtitle: "The Steam Turbine uses Steam to produce electricity."
+			tasks: [{
+				id: "0497A2F2D5A65B0C"
+				type: "item"
+				item: "modern_industrialization:lv_steam_turbine"
+			}]
 			description: [
 				"It converts every mb of Steam to 1 EU, up to 32 mb converted every tick."
 				""
@@ -146,13 +149,9 @@
 				""
 				"Every electric cable has a Tier which determines how many EU/t it can transfer and to which machines it can connect. Copper, Silver and Tin are LV, Cupronickel and Electrum are MV, and so on..."
 			]
-			dependencies: ["19E5E31614FE485E"]
 			id: "55ED05A197F8D24A"
-			tasks: [{
-				id: "0497A2F2D5A65B0C"
-				type: "item"
-				item: "modern_industrialization:lv_steam_turbine"
-			}]
+			x: -11.5d
+			y: 0.5d
 			rewards: [
 				{
 					id: "56B68944B996BFFC"
@@ -165,19 +164,19 @@
 					table_id: 13756307348121783L
 				}
 			]
+			subtitle: "The Steam Turbine uses Steam to produce electricity."
+			dependencies: ["19E5E31614FE485E"]
 		}
 		{
-			x: -10.0d
-			y: 0.5d
-			subtitle: "The Polarizer... polarizes stuff."
-			description: ["It doesn't have many recipes yet, but it is already useful to automate Motors!"]
-			dependencies: ["55ED05A197F8D24A"]
-			id: "5F52B24FFE2DDD86"
 			tasks: [{
 				id: "796F845AA4E8F271"
 				type: "item"
 				item: "modern_industrialization:polarizer"
 			}]
+			description: ["It doesn't have many recipes yet, but it is already useful to automate Motors!"]
+			id: "5F52B24FFE2DDD86"
+			x: -10.0d
+			y: 0.5d
 			rewards: [
 				{
 					id: "36D19E83ED7A2C1B"
@@ -191,23 +190,10 @@
 					table_id: 13756307348121783L
 				}
 			]
+			subtitle: "The Polarizer... polarizes stuff."
+			dependencies: ["55ED05A197F8D24A"]
 		}
 		{
-			icon: "modern_industrialization:electric_blast_furnace"
-			x: -8.5d
-			y: 0.5d
-			subtitle: "The electric version of the Steam Blast Furnace."
-			description: [
-				"It unlocks new recipes and like other multiblock electric machines, its overclock is bounded to 128 EU/t by default."
-				""
-				"The EBF is made of one layer of Heatproof Machine Casings, two hollow layers of Cupronickel Coils and one other layer of Heatproof Machine Casings. The controller must go on the bottom layer, and hatches on the top or bottom layer."
-				""
-				"Don't forget to add Energy Input Hatch(es) or the EBF won't have energy! The LV Energy Input Hatch will only connect to LV cables."
-				""
-				"MV Energy Input Hatches will only connect to MV cables, which can be useful if you need a ton of energy for your EBF! You can't craft them yet, but keep in mind they exist..."
-			]
-			dependencies: ["5F52B24FFE2DDD86"]
-			id: "796F33AE4A9CF30C"
 			tasks: [
 				{
 					id: "39EB9EA6FC93093F"
@@ -227,6 +213,19 @@
 					count: 16L
 				}
 			]
+			description: [
+				"It unlocks new recipes and like other multiblock electric machines, its overclock is bounded to 128 EU/t by default."
+				""
+				"The EBF is made of one layer of Heatproof Machine Casings, two hollow layers of Cupronickel Coils and one other layer of Heatproof Machine Casings. The controller must go on the bottom layer, and hatches on the top or bottom layer."
+				""
+				"Don't forget to add Energy Input Hatch(es) or the EBF won't have energy! The LV Energy Input Hatch will only connect to LV cables."
+				""
+				"MV Energy Input Hatches will only connect to MV cables, which can be useful if you need a ton of energy for your EBF! You can't craft them yet, but keep in mind they exist..."
+			]
+			icon: "modern_industrialization:electric_blast_furnace"
+			id: "796F33AE4A9CF30C"
+			x: -8.5d
+			y: 0.5d
 			rewards: [
 				{
 					id: "242165A5743BEA2A"
@@ -244,20 +243,15 @@
 					table_id: 13756307348121783L
 				}
 			]
+			subtitle: "The electric version of the Steam Blast Furnace."
+			dependencies: ["5F52B24FFE2DDD86"]
 		}
 		{
+			size: 1.2d
 			x: -7.0d
+			id: "6BEB4461CA08633F"
 			y: 0.5d
 			shape: "gear"
-			subtitle: "Advanced Electricity!"
-			dependencies: ["796F33AE4A9CF30C"]
-			size: 1.2d
-			id: "6BEB4461CA08633F"
-			tasks: [{
-				id: "36962E06671E364F"
-				type: "item"
-				item: "modern_industrialization:electronic_circuit"
-			}]
 			rewards: [
 				{
 					id: "3B9ED5E4CBECDD82"
@@ -270,40 +264,33 @@
 					table_id: 13756307348121783L
 				}
 			]
+			subtitle: "Advanced Electricity!"
+			dependencies: ["796F33AE4A9CF30C"]
+			tasks: [{
+				id: "36962E06671E364F"
+				type: "item"
+				item: "modern_industrialization:electronic_circuit"
+			}]
 		}
 		{
-			x: -2.5d
-			y: -2.0d
-			subtitle: "Will turn various fluids into their lighter parts."
-			description: ["This will be very useful for Oil Processing."]
-			dependencies: ["33BF21CF8232FD35"]
-			id: "036292964BDE4944"
 			tasks: [{
 				id: "25449DE629548BDF"
 				type: "item"
 				item: "modern_industrialization:distillery"
 			}]
+			description: ["This will be very useful for Oil Processing."]
+			id: "036292964BDE4944"
+			x: -2.5d
+			y: -2.0d
 			rewards: [{
 				id: "715875CA3ED0A56D"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Will turn various fluids into their lighter parts."
+			dependencies: ["33BF21CF8232FD35"]
 		}
 		{
-			title: "Diesel Jetpack and Tools"
-			x: -3.5d
-			y: -4.5d
-			description: [
-				"- Jetpack go brrr... The more powerful the fuel, the faster the jetpack! We recommend Rubber Boots and a Rubber Helmet..."
-				""
-				"Don't forget to activate it using the (V) keybind."
-				""
-				"> Diesel Mining Drills and Chainsaws are a nice alternative to your usual tools. Fill them with powerful fuels for fast mining speeds!"
-				""
-				"With the Diesel Mining Drill, you can toggle between §eSilk Touch§r and §9Fortune III§r with shift right-click."
-			]
-			dependencies: ["036292964BDE4944"]
-			id: "6D0310EF6A259AC8"
 			tasks: [
 				{
 					id: "67C570594E13FA80"
@@ -321,6 +308,19 @@
 					item: "modern_industrialization:diesel_jetpack"
 				}
 			]
+			description: [
+				"- Jetpack go brrr... The more powerful the fuel, the faster the jetpack! We recommend Rubber Boots and a Rubber Helmet..."
+				""
+				"Don't forget to activate it using the (V) keybind."
+				""
+				"> Diesel Mining Drills and Chainsaws are a nice alternative to your usual tools. Fill them with powerful fuels for fast mining speeds!"
+				""
+				"With the Diesel Mining Drill, you can toggle between §eSilk Touch§r and §9Fortune III§r with shift right-click."
+			]
+			id: "6D0310EF6A259AC8"
+			x: -3.5d
+			y: -4.5d
+			title: "Diesel Jetpack and Tools"
 			rewards: [
 				{
 					id: "4CF843A1EEFA60E8"
@@ -333,45 +333,31 @@
 					table_id: 13756307348121783L
 				}
 			]
+			dependencies: ["036292964BDE4944"]
 		}
 		{
+			size: 1.2d
 			x: 2.0006802721088377d
+			id: "7CE18D246F01445D"
 			y: -2.008163265306102d
 			shape: "gear"
-			subtitle: "A Digital World!"
-			dependencies: [
-				"036292964BDE4944"
-				"64BACF5B60AD2406"
-			]
-			size: 1.2d
-			id: "7CE18D246F01445D"
-			tasks: [{
-				id: "096259C009D8AFC1"
-				type: "item"
-				item: "modern_industrialization:digital_circuit"
-			}]
 			rewards: [{
 				id: "0D155806A704AA5E"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A Digital World!"
+			dependencies: [
+				"036292964BDE4944"
+				"64BACF5B60AD2406"
+			]
+			tasks: [{
+				id: "096259C009D8AFC1"
+				type: "item"
+				item: "modern_industrialization:digital_circuit"
+			}]
 		}
 		{
-			icon: "modern_industrialization:oil_drilling_rig"
-			x: -4.5d
-			y: -2.0d
-			subtitle: "A huge multiblock that can dig for Crude Oil under the bedrock using fluid pipes."
-			description: [
-				"Yes, it's an oil quarry basically. Oil processing will give you a ton of byproducts and energy!"
-				""
-				"The structure of the multiblock is made of: Steel Machine Casings, Steel Pipe Machine Casings and Chains as you can see by placing the controller and holding a Wrench."
-				""
-				"The Hatches can be replaced by Steel Machine Casings, but be sure to have at least Item Input, Fluid Output and Energy Input Hatches!"
-				""
-				"Crude Oil can be turned into various fuels and used for more efficient Rubber Sheet production."
-			]
-			dependencies: ["6BEB4461CA08633F"]
-			id: "33BF21CF8232FD35"
 			tasks: [
 				{
 					id: "26F6DB1C04F1CF93"
@@ -397,33 +383,50 @@
 					count: 18L
 				}
 			]
+			description: [
+				"Yes, it's an oil quarry basically. Oil processing will give you a ton of byproducts and energy!"
+				""
+				"The structure of the multiblock is made of: Steel Machine Casings, Steel Pipe Machine Casings and Chains as you can see by placing the controller and holding a Wrench."
+				""
+				"The Hatches can be replaced by Steel Machine Casings, but be sure to have at least Item Input, Fluid Output and Energy Input Hatches!"
+				""
+				"Crude Oil can be turned into various fuels and used for more efficient Rubber Sheet production."
+			]
+			icon: "modern_industrialization:oil_drilling_rig"
+			id: "33BF21CF8232FD35"
+			x: -4.5d
+			y: -2.0d
 			rewards: [{
 				id: "49EB8376326F1A94"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A huge multiblock that can dig for Crude Oil under the bedrock using fluid pipes."
+			dependencies: ["6BEB4461CA08633F"]
 		}
 		{
-			x: -4.5d
-			y: 0.0d
-			subtitle: "Can make items and fluids react with each other."
-			dependencies: ["6BEB4461CA08633F"]
-			id: "6B11B8A209763B36"
 			tasks: [{
 				id: "4405859846ECFE0E"
 				type: "item"
 				item: "modern_industrialization:chemical_reactor"
 			}]
+			id: "6B11B8A209763B36"
+			x: -4.5d
+			y: 0.0d
 			rewards: [{
 				id: "27A2D5918105F8D3"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Can make items and fluids react with each other."
+			dependencies: ["6BEB4461CA08633F"]
 		}
 		{
-			x: -2.5d
-			y: -4.5d
-			subtitle: "Diesel generators will only use fuel when it needs to."
+			tasks: [{
+				id: "69A5D1E45B60D2DA"
+				type: "item"
+				item: "modern_industrialization:diesel_generator"
+			}]
 			description: [
 				"Various fuels can be burned in the Diesel Generator, and you can check in REI how many EU each fuel produces."
 				""
@@ -433,45 +436,45 @@
 				""
 				"A fully heated Large Steam Boiler will roughly produce twice the amount of energy a Diesel Generator would produce using the same quantity of fuel."
 			]
-			dependencies: ["036292964BDE4944"]
 			id: "6C8E36B461895C72"
-			tasks: [{
-				id: "69A5D1E45B60D2DA"
-				type: "item"
-				item: "modern_industrialization:diesel_generator"
-			}]
+			x: -2.5d
+			y: -4.5d
 			rewards: [{
 				id: "6BF5CD2CA2398E59"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Diesel generators will only use fuel when it needs to."
+			dependencies: ["036292964BDE4944"]
 		}
 		{
-			x: 2.5d
-			y: -4.5d
-			subtitle: "Once you get some digital circuits going, make sure to build a Distillation Tower."
-			description: [
-				"The Distillery only gives you one oil processing output, but the tower gives you ONE PER LAYER!"
-				""
-				"To change the height of the Distillation Tower, right-click it with a screwdriver. This applies to other multiblocks with multiple shapes as well, such as the Kanthal tier EBF."
-			]
-			dependencies: ["7CE18D246F01445D"]
-			id: "2AE689F6495C83A6"
 			tasks: [{
 				id: "54C9073262B25D06"
 				type: "item"
 				item: "modern_industrialization:distillation_tower"
 			}]
+			description: [
+				"The Distillery only gives you one oil processing output, but the tower gives you ONE PER LAYER!"
+				""
+				"To change the height of the Distillation Tower, right-click it with a screwdriver. This applies to other multiblocks with multiple shapes as well, such as the Kanthal tier EBF."
+			]
+			id: "2AE689F6495C83A6"
+			x: 2.5d
+			y: -4.5d
 			rewards: [{
 				id: "37DD170F6A20628A"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Once you get some digital circuits going, make sure to build a Distillation Tower."
+			dependencies: ["7CE18D246F01445D"]
 		}
 		{
-			x: 3.5d
-			y: -4.5d
-			subtitle: "You can use a Heat Exchanger to recover the HP water for another cycle."
+			tasks: [{
+				id: "4223D53BFBB35DEF"
+				type: "item"
+				item: "modern_industrialization:heat_exchanger"
+			}]
 			description: [
 				"Remember that pressurizing water into HP water costs a lot of energy, but the turbine will not give it back!"
 				""
@@ -479,23 +482,35 @@
 				""
 				"Just make sure the turbines powering the Heat Exchanger have higher priority than your main power generator."
 			]
-			dependencies: ["7CE18D246F01445D"]
 			id: "7F41EEF87B3A8B84"
-			tasks: [{
-				id: "4223D53BFBB35DEF"
-				type: "item"
-				item: "modern_industrialization:heat_exchanger"
-			}]
+			x: 3.5d
+			y: -4.5d
 			rewards: [{
 				id: "2D61A6BEF9497B4E"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "You can use a Heat Exchanger to recover the HP water for another cycle."
+			dependencies: ["7CE18D246F01445D"]
 		}
 		{
-			title: "More upgrades!"
-			x: -0.5d
-			y: -4.5d
+			tasks: [
+				{
+					id: "5625CE2C5AF1194F"
+					type: "item"
+					item: "modern_industrialization:turbo_upgrade"
+				}
+				{
+					id: "69609C8483FD256B"
+					type: "item"
+					item: "modern_industrialization:crowbar"
+				}
+				{
+					id: "08B66500C8E9F4CE"
+					type: "item"
+					item: "modern_industrialization:advanced_machine_hull"
+				}
+			]
 			description: [
 				"- Overclock Upgrades"
 				""
@@ -515,65 +530,40 @@
 				""
 				"Right-click with a crowbar to remove the upgrade."
 			]
-			dependencies: ["6B522DC6845DB558"]
 			id: "65CB5CA13FBD010E"
-			tasks: [
-				{
-					id: "5625CE2C5AF1194F"
-					type: "item"
-					item: "modern_industrialization:turbo_upgrade"
-				}
-				{
-					id: "69609C8483FD256B"
-					type: "item"
-					item: "modern_industrialization:crowbar"
-				}
-				{
-					id: "08B66500C8E9F4CE"
-					type: "item"
-					item: "modern_industrialization:advanced_machine_hull"
-				}
-			]
+			x: -0.5d
+			y: -4.5d
+			title: "More upgrades!"
 			rewards: [{
 				id: "5773C6D5F5E9118A"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["6B522DC6845DB558"]
 		}
 		{
-			x: -4.5d
-			y: 2.0d
-			subtitle: "Splits items by spinning them very fast."
-			description: [
-				"You can use it to make carbon dust and unlock better recipes for steel and silicon."
-				""
-				"Before you can get your hands on Upgrades, you should make multiple of these, because Carbon production is slow."
-			]
-			dependencies: ["6BEB4461CA08633F"]
-			id: "693E05A909195578"
 			tasks: [{
 				id: "68D837AA6DE85D6F"
 				type: "item"
 				item: "modern_industrialization:centrifuge"
 			}]
+			description: [
+				"You can use it to make carbon dust and unlock better recipes for steel and silicon."
+				""
+				"Before you can get your hands on Upgrades, you should make multiple of these, because Carbon production is slow."
+			]
+			id: "693E05A909195578"
+			x: -4.5d
+			y: 2.0d
 			rewards: [{
 				id: "030957C1C31F31A1"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Splits items by spinning them very fast."
+			dependencies: ["6BEB4461CA08633F"]
 		}
 		{
-			icon: "modern_industrialization:electric_quarry"
-			x: -7.0d
-			y: -1.5d
-			subtitle: "The electric equivalent of the Steam Quarry."
-			description: [
-				"Provide it with items and energy, and watch your resources GO BRRR!"
-				""
-				"Its structure is exactly the same as the Steam Quarry's."
-			]
-			dependencies: ["6BEB4461CA08633F"]
-			id: "3DC21B6F47A253E4"
 			tasks: [
 				{
 					id: "1004292AA09E90E0"
@@ -599,97 +589,108 @@
 					count: 4L
 				}
 			]
+			description: [
+				"Provide it with items and energy, and watch your resources GO BRRR!"
+				""
+				"Its structure is exactly the same as the Steam Quarry's."
+			]
+			icon: "modern_industrialization:electric_quarry"
+			id: "3DC21B6F47A253E4"
+			x: -7.0d
+			y: -1.5d
 			rewards: [{
 				id: "35A961D0CC2B8B06"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The electric equivalent of the Steam Quarry."
+			dependencies: ["6BEB4461CA08633F"]
 		}
 		{
-			x: -7.0d
-			y: -3.0d
-			subtitle: "Used in the quarry. Check REI for outputs."
-			description: [
-				"Made from gold, it's quite fragile."
-				""
-				"But you can use this to obtain Ancient Debris automatically!"
-			]
-			dependencies: ["3DC21B6F47A253E4"]
-			id: "381693770EF21108"
 			tasks: [{
 				id: "7B1FED6BDC3FB1FA"
 				type: "item"
 				item: "modern_industrialization:gold_drill"
 			}]
+			description: [
+				"Made from gold, it's quite fragile."
+				""
+				"But you can use this to obtain Ancient Debris automatically!"
+			]
+			id: "381693770EF21108"
+			x: -7.0d
+			y: -3.0d
 			rewards: [{
 				id: "6F9BE34823759C39"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			x: -8.0d
-			y: -3.0d
 			subtitle: "Used in the quarry. Check REI for outputs."
 			dependencies: ["3DC21B6F47A253E4"]
-			id: "01BBE636EBB71416"
+		}
+		{
 			tasks: [{
 				id: "6A35321C6F3D7D64"
 				type: "item"
 				item: "modern_industrialization:stainless_steel_drill"
 			}]
+			id: "01BBE636EBB71416"
+			x: -8.0d
+			y: -3.0d
 			rewards: [{
 				id: "2DC1DBF9976DB237"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			x: -6.0d
-			y: -3.0d
 			subtitle: "Used in the quarry. Check REI for outputs."
 			dependencies: ["3DC21B6F47A253E4"]
-			id: "04B4FB69D88D1C76"
+		}
+		{
 			tasks: [{
 				id: "758EB0D2CB85F803"
 				type: "item"
 				item: "modern_industrialization:steel_drill"
 			}]
+			id: "04B4FB69D88D1C76"
+			x: -6.0d
+			y: -3.0d
 			rewards: [{
 				id: "7C21A5542D8CAE35"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Used in the quarry. Check REI for outputs."
+			dependencies: ["3DC21B6F47A253E4"]
 		}
 		{
-			title: "Upgrades!"
-			x: -1.5d
-			y: -4.5d
-			subtitle: "You are almost Prepared!"
-			description: ["Now that your Into the Start of MV, you can start working on your oil processing and start working on Basic Upgrades that you can easily then turn into Advanced Upgrades!"]
-			dependencies: ["036292964BDE4944"]
-			id: "6B522DC6845DB558"
 			tasks: [{
 				id: "71B5428A94930A18"
 				type: "item"
 				item: "modern_industrialization:advanced_upgrade"
 			}]
+			description: ["Now that your Into the Start of MV, you can start working on your oil processing and start working on Basic Upgrades that you can easily then turn into Advanced Upgrades!"]
+			id: "6B522DC6845DB558"
+			x: -1.5d
+			y: -4.5d
+			title: "Upgrades!"
 			rewards: [{
 				id: "5F5B4F44466C5F14"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "You are almost Prepared!"
+			dependencies: ["036292964BDE4944"]
 		}
 		{
-			x: -4.5d
-			y: -1.0d
-			dependencies: ["6BEB4461CA08633F"]
-			id: "7D4B8F84394B1B35"
 			tasks: [{
 				id: "16E814CBBEE5F8AB"
 				type: "item"
 				item: "modern_industrialization:mv_steam_turbine"
 			}]
+			dependencies: ["6BEB4461CA08633F"]
+			id: "7D4B8F84394B1B35"
+			y: -1.0d
+			x: -4.5d
 			rewards: [{
 				id: "0C55BAA10ED787D7"
 				type: "loot"
@@ -697,27 +698,29 @@
 			}]
 		}
 		{
-			x: 0.5d
-			y: -4.5d
-			subtitle: "Another option for small setups is to use an HV steam turbine."
-			description: ["Like other HV generators, it will produce 512 EU/t. This one will only accept regular steam."]
-			dependencies: ["7CE18D246F01445D"]
-			id: "2B0219B675E3820F"
 			tasks: [{
 				id: "54B31CE72767D4C6"
 				type: "item"
 				item: "modern_industrialization:hv_steam_turbine"
 			}]
+			description: ["Like other HV generators, it will produce 512 EU/t. This one will only accept regular steam."]
+			id: "2B0219B675E3820F"
+			x: 0.5d
+			y: -4.5d
 			rewards: [{
 				id: "25B3E34D19921D92"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Another option for small setups is to use an HV steam turbine."
+			dependencies: ["7CE18D246F01445D"]
 		}
 		{
-			x: 1.5d
-			y: -4.5d
-			subtitle: "Keep in mind you can use a Turbo Diesel Generator for compact HV power generation."
+			tasks: [{
+				id: "438923113D0A1141"
+				type: "item"
+				item: "modern_industrialization:turbo_diesel_generator"
+			}]
 			description: [
 				"As you might expect, it produces up to 512 EU/t."
 				""
@@ -725,26 +728,18 @@
 				""
 				"Once you have access to processing units and highly advanced machine hulls, considering making a few Large Diesel Generators. Each of these bad boys will turn fuel into EU, up to 16384 EU/t!"
 			]
-			dependencies: ["7CE18D246F01445D"]
 			id: "715CEF4FB78310FF"
-			tasks: [{
-				id: "438923113D0A1141"
-				type: "item"
-				item: "modern_industrialization:turbo_diesel_generator"
-			}]
+			x: 1.5d
+			y: -4.5d
 			rewards: [{
 				id: "139DE6C871EC83D7"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Keep in mind you can use a Turbo Diesel Generator for compact HV power generation."
+			dependencies: ["7CE18D246F01445D"]
 		}
 		{
-			icon: "modern_industrialization:vacuum_freezer"
-			x: -4.5d
-			y: 1.0d
-			subtitle: "You can check the base materials with REI, and the exact shape with a wrench!"
-			dependencies: ["6BEB4461CA08633F"]
-			id: "0A0931D04AE50D4B"
 			tasks: [
 				{
 					id: "2D292B2E8511A84D"
@@ -758,76 +753,82 @@
 					count: 33L
 				}
 			]
+			icon: "modern_industrialization:vacuum_freezer"
+			id: "0A0931D04AE50D4B"
+			x: -4.5d
+			y: 1.0d
 			rewards: [{
 				id: "59BC7A734B41939A"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "You can check the base materials with REI, and the exact shape with a wrench!"
+			dependencies: ["6BEB4461CA08633F"]
 		}
 		{
-			x: -5.0d
-			y: 3.0d
-			subtitle: "Can split materials into their different parts using strong electric currents."
-			dependencies: ["6BEB4461CA08633F"]
-			id: "68BD457258EC8CBF"
 			tasks: [{
 				id: "4ECD4D66C0DAB6AC"
 				type: "item"
 				item: "modern_industrialization:electrolyzer"
 			}]
+			id: "68BD457258EC8CBF"
+			x: -5.0d
+			y: 3.0d
 			rewards: [{
 				id: "27BEE8715C458319"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Can split materials into their different parts using strong electric currents."
+			dependencies: ["6BEB4461CA08633F"]
 		}
 		{
-			x: -2.5d
-			y: 1.0d
-			subtitle: "The next material you will want a large quantity of."
-			description: ["Smelting stainless steel dust in an EBF will give you hot ingots, which you can cool back into regular ingots with a Vacuum Freezer."]
-			dependencies: ["0A0931D04AE50D4B"]
-			id: "64BACF5B60AD2406"
 			tasks: [{
 				id: "323EFEE7EBA4E2AE"
 				type: "item"
 				item: "modern_industrialization:stainless_steel_ingot"
 			}]
+			description: ["Smelting stainless steel dust in an EBF will give you hot ingots, which you can cool back into regular ingots with a Vacuum Freezer."]
+			id: "64BACF5B60AD2406"
+			x: -2.5d
+			y: 1.0d
 			rewards: [{
 				id: "32987C89A8901696"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The next material you will want a large quantity of."
+			dependencies: ["0A0931D04AE50D4B"]
 		}
 		{
-			x: 0.5d
-			y: 1.0d
-			subtitle: "Don't Screw Yourself!"
-			description: ["The Screwdriver is very Important to increase certain muiltiblock structures. Just Right Click the Main Machine Block and it will increase its size. "]
-			dependencies: ["64BACF5B60AD2406"]
-			id: "49350931282F3BF5"
 			tasks: [{
 				id: "12CA87F780A34D37"
 				type: "item"
 				item: "modern_industrialization:screwdriver"
 			}]
+			description: ["The Screwdriver is very Important to increase certain muiltiblock structures. Just Right Click the Main Machine Block and it will increase its size. "]
+			id: "49350931282F3BF5"
+			x: 0.5d
+			y: 1.0d
 			rewards: [{
 				id: "1C4C438B1ECE028B"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Don't Screw Yourself!"
+			dependencies: ["64BACF5B60AD2406"]
 		}
 		{
-			x: 2.0d
-			y: 1.0d
-			dependencies: ["49350931282F3BF5"]
-			id: "6B15091EC1B119B0"
 			tasks: [{
 				id: "2BD708AAF08C5905"
 				type: "item"
 				item: "modern_industrialization:kanthal_coil"
 				count: 16L
 			}]
+			dependencies: ["49350931282F3BF5"]
+			id: "6B15091EC1B119B0"
+			y: 1.0d
+			x: 2.0d
 			rewards: [{
 				id: "6DFD4B7A898CF0B1"
 				type: "loot"
@@ -835,15 +836,15 @@
 			}]
 		}
 		{
-			x: 5.5d
-			y: 1.0d
-			dependencies: ["6B15091EC1B119B0"]
-			id: "7D3D156BE9C9E150"
 			tasks: [{
 				id: "040031047A05E0AE"
 				type: "item"
 				item: "modern_industrialization:titanium_ingot"
 			}]
+			dependencies: ["6B15091EC1B119B0"]
+			id: "7D3D156BE9C9E150"
+			y: 1.0d
+			x: 5.5d
 			rewards: [{
 				id: "6295E4B97FA674C8"
 				type: "loot"
@@ -851,18 +852,18 @@
 			}]
 		}
 		{
-			x: 2.0d
-			y: -0.5d
-			dependencies: [
-				"6B15091EC1B119B0"
-				"7CE18D246F01445D"
-			]
-			id: "5310B93F2821826A"
 			tasks: [{
 				id: "5D18FA4D68318732"
 				type: "item"
 				item: "modern_industrialization:processing_unit"
 			}]
+			dependencies: [
+				"6B15091EC1B119B0"
+				"7CE18D246F01445D"
+			]
+			id: "5310B93F2821826A"
+			y: -0.5d
+			x: 2.0d
 			rewards: [{
 				id: "10D62CE7BBB003E8"
 				type: "loot"
@@ -870,32 +871,32 @@
 			}]
 		}
 		{
-			x: 7.5d
-			y: 0.0d
-			subtitle: "Obtain this using an Electric Quarry with Titanium Drills or an Extractinator."
-			dependencies: ["7D3D156BE9C9E150"]
-			id: "6B05C72FF31E104D"
 			tasks: [{
 				id: "7103DFB1F1EF3828"
 				type: "item"
 				item: "modern_industrialization:raw_iridium"
 			}]
+			id: "6B05C72FF31E104D"
+			x: 7.5d
+			y: 0.0d
 			rewards: [{
 				id: "60C654118A8A98E8"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Obtain this using an Electric Quarry with Titanium Drills or an Extractinator."
+			dependencies: ["7D3D156BE9C9E150"]
 		}
 		{
-			x: 7.5d
-			y: 1.0d
-			dependencies: ["7D3D156BE9C9E150"]
-			id: "1EACE9E49BA4B753"
 			tasks: [{
 				id: "072C3C5C4355E8DF"
 				type: "item"
 				item: "modern_industrialization:blastproof_alloy_plate"
 			}]
+			dependencies: ["7D3D156BE9C9E150"]
+			id: "1EACE9E49BA4B753"
+			y: 1.0d
+			x: 7.5d
 			rewards: [{
 				id: "58579E7BEFA7FA83"
 				type: "loot"
@@ -903,15 +904,6 @@
 			}]
 		}
 		{
-			icon: "modern_industrialization:pressurizer"
-			x: 5.5d
-			y: -2.0d
-			subtitle: "A new multiblock made of titanium that can turn water into HP (high pressure) water, steam into HP steam, and the other way around."
-			dependencies: [
-				"7D3D156BE9C9E150"
-				"7CE18D246F01445D"
-			]
-			id: "46319F2AE2F90532"
 			tasks: [
 				{
 					id: "34D13E49CD76D0E5"
@@ -931,22 +923,31 @@
 					count: 9L
 				}
 			]
+			icon: "modern_industrialization:pressurizer"
+			id: "46319F2AE2F90532"
+			x: 5.5d
+			y: -2.0d
 			rewards: [{
 				id: "704D05C0FD5AE2DE"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A new multiblock made of titanium that can turn water into HP (high pressure) water, steam into HP steam, and the other way around."
+			dependencies: [
+				"7D3D156BE9C9E150"
+				"7CE18D246F01445D"
+			]
 		}
 		{
-			x: 9.5d
-			y: 0.0d
-			dependencies: ["6B05C72FF31E104D"]
-			id: "18949581A0F3E28B"
 			tasks: [{
 				id: "119D5B764A8F7E09"
 				type: "item"
 				item: "modern_industrialization:superconductor_cable"
 			}]
+			dependencies: ["6B05C72FF31E104D"]
+			id: "18949581A0F3E28B"
+			y: 0.0d
+			x: 9.5d
 			rewards: [{
 				id: "4AED232043169928"
 				type: "loot"
@@ -954,39 +955,28 @@
 			}]
 		}
 		{
-			x: 11.0d
-			y: -0.5d
-			subtitle: "Uses advanced superconductor technology to invert the gravitational field around the player wearing it."
-			description: [
-				"It uses EU, and can be charged by right-clicking a block that can output energy."
-				""
-				"Note that the current GSP technology grants fly and prevents fall damage, but it does not protected against other kinds of damage."
-			]
-			dependencies: ["18949581A0F3E28B"]
-			id: "6C1822FED0613FAF"
 			tasks: [{
 				id: "4AEAA8FA55EA9B82"
 				type: "item"
 				item: "modern_industrialization:gravichestplate"
 			}]
+			description: [
+				"It uses EU, and can be charged by right-clicking a block that can output energy."
+				""
+				"Note that the current GSP technology grants fly and prevents fall damage, but it does not protected against other kinds of damage."
+			]
+			id: "6C1822FED0613FAF"
+			x: 11.0d
+			y: -0.5d
 			rewards: [{
 				id: "2A2212FD1CFE5243"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Uses advanced superconductor technology to invert the gravitational field around the player wearing it."
+			dependencies: ["18949581A0F3E28B"]
 		}
 		{
-			icon: "modern_industrialization:implosion_compressor"
-			x: 9.5d
-			y: 1.0d
-			subtitle: "Using Industrial TNT, the Implosion Compressor is able to compress dust and ingots of the most resistant materials."
-			description: [
-				"This includes Tungsten, Blastproof Alloy, Beryllium - these materials are very important for nuclear fission - and Diamonds at last!"
-				""
-				"Hopefully you have learned to check every REI recipe by now, so you should easily find that Blastproof Mixed Ingots and Tungsten Nuggets can be made with a Compressor... until you have your first Implosion Compressor of course!"
-			]
-			dependencies: ["1EACE9E49BA4B753"]
-			id: "0F7CE2BA2A295A4D"
 			tasks: [
 				{
 					id: "459C20F94BC31393"
@@ -1006,22 +996,33 @@
 					count: 17L
 				}
 			]
+			description: [
+				"This includes Tungsten, Blastproof Alloy, Beryllium - these materials are very important for nuclear fission - and Diamonds at last!"
+				""
+				"Hopefully you have learned to check every REI recipe by now, so you should easily find that Blastproof Mixed Ingots and Tungsten Nuggets can be made with a Compressor... until you have your first Implosion Compressor of course!"
+			]
+			icon: "modern_industrialization:implosion_compressor"
+			id: "0F7CE2BA2A295A4D"
+			x: 9.5d
+			y: 1.0d
 			rewards: [{
 				id: "72B642876E498FE0"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Using Industrial TNT, the Implosion Compressor is able to compress dust and ingots of the most resistant materials."
+			dependencies: ["1EACE9E49BA4B753"]
 		}
 		{
-			x: 11.0d
-			y: 0.5d
-			dependencies: ["0F7CE2BA2A295A4D"]
-			id: "46D1B0C583A57B12"
 			tasks: [{
 				id: "5E67F55373049C23"
 				type: "item"
 				item: "modern_industrialization:mixed_ingot_iridium"
 			}]
+			dependencies: ["0F7CE2BA2A295A4D"]
+			id: "46D1B0C583A57B12"
+			y: 0.5d
+			x: 11.0d
 			rewards: [{
 				id: "4B78044EDEFCD8D7"
 				type: "loot"
@@ -1029,15 +1030,15 @@
 			}]
 		}
 		{
-			x: 12.5d
-			y: 0.5d
-			dependencies: ["46D1B0C583A57B12"]
-			id: "363455215C23E84E"
 			tasks: [{
 				id: "7E4D849D6F611B94"
 				type: "item"
 				item: "modern_industrialization:quantum_circuit"
 			}]
+			dependencies: ["46D1B0C583A57B12"]
+			id: "363455215C23E84E"
+			y: 0.5d
+			x: 12.5d
 			rewards: [{
 				id: "0BEC20C9D3E3FA0D"
 				type: "loot"
@@ -1045,34 +1046,23 @@
 			}]
 		}
 		{
-			x: 12.0d
-			y: -1.0d
-			subtitle: "The most powerful machine upgrade ever. Have a look for yourself."
-			dependencies: ["363455215C23E84E"]
-			id: "4847BA675A04852F"
 			tasks: [{
 				id: "4CD547671372F659"
 				type: "item"
 				item: "modern_industrialization:quantum_upgrade"
 			}]
+			id: "4847BA675A04852F"
+			x: 12.0d
+			y: -1.0d
 			rewards: [{
 				id: "284AB7D05FCF1B41"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The most powerful machine upgrade ever. Have a look for yourself."
+			dependencies: ["363455215C23E84E"]
 		}
 		{
-			icon: "modern_industrialization:fusion_reactor"
-			x: 14.0d
-			y: 0.5d
-			subtitle: "The Fusion Reactor is the ultimate energy source!"
-			description: [
-				"It can combine Deuterium, Tritium, and/or Helium-3 into Helium Plasma, the most powerful fuel in the game!"
-				""
-				"However, it requires a large amount of energy to ignite the reaction."
-			]
-			dependencies: ["363455215C23E84E"]
-			id: "208DE0E29C636F41"
 			tasks: [
 				{
 					id: "3F8F140654BCBDCA"
@@ -1092,19 +1082,24 @@
 					count: 203L
 				}
 			]
+			description: [
+				"It can combine Deuterium, Tritium, and/or Helium-3 into Helium Plasma, the most powerful fuel in the game!"
+				""
+				"However, it requires a large amount of energy to ignite the reaction."
+			]
+			icon: "modern_industrialization:fusion_reactor"
+			id: "208DE0E29C636F41"
+			x: 14.0d
+			y: 0.5d
 			rewards: [{
 				id: "5BA1266B129C0A12"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The Fusion Reactor is the ultimate energy source!"
+			dependencies: ["363455215C23E84E"]
 		}
 		{
-			x: 15.5d
-			y: 0.5d
-			subtitle: "Turns Helium Plasma into EU, at the rate of 100 kEU per millibucket."
-			description: ["Its maximum production rate is roughly 1 MEU/t."]
-			dependencies: ["208DE0E29C636F41"]
-			id: "370EE225E8140570"
 			tasks: [
 				{
 					id: "414FC59A3998C675"
@@ -1124,16 +1119,38 @@
 					count: 17L
 				}
 			]
+			description: ["Its maximum production rate is roughly 1 MEU/t."]
+			id: "370EE225E8140570"
+			x: 15.5d
+			y: 0.5d
 			rewards: [{
 				id: "62C30F884D4BFEED"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Turns Helium Plasma into EU, at the rate of 100 kEU per millibucket."
+			dependencies: ["208DE0E29C636F41"]
 		}
 		{
-			x: 11.0d
-			y: 1.5d
-			subtitle: "A large multiblock whose purpose is to generate massive amounts of energy by consuming nuclear fuel."
+			tasks: [
+				{
+					id: "6539BC5A7D008ABE"
+					type: "item"
+					item: "modern_industrialization:nuclear_reactor"
+				}
+				{
+					id: "453E60CB97E09F53"
+					type: "item"
+					item: "modern_industrialization:nuclear_alloy_machine_casing_pipe"
+					count: 27L
+				}
+				{
+					id: "6A65032810E039AA"
+					type: "item"
+					item: "modern_industrialization:nuclear_casing"
+					count: 77L
+				}
+			]
 			description: [
 				"It can produce 100s of times more EU/t than diesel. It comes in several sizes from small to large."
 				""
@@ -1163,78 +1180,62 @@
 				""
 				"The same thing happens for fluids: a bit of fluid is transformed after each neutron absorption. This can be used to mass produce useful isotopes like deuterium and tritium. In both cases, the outcome is shown in REI."
 			]
-			dependencies: ["0F7CE2BA2A295A4D"]
 			id: "03896D148D7B4E3B"
-			tasks: [
-				{
-					id: "6539BC5A7D008ABE"
-					type: "item"
-					item: "modern_industrialization:nuclear_reactor"
-				}
-				{
-					id: "453E60CB97E09F53"
-					type: "item"
-					item: "modern_industrialization:nuclear_alloy_machine_casing_pipe"
-					count: 27L
-				}
-				{
-					id: "6A65032810E039AA"
-					type: "item"
-					item: "modern_industrialization:nuclear_casing"
-					count: 77L
-				}
-			]
+			x: 11.0d
+			y: 1.5d
 			rewards: [{
 				id: "129DB4B4FFE26E14"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A large multiblock whose purpose is to generate massive amounts of energy by consuming nuclear fuel."
+			dependencies: ["0F7CE2BA2A295A4D"]
 		}
 		{
-			x: 12.5d
-			y: 1.5d
-			subtitle: "Does it work?"
-			dependencies: ["03896D148D7B4E3B"]
-			id: "04FAF93691F0BD9C"
 			tasks: [{
 				id: "562F6128B9E139A8"
 				type: "item"
 				item: "modern_industrialization:nuke"
 			}]
+			id: "04FAF93691F0BD9C"
+			x: 12.5d
+			y: 1.5d
 			rewards: [{
 				id: "251F9B88A53BD193"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Does it work?"
+			dependencies: ["03896D148D7B4E3B"]
 		}
 		{
-			x: 14.0d
-			y: 1.5d
-			subtitle: "What happens when scientists try to build a miniature black hole in their lab?"
-			description: ["The Singularity is the answer: this immensely powerful ball of matter has very useful quantum physics applications with the proper stabilizing materials."]
-			dependencies: ["04FAF93691F0BD9C"]
-			id: "6314525E36DEA54B"
 			tasks: [{
 				id: "1A5C0F0D73190307"
 				type: "item"
 				item: "modern_industrialization:singularity"
 			}]
+			description: ["The Singularity is the answer: this immensely powerful ball of matter has very useful quantum physics applications with the proper stabilizing materials."]
+			id: "6314525E36DEA54B"
+			x: 14.0d
+			y: 1.5d
 			rewards: [{
 				id: "6220D6964E84DF80"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "What happens when scientists try to build a miniature black hole in their lab?"
+			dependencies: ["04FAF93691F0BD9C"]
 		}
 		{
-			x: 4.0d
-			y: -0.5d
-			dependencies: ["5310B93F2821826A"]
-			id: "60A05C52ACCBE35D"
 			tasks: [{
 				id: "537CE70D027A8B77"
 				type: "item"
 				item: "modern_industrialization:highly_advanced_upgrade"
 			}]
+			dependencies: ["5310B93F2821826A"]
+			id: "60A05C52ACCBE35D"
+			y: -0.5d
+			x: 4.0d
 			rewards: [{
 				id: "2FFAE69D34EB05DB"
 				type: "loot"
@@ -1242,51 +1243,49 @@
 			}]
 		}
 		{
-			x: -4.5d
-			y: -3.0d
-			subtitle: "Used in the quarry. Check REI for outputs."
-			dependencies: ["33BF21CF8232FD35"]
-			id: "419F7B74E30C2AF4"
 			tasks: [{
 				id: "5F35CE6C3C6BAEF9"
 				type: "item"
 				item: "modern_industrialization:aluminum_drill"
 			}]
+			id: "419F7B74E30C2AF4"
+			x: -4.5d
+			y: -3.0d
 			rewards: [{
 				id: "29DCA64EF4A010A8"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Used in the quarry. Check REI for outputs."
+			dependencies: ["33BF21CF8232FD35"]
 		}
 		{
-			x: 7.5d
-			y: 2.0d
-			subtitle: "Used in the quarry. Check REI for outputs."
-			dependencies: ["7D3D156BE9C9E150"]
-			id: "24535DA01189CC75"
 			tasks: [{
 				id: "6448D47D73DD3726"
 				type: "item"
 				item: "modern_industrialization:titanium_drill"
 			}]
+			id: "24535DA01189CC75"
+			x: 7.5d
+			y: 2.0d
 			rewards: [{
 				id: "296D56D21B0D054D"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Used in the quarry. Check REI for outputs."
+			dependencies: ["7D3D156BE9C9E150"]
 		}
 		{
-			x: -8.5d
-			y: 2.0d
-			subtitle: "A Giant Inlet? "
-			description: ["Now that were getting into Electric Muiltiblock Structures you will start using Energy Hatches. You can upgrades the Hatches to other tiers as you wish."]
-			dependencies: ["796F33AE4A9CF30C"]
-			id: "1B0A4271FCBD581F"
 			tasks: [{
 				id: "13C4EB4423DBF2B5"
 				type: "item"
 				item: "modern_industrialization:lv_energy_input_hatch"
 			}]
+			description: ["Now that were getting into Electric Muiltiblock Structures you will start using Energy Hatches. You can upgrades the Hatches to other tiers as you wish."]
+			id: "1B0A4271FCBD581F"
+			x: -8.5d
+			y: 2.0d
 			rewards: [
 				{
 					id: "0CFB0E3E504A70F7"
@@ -1299,12 +1298,15 @@
 					table_id: 13756307348121783L
 				}
 			]
+			subtitle: "A Giant Inlet? "
+			dependencies: ["796F33AE4A9CF30C"]
 		}
 		{
-			title: "Energy Transfer"
-			x: -13.0d
-			y: 2.5d
-			subtitle: "Cable networks have limitations on the amount of energy they will pull into the network depending on tier."
+			tasks: [{
+				id: "2E9730BA35730C4B"
+				type: "item"
+				item: "modern_industrialization:tin_cable"
+			}]
 			description: [
 				"256 EU/t for LV cables, 1024 EU/t for MV cables and 8192 EU/t for HV cables."
 				""
@@ -1316,63 +1318,64 @@
 				""
 				"As you would expect, an X to Y Transformer will connect to Y cables on its output side and to X cables on its 5 other sides."
 			]
-			dependencies: ["19E5E31614FE485E"]
 			id: "4DCFE7721417E669"
-			tasks: [{
-				id: "2E9730BA35730C4B"
-				type: "item"
-				item: "modern_industrialization:tin_cable"
-			}]
+			x: -13.0d
+			y: 2.5d
+			title: "Energy Transfer"
 			rewards: [{
 				id: "7ABBD7E8207C36A2"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Cable networks have limitations on the amount of energy they will pull into the network depending on tier."
+			dependencies: ["19E5E31614FE485E"]
 		}
 		{
-			x: -7.0d
-			y: 3.5d
-			subtitle: "A better and bigger Large Steam Boiler!"
-			description: ["This advanced version can produce up to 1024 mb/t of steam!"]
-			dependencies: ["6BEB4461CA08633F"]
-			id: "31BCEF301071F67C"
 			tasks: [{
 				id: "5A4042280D8835FB"
 				type: "item"
 				item: "modern_industrialization:advanced_large_steam_boiler"
 			}]
+			description: ["This advanced version can produce up to 1024 mb/t of steam!"]
+			id: "31BCEF301071F67C"
+			x: -7.0d
+			y: 3.5d
 			rewards: [{
 				id: "3018FE391FB1338D"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A better and bigger Large Steam Boiler!"
+			dependencies: ["6BEB4461CA08633F"]
 		}
 		{
-			x: -6.0d
-			y: 3.5d
-			subtitle: "It's self-explainatory."
-			description: [
-				"Pump items from above or side, get outputs from below!"
-				""
-				"Check REI for compatible blocks which Extractinator can process."
-			]
-			dependencies: ["6BEB4461CA08633F"]
-			id: "1116AFB4A0475F4F"
 			tasks: [{
 				id: "0A3E83D3D509BFBE"
 				type: "item"
 				item: "the_extractinator:extractinator"
 			}]
+			description: [
+				"Pump items from above or side, get outputs from below!"
+				""
+				"Check REI for compatible blocks which Extractinator can process."
+			]
+			id: "1116AFB4A0475F4F"
+			x: -6.0d
+			y: 3.5d
 			rewards: [{
 				id: "67C61B4CC065BA9C"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "It's self-explainatory."
+			dependencies: ["6BEB4461CA08633F"]
 		}
 		{
-			x: -11.5d
-			y: 2.5d
-			subtitle: "Early-game 3x3 §eSilk Touch§r Drill."
+			tasks: [{
+				id: "4BCB31C3818DC3D7"
+				type: "item"
+				item: "modern_industrialization:steam_mining_drill"
+			}]
 			description: [
 				"The Steam Mining Drill can mine 3x3 blocks at the time, perfect as an early-game AoE Tool!"
 				""
@@ -1382,13 +1385,9 @@
 				""
 				"The fuel will be consumed slowly when you mine."
 			]
-			dependencies: ["79F4B68189C05A25"]
 			id: "70CD9F0D26A75E13"
-			tasks: [{
-				id: "4BCB31C3818DC3D7"
-				type: "item"
-				item: "modern_industrialization:steam_mining_drill"
-			}]
+			x: -11.5d
+			y: 2.5d
 			rewards: [
 				{
 					id: "77CB2BB7884957A3"
@@ -1402,92 +1401,93 @@
 					count: 16
 				}
 			]
+			subtitle: "Early-game 3x3 §eSilk Touch§r Drill."
+			dependencies: ["79F4B68189C05A25"]
 		}
 		{
-			x: -10.0d
-			y: 1.5d
-			subtitle: "A Gate to other Tech Mods opens up!"
-			description: [
-				"Using an Assembler, you can make your first Basic Machine Frames!"
-				""
-				"These are integral for tech mods such as Tech Reborn, Industrial Revolution and power generation Mods."
-			]
-			dependencies: ["79F4B68189C05A25"]
-			id: "70BA43AC7648FF65"
 			tasks: [{
 				id: "726E8850C01D0A5C"
 				type: "item"
 				item: "techreborn:basic_machine_frame"
 			}]
+			description: [
+				"Using an Assembler, you can make your first Basic Machine Frames!"
+				""
+				"These are integral for tech mods such as Tech Reborn, Industrial Revolution and power generation Mods."
+			]
+			id: "70BA43AC7648FF65"
+			x: -10.0d
+			y: 1.5d
+			subtitle: "A Gate to other Tech Mods opens up!"
+			dependencies: ["79F4B68189C05A25"]
 		}
 		{
-			x: -2.5d
-			y: 3.0d
-			subtitle: "Either use Extractinator or get it from Mozanite Processing."
-			description: ["A necessary component for Cadmium Batteries!"]
-			hide_dependency_lines: true
-			dependencies: [
-				"1116AFB4A0475F4F"
-				"01BBE636EBB71416"
-			]
-			dependency_requirement: "one_completed"
-			id: "69DC40B24C76B53A"
 			tasks: [{
 				id: "5A1D6009D16EC896"
 				type: "item"
 				item: "modern_industrialization:cadmium_dust"
 			}]
+			description: ["A necessary component for Cadmium Batteries!"]
+			id: "69DC40B24C76B53A"
+			x: -2.5d
+			y: 3.0d
+			dependency_requirement: "one_completed"
+			subtitle: "Either use Extractinator or get it from Mozanite Processing."
+			dependencies: [
+				"1116AFB4A0475F4F"
+				"01BBE636EBB71416"
+			]
+			hide_dependency_lines: true
 		}
 		{
-			x: -1.0d
-			y: 3.0d
-			subtitle: "With the Cadmium Batteries, you can craft Building Gadgets and EV Machine Hulls."
-			dependencies: ["69DC40B24C76B53A"]
-			id: "6D844CA6CF326DFC"
 			tasks: [{
 				id: "0E0BD01A03DB74D9"
 				type: "item"
 				item: "modern_industrialization:cadmium_battery"
 			}]
+			dependencies: ["69DC40B24C76B53A"]
+			subtitle: "With the Cadmium Batteries, you can craft Building Gadgets and EV Machine Hulls."
+			id: "6D844CA6CF326DFC"
+			y: 3.0d
+			x: -1.0d
 		}
 		{
-			title: "Spatial Harvesters Available!"
+			tasks: [{
+				type: "item"
+				id: "6272FE87544B5F72"
+				item: "modern_industrialization:quantum_circuit"
+				icon: "spatialharvesters:casing"
+				title: "Spatial Harvesters"
+			}]
+			id: "02B84C908EA803E5"
 			x: 13.0d
 			y: -1.0d
+			title: "Spatial Harvesters Available!"
 			subtitle: "A Gate to Spatial Harvesters is now open!"
 			dependencies: ["363455215C23E84E"]
-			id: "02B84C908EA803E5"
-			tasks: [{
-				id: "6272FE87544B5F72"
-				type: "item"
-				title: "Spatial Harvesters"
-				icon: "spatialharvesters:casing"
-				item: "modern_industrialization:quantum_circuit"
-			}]
 		}
 		{
-			x: 9.5d
-			y: -1.0d
-			subtitle: "EU through ME Network!"
-			description: [
-				"You can *only* connect Superconductor Cables to this tunnel."
-				""
-				"Just like Energy P2P Tunnel, the ME Network will draw 5% tax on transfered energy."
-			]
-			dependencies: ["18949581A0F3E28B"]
-			id: "39D6CB2B3FDC4936"
 			tasks: [{
 				id: "46A9180718528137"
 				type: "item"
 				item: "modern_industrialization:energy_p2p_tunnel"
 			}]
+			description: [
+				"You can *only* connect Superconductor Cables to this tunnel."
+				""
+				"Just like Energy P2P Tunnel, the ME Network will draw 5% tax on transfered energy."
+			]
+			id: "39D6CB2B3FDC4936"
+			x: 9.5d
+			y: -1.0d
 			rewards: [{
 				id: "2BC555284DC13BA9"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "EU through ME Network!"
+			dependencies: ["18949581A0F3E28B"]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/endgame.snbt
+++ b/config/ftbquests/quests/chapters/endgame.snbt
@@ -1,104 +1,107 @@
 {
-	id: "7399B85C439F32D6"
-	group: "5A79AA7D1974C9A9"
-	order_index: 1
-	filename: "endgame"
-	title: "Endgame"
-	icon: "kubejs:infinity_catalyst"
-	default_quest_shape: ""
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "5A79AA7D1974C9A9"
+	id: "7399B85C439F32D6"
+	filename: "endgame"
+	default_quest_shape: ""
+	icon: "kubejs:infinity_catalyst"
+	title: "Endgame"
+	order_index: 1
 	quests: [
 		{
-			x: 8.5d
-			y: -3.0d
-			shape: "square"
-			subtitle: "Each piece gives +25% chance to completely nullify an attack."
-			dependencies: ["7333416F7B297625"]
-			id: "1C160F416FFFE533"
 			tasks: [{
 				id: "3C259C716EB5F722"
 				type: "item"
 				item: "modern_industrialization:quantum_helmet"
 			}]
-		}
-		{
 			x: 8.5d
-			y: -2.0d
+			id: "1C160F416FFFE533"
+			y: -3.0d
 			shape: "square"
 			subtitle: "Each piece gives +25% chance to completely nullify an attack."
 			dependencies: ["7333416F7B297625"]
-			id: "3509449F128B121A"
+		}
+		{
 			tasks: [{
 				id: "1A59B1136DF98C9B"
 				type: "item"
 				item: "modern_industrialization:quantum_chestplate"
 			}]
-		}
-		{
 			x: 8.5d
-			y: -1.0d
+			id: "3509449F128B121A"
+			y: -2.0d
 			shape: "square"
 			subtitle: "Each piece gives +25% chance to completely nullify an attack."
 			dependencies: ["7333416F7B297625"]
-			id: "592A917BBC32DB01"
+		}
+		{
 			tasks: [{
 				id: "5422493CD5560280"
 				type: "item"
 				item: "modern_industrialization:quantum_leggings"
 			}]
-		}
-		{
 			x: 8.5d
-			y: 0.0d
+			id: "592A917BBC32DB01"
+			y: -1.0d
 			shape: "square"
 			subtitle: "Each piece gives +25% chance to completely nullify an attack."
 			dependencies: ["7333416F7B297625"]
-			id: "3A40E03A1201EF3D"
+		}
+		{
 			tasks: [{
 				id: "71D74F28731CA68E"
 				type: "item"
 				item: "modern_industrialization:quantum_boots"
 			}]
+			x: 8.5d
+			id: "3A40E03A1201EF3D"
+			y: 0.0d
+			shape: "square"
+			subtitle: "Each piece gives +25% chance to completely nullify an attack."
+			dependencies: ["7333416F7B297625"]
 		}
 		{
-			x: 9.5d
-			y: -1.5d
-			subtitle: "Literally /kill's mobs."
-			dependencies: ["7333416F7B297625"]
-			id: "4E43971CD589E489"
 			tasks: [{
 				id: "681D7B8E91D66CF1"
 				type: "item"
 				item: "modern_industrialization:quantum_sword"
 			}]
+			dependencies: ["7333416F7B297625"]
+			subtitle: "Literally /kill's mobs."
+			id: "4E43971CD589E489"
+			y: -1.5d
+			x: 9.5d
 		}
 		{
-			x: -3.5d
-			y: 1.5d
-			subtitle: "A Crafting Table with a 5x5 Grid."
-			id: "6DB49FCA620A2F05"
 			tasks: [{
 				id: "6912502BE3A397E0"
 				type: "item"
 				item: "artis:big_bench"
 			}]
+			subtitle: "A Crafting Table with a 5x5 Grid."
+			id: "6DB49FCA620A2F05"
+			y: 1.5d
+			x: -3.5d
 		}
 		{
-			x: -3.5d
-			y: 0.5d
-			subtitle: "A Crafting Table with a 7x7 grid."
-			dependencies: [
-				"6DB49FCA620A2F05"
-				"59F7DE03A3A8E6F8"
-			]
-			id: "693E287970E53404"
 			tasks: [{
 				id: "703EA9F792F01774"
 				type: "item"
 				item: "artis:bigger_bench"
 			}]
+			dependencies: [
+				"6DB49FCA620A2F05"
+				"59F7DE03A3A8E6F8"
+			]
+			subtitle: "A Crafting Table with a 7x7 grid."
+			id: "693E287970E53404"
+			y: 0.5d
+			x: -3.5d
 		}
 		{
+			size: 1.5d
+			id: "4818E72ED80C8D7D"
 			x: -2.5d
 			y: -1.5d
 			subtitle: "A Crafting Table with a 9x9 grid."
@@ -118,8 +121,6 @@
 				"2E453832695F2656"
 				"5A575F67D7CDFA7E"
 			]
-			size: 1.5d
-			id: "4818E72ED80C8D7D"
 			tasks: [{
 				id: "57BBC4FCF0923934"
 				type: "item"
@@ -127,124 +128,124 @@
 			}]
 		}
 		{
-			x: -2.5d
-			y: -5.0d
-			subtitle: "The massive explosion in confined space led to the creation of a miniature black hole."
-			dependencies: ["6314525E36DEA54B"]
-			id: "513180A5E2142F83"
 			tasks: [{
 				id: "1629AB46D3240E04"
 				type: "item"
 				item: "modern_industrialization:singularity"
 			}]
+			dependencies: ["6314525E36DEA54B"]
+			subtitle: "The massive explosion in confined space led to the creation of a miniature black hole."
+			id: "513180A5E2142F83"
+			y: -5.0d
+			x: -2.5d
 		}
 		{
-			x: -4.5d
-			y: -2.0d
-			subtitle: "A miniature Black Hole, with 13,122 Diamonds tossed in."
-			description: ["You will need to add a Quantum Upgrade to your Implosion Compressor to satisfy its power requirement."]
-			dependencies: [
-				"513180A5E2142F83"
-				"4847BA675A04852F"
-			]
-			id: "36E78866627C6B40"
 			tasks: [{
 				id: "397288529E0FEBF3"
 				type: "item"
 				item: "kubejs:diamond_singularity"
 			}]
-		}
-		{
-			x: -4.5d
-			y: -3.0d
-			subtitle: "A miniature Black Hole, with 13,122 Emeralds tossed in."
 			description: ["You will need to add a Quantum Upgrade to your Implosion Compressor to satisfy its power requirement."]
+			id: "36E78866627C6B40"
+			x: -4.5d
+			y: -2.0d
+			subtitle: "A miniature Black Hole, with 13,122 Diamonds tossed in."
 			dependencies: [
 				"513180A5E2142F83"
 				"4847BA675A04852F"
 			]
-			id: "29C94774A9E2E953"
+		}
+		{
 			tasks: [{
 				id: "3D8BB3544D05F6B6"
 				type: "item"
 				item: "kubejs:emerald_singularity"
 			}]
-		}
-		{
-			x: -3.5d
-			y: -3.5d
-			subtitle: "A miniature Black Hole, with 13,122 Gold Ingots tossed in."
 			description: ["You will need to add a Quantum Upgrade to your Implosion Compressor to satisfy its power requirement."]
+			id: "29C94774A9E2E953"
+			x: -4.5d
+			y: -3.0d
+			subtitle: "A miniature Black Hole, with 13,122 Emeralds tossed in."
 			dependencies: [
 				"513180A5E2142F83"
 				"4847BA675A04852F"
 			]
-			id: "4628FBF318F9B11B"
+		}
+		{
 			tasks: [{
 				id: "61EDE333ED2EE8C1"
 				type: "item"
 				item: "kubejs:golden_singularity"
 			}]
-		}
-		{
-			x: -1.5d
-			y: -3.5d
-			subtitle: "A miniature Black Hole, with 13,122 Iron Ingots tossed in."
 			description: ["You will need to add a Quantum Upgrade to your Implosion Compressor to satisfy its power requirement."]
+			id: "4628FBF318F9B11B"
+			x: -3.5d
+			y: -3.5d
+			subtitle: "A miniature Black Hole, with 13,122 Gold Ingots tossed in."
 			dependencies: [
 				"513180A5E2142F83"
 				"4847BA675A04852F"
 			]
-			id: "2BD1A66700434E4B"
+		}
+		{
 			tasks: [{
 				id: "13805879914DB3F7"
 				type: "item"
 				item: "kubejs:iron_singularity"
 			}]
-		}
-		{
-			x: -0.5d
-			y: -3.0d
-			subtitle: "A miniature Black Hole, with 13,122 Lapis Lazuli tossed in."
 			description: ["You will need to add a Quantum Upgrade to your Implosion Compressor to satisfy its power requirement."]
+			id: "2BD1A66700434E4B"
+			x: -1.5d
+			y: -3.5d
+			subtitle: "A miniature Black Hole, with 13,122 Iron Ingots tossed in."
 			dependencies: [
 				"513180A5E2142F83"
 				"4847BA675A04852F"
 			]
-			id: "7F93DF7B96922E0F"
+		}
+		{
 			tasks: [{
 				id: "4D4674BFFBD67B4B"
 				type: "item"
 				item: "kubejs:lapis_singularity"
 			}]
-		}
-		{
-			x: -0.5d
-			y: -2.0d
-			subtitle: "A miniature Black Hole, with 13,122 Redstone Dust tossed in."
 			description: ["You will need to add a Quantum Upgrade to your Implosion Compressor to satisfy its power requirement."]
+			id: "7F93DF7B96922E0F"
+			x: -0.5d
+			y: -3.0d
+			subtitle: "A miniature Black Hole, with 13,122 Lapis Lazuli tossed in."
 			dependencies: [
 				"513180A5E2142F83"
 				"4847BA675A04852F"
 			]
-			id: "5BC1E66D78FBE6EB"
+		}
+		{
 			tasks: [{
 				id: "4ACD8280BD0204C1"
 				type: "item"
 				item: "kubejs:redstone_singularity"
 			}]
+			description: ["You will need to add a Quantum Upgrade to your Implosion Compressor to satisfy its power requirement."]
+			id: "5BC1E66D78FBE6EB"
+			x: -0.5d
+			y: -2.0d
+			subtitle: "A miniature Black Hole, with 13,122 Redstone Dust tossed in."
+			dependencies: [
+				"513180A5E2142F83"
+				"4847BA675A04852F"
+			]
 		}
 		{
+			size: 1.5d
+			description: ["Not automatically craftable with a Mechanical Mixer, as the Basin does not have enough slots."]
+			id: "07FDBACE26E651C2"
 			x: 2.5d
 			y: -1.5d
 			subtitle: "The penultimate material!"
-			description: ["Not automatically craftable with a Mechanical Mixer, as the Basin does not have enough slots."]
 			dependencies: [
 				"11F4D634651C541B"
 				"413B0EFC7DAE33F2"
 			]
-			size: 1.5d
-			id: "07FDBACE26E651C2"
 			tasks: [{
 				id: "5D3D4D3F360E1379"
 				type: "item"
@@ -252,49 +253,49 @@
 			}]
 		}
 		{
-			x: -4.5d
-			y: 1.0d
-			subtitle: "... as well as into the Ingot form!"
-			dependencies: ["59F7DE03A3A8E6F8"]
-			id: "3B0EFD01FFDE1E2C"
 			tasks: [{
 				id: "6DCC9D19EA626CEB"
 				type: "item"
 				item: "kubejs:neutronium_ingot"
 			}]
+			dependencies: ["59F7DE03A3A8E6F8"]
+			subtitle: "... as well as into the Ingot form!"
+			id: "3B0EFD01FFDE1E2C"
+			y: 1.0d
+			x: -4.5d
 		}
 		{
-			x: -4.5d
-			y: 0.0d
-			subtitle: "These neutrons seem to be formable into a nugget form..."
-			dependencies: ["740671D7B69AF373"]
-			id: "59F7DE03A3A8E6F8"
 			tasks: [{
 				id: "12253927C8416D8F"
 				type: "item"
 				item: "kubejs:neutronium_nugget"
 			}]
+			dependencies: ["740671D7B69AF373"]
+			subtitle: "These neutrons seem to be formable into a nugget form..."
+			id: "59F7DE03A3A8E6F8"
+			y: 0.0d
+			x: -4.5d
 		}
 		{
-			title: "Pile of Neutrons"
-			x: -5.5d
-			y: 0.0d
-			subtitle: "So many Neutrons!"
-			description: ["Mixing radioactive materials with very hot Helium Plasma seemed to evaporate everything, but neutrons."]
-			dependencies: ["6B83B56BAC02F111"]
-			id: "740671D7B69AF373"
 			tasks: [{
 				id: "47EFAB8688FB7346"
 				type: "item"
 				item: "kubejs:pileof_neutrons"
 			}]
+			description: ["Mixing radioactive materials with very hot Helium Plasma seemed to evaporate everything, but neutrons."]
+			id: "740671D7B69AF373"
+			x: -5.5d
+			y: 0.0d
+			title: "Pile of Neutrons"
+			subtitle: "So many Neutrons!"
+			dependencies: ["6B83B56BAC02F111"]
 		}
 		{
-			x: -6.875d
-			y: 0.0d
-			subtitle: "Seems to be extractable from that gravitational anomaly..."
 			size: 1.25d
+			subtitle: "Seems to be extractable from that gravitational anomaly..."
 			id: "6B83B56BAC02F111"
+			y: 0.0d
+			x: -6.875d
 			tasks: [{
 				id: "2F36CFA376D80754"
 				type: "item"
@@ -302,85 +303,85 @@
 			}]
 		}
 		{
-			x: -2.5d
-			y: 1.0d
-			subtitle: "Made from all the meat in the game!"
-			dependencies: ["693E287970E53404"]
-			id: "136532374C24E706"
 			tasks: [{
 				id: "40EBB927546C8F02"
 				type: "item"
 				item: "kubejs:cosmic_meatballs"
 			}]
+			dependencies: ["693E287970E53404"]
+			subtitle: "Made from all the meat in the game!"
+			id: "136532374C24E706"
+			y: 1.0d
+			x: -2.5d
 		}
 		{
-			x: -1.5d
-			y: 0.5d
-			subtitle: "All the fish and chips, spiced up with Dragon's Breath."
-			dependencies: ["693E287970E53404"]
-			id: "2E453832695F2656"
 			tasks: [{
 				id: "6B659A771C9B19B7"
 				type: "item"
 				item: "kubejs:fish_and_chips"
 			}]
+			dependencies: ["693E287970E53404"]
+			subtitle: "All the fish and chips, spiced up with Dragon's Breath."
+			id: "2E453832695F2656"
+			y: 0.5d
+			x: -1.5d
 		}
 		{
-			disable_toast: true
-			x: -0.5d
-			y: 0.0d
-			subtitle: "I hope you have farmed those."
-			id: "42710D1A071289E4"
 			tasks: [{
 				id: "322A7373F9A2CC2F"
 				type: "item"
 				item: "spectrum:germinated_jade_vine_seeds"
 			}]
+			subtitle: "I hope you have farmed those."
+			id: "42710D1A071289E4"
+			y: 0.0d
+			disable_toast: true
+			x: -0.5d
 		}
 		{
-			disable_toast: true
-			x: -4.5d
-			y: -1.0d
-			subtitle: "A Netherite Ingot infused with Matrix Fragments."
-			dependencies: ["3F69B97A783AC81C"]
-			id: "2416B9BF7746143B"
 			tasks: [{
 				id: "0BC2B1CC69436427"
 				type: "item"
 				item: "dml-refabricated:glitch_ingot"
 			}]
+			x: -4.5d
+			id: "2416B9BF7746143B"
+			disable_toast: true
+			y: -1.0d
+			subtitle: "A Netherite Ingot infused with Matrix Fragments."
+			dependencies: ["3F69B97A783AC81C"]
 		}
 		{
-			x: -2.5d
-			y: -4.0d
-			subtitle: "Nether Stars in the mesh of Diamonds."
-			id: "43A20488F96931A2"
 			tasks: [{
 				id: "45A8D0E844A910B4"
 				type: "item"
 				item: "kubejs:crystal_matrix_ingot"
 			}]
+			subtitle: "Nether Stars in the mesh of Diamonds."
+			id: "43A20488F96931A2"
+			y: -4.0d
+			x: -2.5d
 		}
 		{
-			x: 1.0d
-			y: -1.0d
-			subtitle: "A Stew made out of rainbow-colored assortment of fruit and vegetables."
-			dependencies: ["4818E72ED80C8D7D"]
-			id: "11F4D634651C541B"
 			tasks: [{
 				id: "2553A8EEC42FD707"
 				type: "item"
 				item: "kubejs:ultimate_stew"
 			}]
+			dependencies: ["4818E72ED80C8D7D"]
+			subtitle: "A Stew made out of rainbow-colored assortment of fruit and vegetables."
+			id: "11F4D634651C541B"
+			y: -1.0d
+			x: 1.0d
 		}
 		{
+			size: 1.5d
+			description: ["Feel free to brag."]
+			id: "7D17BAA0723569A5"
 			x: 4.0d
 			y: -1.5d
 			subtitle: "The Ultimate Material!"
-			description: ["Feel free to brag."]
 			dependencies: ["07FDBACE26E651C2"]
-			size: 1.5d
-			id: "7D17BAA0723569A5"
 			tasks: [{
 				id: "756D2313F968AED8"
 				type: "item"
@@ -388,33 +389,29 @@
 			}]
 		}
 		{
-			x: 5.5d
-			y: -1.5d
-			dependencies: ["7D17BAA0723569A5"]
-			id: "7333416F7B297625"
 			tasks: [{
 				id: "711B81987D89FF75"
 				type: "checkmark"
 				title: "Bragging Rights"
 			}]
+			dependencies: ["7D17BAA0723569A5"]
+			id: "7333416F7B297625"
+			y: -1.5d
+			x: 5.5d
 		}
 		{
-			x: 7.5d
-			y: 2.0d
-			subtitle: "Unlimited Power!!! (v2)"
-			dependencies: ["63D59158E8BC23F3"]
-			id: "387F5E8FA77F2AB3"
 			tasks: [{
 				id: "4041946A78B95D94"
 				type: "item"
 				item: "indrev:lazuli_flux_container_creative"
 			}]
+			dependencies: ["63D59158E8BC23F3"]
+			subtitle: "Unlimited Power!!! (v2)"
+			id: "387F5E8FA77F2AB3"
+			y: 2.0d
+			x: 7.5d
 		}
 		{
-			x: 7.5d
-			y: -3.5d
-			dependencies: ["7333416F7B297625"]
-			id: "4C76A9150C025A8C"
 			tasks: [{
 				id: "7009209544DBCFBB"
 				type: "item"
@@ -426,11 +423,17 @@
 					}
 				}
 			}]
+			dependencies: ["7333416F7B297625"]
+			id: "4C76A9150C025A8C"
+			y: -3.5d
+			x: 7.5d
 		}
 		{
-			x: 6.5d
-			y: -4.0d
-			subtitle: "Can replicate most of the items using 100 mB of UU Matter."
+			tasks: [{
+				id: "0467CAF8C3FB74E2"
+				type: "item"
+				item: "modern_industrialization:replicator"
+			}]
 			description: [
 				"The notable exceptions are:"
 				"> Items that can contain other items,"
@@ -440,150 +443,148 @@
 				"Every non-replicable item can be found using a tag:"
 				"#modern_industrialization:replicator_blacklist"
 			]
-			dependencies: ["7333416F7B297625"]
-			min_width: 300
 			id: "5D28EFA03639684D"
-			tasks: [{
-				id: "0467CAF8C3FB74E2"
-				type: "item"
-				item: "modern_industrialization:replicator"
-			}]
+			x: 6.5d
+			y: -4.0d
+			min_width: 300
+			subtitle: "Can replicate most of the items using 100 mB of UU Matter."
+			dependencies: ["7333416F7B297625"]
 		}
 		{
-			x: 1.0d
-			y: -2.0d
-			subtitle: "More ender than an ender pearl."
-			dependencies: ["4818E72ED80C8D7D"]
-			id: "413B0EFC7DAE33F2"
 			tasks: [{
 				id: "080485C349F18EAA"
 				type: "item"
 				item: "kubejs:endest_pearl"
 			}]
+			dependencies: ["4818E72ED80C8D7D"]
+			subtitle: "More ender than an ender pearl."
+			id: "413B0EFC7DAE33F2"
+			y: -2.0d
+			x: 1.0d
 		}
 		{
-			x: 6.5d
-			y: -5.5d
-			subtitle: "Provides unlimited amount of one item."
-			dependencies: ["5D28EFA03639684D"]
-			id: "509EA7291D462C54"
 			tasks: [{
 				id: "3C099BFD0FBABA21"
 				type: "item"
 				item: "techreborn:creative_storage_unit"
 			}]
+			dependencies: ["5D28EFA03639684D"]
+			subtitle: "Provides unlimited amount of one item."
+			id: "509EA7291D462C54"
+			y: -5.5d
+			x: 6.5d
 		}
 		{
-			x: 5.5d
-			y: -5.0d
-			subtitle: "Provides unlimited amount of one fluid."
-			dependencies: ["5D28EFA03639684D"]
-			id: "1F98724810B48B0E"
 			tasks: [{
 				id: "70A2395CD1C4F525"
 				type: "item"
 				item: "techreborn:creative_tank_unit"
 			}]
+			dependencies: ["5D28EFA03639684D"]
+			subtitle: "Provides unlimited amount of one fluid."
+			id: "1F98724810B48B0E"
+			y: -5.0d
+			x: 5.5d
 		}
 		{
-			x: 7.5d
-			y: 1.0d
-			subtitle: "Unlimited Power!!!"
-			dependencies: ["7333416F7B297625"]
-			id: "63D59158E8BC23F3"
 			tasks: [{
 				id: "147AD97FFEEC64B1"
 				type: "item"
 				item: "techreborn:creative_solar_panel"
 			}]
+			dependencies: ["7333416F7B297625"]
+			subtitle: "Unlimited Power!!!"
+			id: "63D59158E8BC23F3"
+			y: 1.0d
+			x: 7.5d
 		}
 		{
-			x: 7.5d
-			y: -5.0d
-			subtitle: "Holds infinite Mana."
-			description: ["Filled with Vazkii's Tears :("]
-			dependencies: ["5D28EFA03639684D"]
-			id: "59019D4DC9BF2395"
 			tasks: [{
 				id: "19AA99B698C45BEC"
 				type: "item"
 				item: "botania:creative_pool"
 			}]
+			description: ["Filled with Vazkii's Tears :("]
+			id: "59019D4DC9BF2395"
+			x: 7.5d
+			y: -5.0d
+			subtitle: "Holds infinite Mana."
+			dependencies: ["5D28EFA03639684D"]
 		}
 		{
-			x: 5.5d
-			y: 2.0d
-			subtitle: "???"
-			dependencies: ["7333416F7B297625"]
-			id: "51ECB670CB7C48DD"
 			tasks: [{
 				id: "51C2FA6634A635EA"
 				type: "item"
 				item: "iron-jetpacks:creative_cell"
 			}]
+			dependencies: ["7333416F7B297625"]
+			subtitle: "???"
+			id: "51ECB670CB7C48DD"
+			y: 2.0d
+			x: 5.5d
 		}
 		{
-			x: 5.5d
-			y: 3.0d
-			subtitle: "A Different kind of \"Creative Flight\""
-			dependencies: ["51ECB670CB7C48DD"]
-			id: "52C6F4A3D0793A00"
 			tasks: [{
 				id: "06BD127F6C242ED4"
 				type: "item"
 				item: "iron-jetpacks:creative_jetpack"
 			}]
+			dependencies: ["51ECB670CB7C48DD"]
+			subtitle: "A Different kind of \"Creative Flight\""
+			id: "52C6F4A3D0793A00"
+			y: 3.0d
+			x: 5.5d
 		}
 		{
-			x: 6.5d
-			y: -6.5d
-			subtitle: "Provides unlimited amount of items."
-			description: ["Format it using a Cell Workbench first."]
-			dependencies: ["509EA7291D462C54"]
-			id: "73E1094729156DC6"
 			tasks: [{
 				id: "4E0A0CD0E8ACAE40"
 				type: "item"
 				item: "ae2:creative_item_cell"
 			}]
+			description: ["Format it using a Cell Workbench first."]
+			id: "73E1094729156DC6"
+			x: 6.5d
+			y: -6.5d
+			subtitle: "Provides unlimited amount of items."
+			dependencies: ["509EA7291D462C54"]
 		}
 		{
-			x: 5.5d
-			y: -6.0d
-			subtitle: "Provides unlimited amount of fluids."
-			description: ["Format it using a Cell Workbench first."]
-			dependencies: ["1F98724810B48B0E"]
-			id: "6B3DD5E1DC5CBD67"
 			tasks: [{
 				id: "4C95D0DC2CC9A7E9"
 				type: "item"
 				item: "ae2:creative_fluid_cell"
 			}]
+			description: ["Format it using a Cell Workbench first."]
+			id: "6B3DD5E1DC5CBD67"
+			x: 5.5d
+			y: -6.0d
+			subtitle: "Provides unlimited amount of fluids."
+			dependencies: ["1F98724810B48B0E"]
 		}
 		{
-			x: 6.5d
-			y: 1.5d
-			subtitle: "Unlimited Power!!! (for AE2)"
-			dependencies: ["7333416F7B297625"]
-			id: "2460A5C57EDCDAE7"
 			tasks: [{
 				id: "4EB37DAE1E46F306"
 				type: "item"
 				item: "ae2:creative_energy_cell"
 			}]
+			dependencies: ["7333416F7B297625"]
+			subtitle: "Unlimited Power!!! (for AE2)"
+			id: "2460A5C57EDCDAE7"
+			y: 1.5d
+			x: 6.5d
 		}
 		{
-			x: -2.5d
-			y: 2.0d
-			subtitle: "Expands the Wireless Terminal's Range to Infinity!"
-			description: ["It will consume more power when outside of normal range."]
-			dependencies: ["693E287970E53404"]
-			id: "546310057FE774E0"
 			tasks: [{
 				id: "39C2026D22EF6A9B"
 				type: "item"
 				item: "ae2wtlib:infinity_booster_card"
 			}]
+			description: ["It will consume more power when outside of normal range."]
+			id: "546310057FE774E0"
+			x: -2.5d
+			y: 2.0d
+			subtitle: "Expands the Wireless Terminal's Range to Infinity!"
+			dependencies: ["693E287970E53404"]
 		}
 		{
 			x: -0.5d
@@ -596,40 +597,39 @@
 			}]
 		}
 		{
-			x: 2.5d
-			y: 0.0d
-			subtitle: "Choose your way of enchantment."
-			description: [
-				"The ultimate enchantment table!"
-				"You can pick and choose enchantments, upgrading or downgrading them at the cost of XP."
-				"Enchanting cost can be reduced by using a multiblock structure."
-			]
-			dependencies: ["07FDBACE26E651C2"]
-			id: "030CFE419C9627F0"
 			tasks: [{
 				id: "2A1E3263D4BC0DE4"
 				type: "item"
 				item: "dark-enchanting:dark_enchanter"
 			}]
+			description: [
+				"The ultimate enchantment table!"
+				"You can pick and choose enchantments, upgrading or downgrading them at the cost of XP."
+				"Enchanting cost can be reduced by using a multiblock structure."
+			]
+			id: "030CFE419C9627F0"
+			x: 2.5d
+			y: 0.0d
 			rewards: [{
 				id: "6C4C5B29661563A7"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Choose your way of enchantment."
+			dependencies: ["07FDBACE26E651C2"]
 		}
 		{
-			x: -4.5d
-			y: 2.0d
-			subtitle: "The Penultimate Jetpack."
-			description: ["Shouldn't you just use Creative flight at this point?"]
-			dependencies: ["3B0EFD01FFDE1E2C"]
-			id: "573B150F7F9769EA"
 			tasks: [{
 				id: "0A2DC6D812A58508"
 				type: "item"
 				item: "iron-jetpacks:neutronium_jetpack"
 			}]
+			description: ["Shouldn't you just use Creative flight at this point?"]
+			id: "573B150F7F9769EA"
+			x: -4.5d
+			y: 2.0d
+			subtitle: "The Penultimate Jetpack."
+			dependencies: ["3B0EFD01FFDE1E2C"]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/gadgets.snbt
+++ b/config/ftbquests/quests/chapters/gadgets.snbt
@@ -1,9 +1,10 @@
 {
-	id: "19424F3F4D7521A2"
+	quest_links: [ ]
+	default_hide_dependency_lines: false
 	group: "76C22988F9A7C9CE"
-	order_index: 0
+	id: "19424F3F4D7521A2"
 	filename: "gadgets"
-	title: "Building"
+	default_quest_shape: ""
 	icon: {
 		id: "indrev:hammer"
 		Count: 1b
@@ -11,13 +12,15 @@
 			Damage: 0
 		}
 	}
-	default_quest_shape: ""
-	default_hide_dependency_lines: false
+	title: "Building"
+	order_index: 0
 	quests: [
 		{
-			x: 0.0d
-			y: 1.5d
-			subtitle: "You can dream, create, design, and build the most wonderful place in the world."
+			tasks: [{
+				id: "0AE0962EF2F84060"
+				type: "checkmark"
+				title: "Your every day toolbelt"
+			}]
 			dependencies: [
 				"57A128EE5135A494"
 				"4EC49EFF4B139771"
@@ -36,20 +39,12 @@
 				"72D41352FD2B752C"
 				"009320766602EAAF"
 			]
+			subtitle: "You can dream, create, design, and build the most wonderful place in the world."
 			id: "341C7D2C93742900"
-			tasks: [{
-				id: "0AE0962EF2F84060"
-				type: "checkmark"
-				title: "Your every day toolbelt"
-			}]
+			y: 1.5d
+			x: 0.0d
 		}
 		{
-			x: 0.5d
-			y: -1.5d
-			subtitle: "Allows you to build structures using a set of different Building Modes."
-			description: ["Cadmium Batteries are required to craft this item."]
-			dependencies: ["6D844CA6CF326DFC"]
-			id: "45472C7319EC2261"
 			tasks: [{
 				id: "33686463964EEAED"
 				type: "item"
@@ -68,19 +63,19 @@
 					}
 				}
 			}]
+			description: ["Cadmium Batteries are required to craft this item."]
+			id: "45472C7319EC2261"
+			x: 0.5d
+			y: -1.5d
 			rewards: [{
 				id: "5EA1ECBEFF608B9C"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Allows you to build structures using a set of different Building Modes."
+			dependencies: ["6D844CA6CF326DFC"]
 		}
 		{
-			x: -0.5d
-			y: -1.5d
-			subtitle: "Provides basic exchanging abilities using a set of different Exchanging Modes."
-			description: ["Cadmium Batteries are required to craft this item."]
-			dependencies: ["6D844CA6CF326DFC"]
-			id: "72D473E1810E45D7"
 			tasks: [{
 				id: "4278655EFD94DBF1"
 				type: "item"
@@ -99,19 +94,19 @@
 					}
 				}
 			}]
+			description: ["Cadmium Batteries are required to craft this item."]
+			id: "72D473E1810E45D7"
+			x: -0.5d
+			y: -1.5d
 			rewards: [{
 				id: "33177193670A70BC"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Provides basic exchanging abilities using a set of different Exchanging Modes."
+			dependencies: ["6D844CA6CF326DFC"]
 		}
 		{
-			x: 1.5d
-			y: -1.0d
-			subtitle: "Allows you to select a large radius to copy and paste in a different location."
-			description: ["Cadmium Batteries are required to craft this item."]
-			dependencies: ["6D844CA6CF326DFC"]
-			id: "0232F82465ACC551"
 			tasks: [{
 				id: "77BB53C023067B54"
 				type: "item"
@@ -131,22 +126,28 @@
 					}
 				}
 			}]
+			description: ["Cadmium Batteries are required to craft this item."]
+			id: "0232F82465ACC551"
+			x: 1.5d
+			y: -1.0d
 			rewards: [{
 				id: "77136482EFE2C8EA"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Allows you to select a large radius to copy and paste in a different location."
+			dependencies: ["6D844CA6CF326DFC"]
 		}
 		{
-			x: -2.5d
-			y: -0.5d
-			subtitle: "Right-click and put your block of choice in slot. Choose the variant that suits you."
-			id: "5D5E53BCC9686BEB"
 			tasks: [{
 				id: "2A15AF7129E1D209"
 				type: "item"
 				item: "chisel:chisel"
 			}]
+			subtitle: "Right-click and put your block of choice in slot. Choose the variant that suits you."
+			id: "5D5E53BCC9686BEB"
+			y: -0.5d
+			x: -2.5d
 			rewards: [{
 				id: "274486AF5C53B027"
 				type: "loot"
@@ -154,16 +155,6 @@
 			}]
 		}
 		{
-			title: "Bits and Chisels"
-			x: 2.5d
-			y: -0.5d
-			subtitle: "Sculpture the world!"
-			description: [
-				"Remove small bits from blocks using chisels."
-				""
-				"You can use these bits to build detailed decorations or whatever else you want."
-			]
-			id: "1503EBD099C0444B"
 			tasks: [{
 				id: "5C9D9AF921A12ED1"
 				type: "item"
@@ -175,19 +166,23 @@
 					}
 				}
 			}]
+			description: [
+				"Remove small bits from blocks using chisels."
+				""
+				"You can use these bits to build detailed decorations or whatever else you want."
+			]
+			id: "1503EBD099C0444B"
+			x: 2.5d
+			y: -0.5d
+			title: "Bits and Chisels"
 			rewards: [{
 				id: "567C37D50BB09667"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Sculpture the world!"
 		}
 		{
-			x: -1.5d
-			y: -1.0d
-			subtitle: "Allows you to void a large area."
-			description: ["Cadmium Batteries are required to craft this item."]
-			dependencies: ["6D844CA6CF326DFC"]
-			id: "454C6A0D83B852C7"
 			tasks: [{
 				id: "5E7623ACE78AD0E5"
 				type: "item"
@@ -201,18 +196,19 @@
 					}
 				}
 			}]
+			description: ["Cadmium Batteries are required to craft this item."]
+			id: "454C6A0D83B852C7"
+			x: -1.5d
+			y: -1.0d
 			rewards: [{
 				id: "5D4DEF0828F97584"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Allows you to void a large area."
+			dependencies: ["6D844CA6CF326DFC"]
 		}
 		{
-			x: -1.5d
-			y: 4.0d
-			subtitle: "Used to speed up building and block placement."
-			description: ["- Holding a staff will show a placement range (but a range will only be displayed if you have the required items in your inventory)."]
-			id: "4EC49EFF4B139771"
 			tasks: [{
 				id: "2F2DA7D863BC327A"
 				type: "item"
@@ -224,18 +220,18 @@
 					}
 				}
 			}]
+			description: ["- Holding a staff will show a placement range (but a range will only be displayed if you have the required items in your inventory)."]
+			id: "4EC49EFF4B139771"
+			x: -1.5d
+			y: 4.0d
 			rewards: [{
 				id: "051478D507A6B7E3"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Used to speed up building and block placement."
 		}
 		{
-			x: -0.5d
-			y: 4.5d
-			subtitle: "Used to speed up building and block placement."
-			description: ["- Holding a staff will show a placement range (but a range will only be displayed if you have the required items in your inventory)."]
-			id: "424D1FF456C5309D"
 			tasks: [{
 				id: "2310EE65434E176F"
 				type: "item"
@@ -247,18 +243,18 @@
 					}
 				}
 			}]
+			description: ["- Holding a staff will show a placement range (but a range will only be displayed if you have the required items in your inventory)."]
+			id: "424D1FF456C5309D"
+			x: -0.5d
+			y: 4.5d
 			rewards: [{
 				id: "6485B3F9E55938C3"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Used to speed up building and block placement."
 		}
 		{
-			x: 0.5d
-			y: 4.5d
-			subtitle: "Used to speed up building and block placement."
-			description: ["- Holding a staff will show a placement range (but a range will only be displayed if you have the required items in your inventory)."]
-			id: "4AD1DD230664681D"
 			tasks: [{
 				id: "7D5B4820134A5ACF"
 				type: "item"
@@ -270,18 +266,18 @@
 					}
 				}
 			}]
+			description: ["- Holding a staff will show a placement range (but a range will only be displayed if you have the required items in your inventory)."]
+			id: "4AD1DD230664681D"
+			x: 0.5d
+			y: 4.5d
 			rewards: [{
 				id: "7BE7724358457022"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Used to speed up building and block placement."
 		}
 		{
-			x: 1.5d
-			y: 4.0d
-			subtitle: "Used to speed up building and block placement."
-			description: ["- Holding a staff will show a placement range (but a range will only be displayed if you have the required items in your inventory)."]
-			id: "661F9C730DFEA05C"
 			tasks: [{
 				id: "0944E8C92FD41166"
 				type: "item"
@@ -293,6 +289,10 @@
 					}
 				}
 			}]
+			description: ["- Holding a staff will show a placement range (but a range will only be displayed if you have the required items in your inventory)."]
+			id: "661F9C730DFEA05C"
+			x: 1.5d
+			y: 4.0d
 			rewards: [
 				{
 					id: "2F8B7273C24A94ED"
@@ -337,17 +337,18 @@
 					count: 64
 				}
 			]
+			subtitle: "Used to speed up building and block placement."
 		}
 		{
-			x: 3.0d
-			y: 0.5d
-			subtitle: "Dirty Stick"
-			id: "1A7AF56567D80ECB"
 			tasks: [{
 				id: "3AA7A6C9CA235353"
 				type: "item"
 				item: "botania:dirt_rod"
 			}]
+			subtitle: "Dirty Stick"
+			id: "1A7AF56567D80ECB"
+			y: 0.5d
+			x: 3.0d
 			rewards: [{
 				id: "60008B7651F96325"
 				type: "random"
@@ -355,32 +356,32 @@
 			}]
 		}
 		{
-			x: 3.5d
-			y: 1.5d
-			subtitle: "Dirty Stick MK II"
-			description: ["Functions the same as the Rod of the Lands, except it can place Dirt Block in midair!"]
-			id: "6CFB83CA3C41D891"
 			tasks: [{
 				id: "07E070E14442B2D5"
 				type: "item"
 				item: "botania:skydirt_rod"
 			}]
+			description: ["Functions the same as the Rod of the Lands, except it can place Dirt Block in midair!"]
+			id: "6CFB83CA3C41D891"
+			x: 3.5d
+			y: 1.5d
 			rewards: [{
 				id: "4E850F618F4B07BC"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Dirty Stick MK II"
 		}
 		{
-			x: 3.0d
-			y: 2.5d
-			description: ["It can terraform by adding Dirt Blocks or removing terrain blocks to flatten the terrain."]
-			id: "503DD3CEEFE78FFF"
 			tasks: [{
 				id: "6E7765039271CC78"
 				type: "item"
 				item: "botania:terraform_rod"
 			}]
+			description: ["It can terraform by adding Dirt Blocks or removing terrain blocks to flatten the terrain."]
+			id: "503DD3CEEFE78FFF"
+			y: 2.5d
+			x: 3.0d
 			rewards: [{
 				id: "1ED31F8DA461B54B"
 				type: "random"
@@ -388,15 +389,15 @@
 			}]
 		}
 		{
-			x: -3.5d
-			y: 1.5d
-			subtitle: "It's cobbling time!"
-			id: "009320766602EAAF"
 			tasks: [{
 				id: "5B3866A5E0AD8DCF"
 				type: "item"
 				item: "botania:cobble_rod"
 			}]
+			subtitle: "It's cobbling time!"
+			id: "009320766602EAAF"
+			y: 1.5d
+			x: -3.5d
 			rewards: [{
 				id: "1CE5C30DD79A7098"
 				type: "random"
@@ -404,39 +405,38 @@
 			}]
 		}
 		{
-			x: -3.0d
-			y: 0.5d
-			subtitle: "Keep the ocean clean!"
-			description: ["Places Water at the cost of a bit of Mana."]
-			id: "72D41352FD2B752C"
 			tasks: [{
 				id: "69CE55AF68F39797"
 				type: "item"
 				item: "botania:water_rod"
 			}]
+			description: ["Places Water at the cost of a bit of Mana."]
+			id: "72D41352FD2B752C"
+			x: -3.0d
+			y: 0.5d
 			rewards: [{
 				id: "1A8308C8DEE71022"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Keep the ocean clean!"
 		}
 		{
-			x: -3.0d
-			y: 2.5d
-			subtitle: "Shift your block of choice."
-			description: ["Aluminium Rods are required to craft this item."]
-			id: "57A128EE5135A494"
 			tasks: [{
 				id: "5F10EB7947E7C1CB"
 				type: "item"
 				item: "botania:exchange_rod"
 			}]
+			description: ["Aluminium Rods are required to craft this item."]
+			id: "57A128EE5135A494"
+			x: -3.0d
+			y: 2.5d
 			rewards: [{
 				id: "4E2062F5C1DBE105"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Shift your block of choice."
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/getting_started.snbt
+++ b/config/ftbquests/quests/chapters/getting_started.snbt
@@ -1,73 +1,63 @@
 {
-	id: "77498621DD383E8B"
-	group: ""
-	order_index: 0
-	filename: "getting_started"
-	title: "Getting Started"
-	icon: "onastick:crafting_table_on_a_stick"
-	default_quest_shape: ""
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: ""
+	id: "77498621DD383E8B"
+	filename: "getting_started"
+	default_quest_shape: ""
+	icon: "onastick:crafting_table_on_a_stick"
+	title: "Getting Started"
+	order_index: 0
 	quests: [
 		{
-			title: "Welcome to Sky FABRICation 3"
+			size: 1.5d
+			description: [
+				"{getting_started.welcome.text.1}"
+				""
+				"{getting_started.welcome.text.2}"
+			]
+			id: "175F5611FB7716A4"
 			icon: "kubejs:skyfabrication_logo"
 			x: 7.5357142857142705d
 			y: 2.017857142857146d
 			shape: "octagon"
-			subtitle: "A Whole New Void!"
-			description: [
-				"Thanks for playing Sky FABRICation 3."
-				""
-				""
-				"In this version you have the choice how to start the modpack. You will also have to chose your Origin!"
+			title: "{getting_started.welcome.title}"
+			rewards: [
+				{
+					type: "custom"
+					id: "71DCA33AC06D25FB"
+					auto: "enabled"
+					icon: "xps:key"
+					title: "{getting_started.welcome.unlock_inventory}"
+				}
+				{
+					type: "item"
+					count: 8
+					id: "6F0ADFD33AA82B12"
+					auto: "enabled"
+					item: "minecraft:apple"
+				}
+				{
+					type: "item"
+					count: 4
+					id: "603A41D43C735B53"
+					auto: "enabled"
+					item: "minecraft:cooked_porkchop"
+				}
 			]
-			size: 1.5d
-			id: "175F5611FB7716A4"
+			subtitle: "{getting_started.welcome.subtitle}"
 			tasks: [{
 				id: "25B2DFAFD351900E"
 				type: "checkmark"
-				title: "Welcome to Sky FABRICation 3"
+				title: "{getting_started.welcome.title}"
 				icon: "kubejs:aof5_logo"
 			}]
-			rewards: [
-				{
-					id: "71DCA33AC06D25FB"
-					type: "custom"
-					title: "Unlock Inventory"
-					icon: "xps:key"
-					auto: "enabled"
-				}
-				{
-					id: "6F0ADFD33AA82B12"
-					type: "item"
-					auto: "enabled"
-					item: "minecraft:apple"
-					count: 8
-				}
-				{
-					id: "603A41D43C735B53"
-					type: "item"
-					auto: "enabled"
-					item: "minecraft:cooked_porkchop"
-					count: 4
-				}
-			]
 		}
 		{
-			x: 9.5d
-			y: 2.0d
-			subtitle: "Ores Be Gone!"
-			description: [
-				"Excavate is by default bound to keybind \"Grave\""
-				""
-				"You can change this keybind by going into options and change the FTB Ultimine keybinds."
-			]
-			dependencies: ["175F5611FB7716A4"]
-			id: "7050DE96E151D1D1"
 			tasks: [{
 				id: "520CE3437306804D"
 				type: "checkmark"
-				title: "Excavate"
+				title: "{getting_started.excavate.checkmark}"
 				icon: {
 					id: "minecraft:diamond_pickaxe"
 					Count: 1b
@@ -76,96 +66,96 @@
 					}
 				}
 			}]
+			description: [
+				"{getting_started.excavate.text.1}"
+				""
+				"{getting_started.excavate.text.2}"
+			]
+			id: "7050DE96E151D1D1"
+			x: 9.5d
+			y: 2.0d
+			title: "{getting_started.excavate.title}"
+			subtitle: "{getting_started.excavate.subtitle}"
+			dependencies: ["175F5611FB7716A4"]
 		}
 		{
-			title: "Where to start?"
-			icon: "techreborn:wrench"
-			x: 6.0d
-			y: 0.5d
-			subtitle: "Follow the Progression Guide to continue!"
-			description: [
-				"Mods are split into 5 categories:"
-				"- Progression"
-				"- Technology"
-				"- Magic"
-				"- Utilities"
-				"- Logistics"
-				""
-				"Respectively, each chapter will guide you through progression."
-				""
-				"Certain chapters will have tips and tricks on how to ease your adventures with useful trinkets and gadgets."
-			]
-			dependencies: ["175F5611FB7716A4"]
-			id: "257EAB9268907E1D"
 			tasks: [{
 				id: "60A1EB763CF25699"
 				type: "checkmark"
-				title: "Learning Mods"
+				title: "{getting_started.start.checkmark}"
 			}]
+			description: [
+				"{getting_started.start.text.1}"
+				"{getting_started.start.text.2}"
+				""
+				"{getting_started.start.text.3}"
+				""
+				"{getting_started.start.text.4}"
+			]
+			id: "257EAB9268907E1D"
+			icon: "techreborn:wrench"
+			x: 6.0d
+			y: 0.5d
+			title: "{getting_started.start.title}"
+			subtitle: "{getting_started.start.subtitle}"
+			dependencies: ["175F5611FB7716A4"]
 		}
 		{
-			title: "Crafting on the Go"
-			x: 6.0d
-			y: 3.5d
-			subtitle: "Only 0.0001 BTC"
-			description: [
-				"Tired of having to put that crafting table of yours down any time your tool breaks when mining? Look no more!"
-				""
-				"Make the Crafting Table On A Stick! "
-				""
-				"There's also one for the following:"
-				"- Anvil"
-				"- Cartography"
-				"- Grindstone"
-				"- Loom"
-				"- Smithing"
-				"- Stonecutter"
-			]
-			dependencies: ["175F5611FB7716A4"]
-			id: "77EA450F77679791"
 			tasks: [{
 				id: "2EC6B9D7A8E9438D"
 				type: "checkmark"
-				title: "Crafting on the Go"
+				title: "{getting_started.crafting.checkmark}"
 				icon: "onastick:crafting_table_on_a_stick"
 			}]
+			description: [
+				"{getting_started.crafting.text.1}"
+				""
+				"{getting_started.crafting.text.2}"
+				""
+				"{getting_started.crafting.text.3}"
+				"{getting_started.crafting.text.4}"
+			]
+			id: "77EA450F77679791"
+			x: 6.0d
+			y: 3.5d
+			title: "{getting_started.crafting.title}"
+			subtitle: "{getting_started.crafting.subtitle}"
+			dependencies: ["175F5611FB7716A4"]
 		}
 		{
-			title: "Recipe Wizardry"
-			icon: "botania:placeholder"
-			x: 9.0d
-			y: 3.5d
-			subtitle: "A recipe is a story that ends with a good meal."
-			description: [
-				"How to use an item? Hover over the item in REI and press \"U\" this will show you the uses, pay attention to the tabs."
-				""
-				"Dont know how to craft an item? Hover over the item and press \"R\"."
-				""
-				"Sometimes you have to start out processing a nugget, instead of an ingot or a block."
-				""
-				"You may need to look at the recipes for the material's respective nugget or sometimes even powders."
-			]
-			dependencies: ["175F5611FB7716A4"]
-			id: "2AB91711E9E7B298"
 			tasks: [{
 				id: "0657F4EC97E5ACAC"
 				type: "checkmark"
-				title: "I know how to use U and R"
+				title: "{getting_started.recipe.checkmark}"
 			}]
+			description: [
+				"{getting_started.recipe.text.1}"
+				""
+				"{getting_started.recipe.text.2}"
+				""
+				"{getting_started.recipe.text.3}"
+				""
+				"{getting_started.recipe.text.4}"
+			]
+			id: "2AB91711E9E7B298"
+			icon: "botania:placeholder"
+			x: 9.0d
+			y: 3.5d
+			title: "{getting_started.recipe.title}"
+			subtitle: "{getting_started.recipe.subtitle}"
+			dependencies: ["175F5611FB7716A4"]
 		}
 		{
-			title: "Fall into the void"
-			x: 5.5d
-			y: 2.0d
-			subtitle: "If you fall into the void you will be teleported to the top of the world."
-			dependencies: ["175F5611FB7716A4"]
-			id: "2A0B08D06A77891A"
 			tasks: [{
 				id: "5880F2C9D23E6209"
 				type: "custom"
-				title: "Fall in the Void"
+				title: "{getting_started.void.checkmark}"
 				icon: "yigd:grave"
 			}]
+			id: "2A0B08D06A77891A"
+			x: 5.5d
+			y: 2.0d
+			title: "{getting_started.void.title}"
 			rewards: [{
 				id: "114D500D32EBB31E"
 				type: "item"
@@ -177,26 +167,14 @@
 					}
 				}
 			}]
+			subtitle: "{getting_started.void.subtitle}"
+			dependencies: ["175F5611FB7716A4"]
 		}
 		{
-			title: "Where are my Trinkets Slots?"
-			x: 7.5d
-			y: 4.0d
-			subtitle: "Use the switch in the upper right of your inventory!"
-			description: [
-				"Inventorio was installed to improve the inventory."
-				""
-				"By default you have a tool-belt and 4 off-hand slots."
-				"You can switch back to the default inventory by using the switch in the upper right."
-				""
-				"Please give feedback in the Discord Server."
-			]
-			dependencies: ["175F5611FB7716A4"]
-			id: "47F9185D2FD40CB1"
 			tasks: [{
 				id: "167928F2A7F92222"
 				type: "checkmark"
-				title: "Inventory Upgrade"
+				title: "{getting_started.trinkets.checkmark}"
 				icon: {
 					id: "itemfilters:or"
 					Count: 1b
@@ -226,41 +204,56 @@
 					}
 				}
 			}]
+			description: [
+				"{getting_started.trinkets.text.1}"
+				""
+				"{getting_started.trinkets.text.2}"
+				"{getting_started.trinkets.text.3}"
+				""
+				"{getting_started.trinkets.text.4}"
+			]
+			id: "47F9185D2FD40CB1"
+			x: 7.5d
+			y: 4.0d
+			title: "{getting_started.trinkets.title}"
+			subtitle: "{getting_started.trinkets.subtitle}"
+			dependencies: ["175F5611FB7716A4"]
 		}
 		{
-			x: 9.0d
-			y: 0.5d
-			subtitle: "Structures are not disabled!"
-			description: [
-				"The Overworld is completely empty, you will not find any structure here."
-				""
-				"The Nether and some dimension like the Sky Islands Dimension or the End are full with common and rare structures to discover."
-				""
-				"Take a look at the Adventurer chapter to find out more detailed informations."
-			]
-			dependencies: ["175F5611FB7716A4"]
-			id: "6AD8B7C385B08389"
 			tasks: [{
 				id: "45480B814453AEE7"
 				type: "checkmark"
-				title: "Where are the Structures?"
+				title: "{getting_started.structures.checkmark}"
 				icon: "minecraft:end_portal_frame"
 			}]
+			description: [
+				"{getting_started.structures.text.1}"
+				""
+				"{getting_started.structures.text.2}"
+				""
+				"{getting_started.structures.text.3}"
+			]
+			id: "6AD8B7C385B08389"
+			x: 9.0d
+			y: 0.5d
+			title: "{getting_started.structures.title}"
+			subtitle: "{getting_started.structures.subtitle}"
+			dependencies: ["175F5611FB7716A4"]
 		}
 		{
-			title: "In case of Emergency"
-			icon: "mcwtrpdoors:metal_warning_trapdoor"
-			x: 7.5d
-			y: 0.0d
-			subtitle: "Use the §f§n/emergency§r command in case you lost your only sapling/bamboo/fishing rod, depending on chosen island."
-			dependencies: ["175F5611FB7716A4"]
-			min_width: 300
-			id: "27C275CE408D4506"
 			tasks: [{
 				id: "4B8FE859920F7A18"
 				type: "checkmark"
+				title: "{getting_started.emergency.checkmark}"
 			}]
+			id: "27C275CE408D4506"
+			icon: "mcwtrpdoors:metal_warning_trapdoor"
+			x: 7.5d
+			y: 0.0d
+			title: "{getting_started.emergency.title}"
+			min_width: 300
+			subtitle: "{getting_started.emergency.subtitle}"
+			dependencies: ["175F5611FB7716A4"]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/industrial_revolution.snbt
+++ b/config/ftbquests/quests/chapters/industrial_revolution.snbt
@@ -1,152 +1,143 @@
 {
-	id: "47B446DF2ABE5972"
-	group: "0815C5D80307ECDF"
-	order_index: 0
-	filename: "industrial_revolution"
-	title: "Industrial Revolution"
-	icon: "indrev:modular_core"
-	default_quest_shape: ""
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "0815C5D80307ECDF"
+	id: "47B446DF2ABE5972"
+	filename: "industrial_revolution"
+	default_quest_shape: ""
+	icon: "indrev:modular_core"
+	title: "Industrial Revolution"
+	order_index: 0
 	quests: [
 		{
-			x: 0.5d
-			y: 1.5d
-			subtitle: "A necessary component for most of Industrial Revolution machines."
-			hide: true
-			id: "428D908D1D50663A"
 			tasks: [{
 				id: "4E645FAF391C2073"
 				type: "item"
 				item: "indrev:nikolite_dust"
 			}]
+			id: "428D908D1D50663A"
+			x: 0.5d
+			y: 1.5d
 			rewards: [{
 				id: "5A6028346E54F85F"
 				type: "item"
 				item: "indrev:guide_book"
 			}]
+			subtitle: "A necessary component for most of Industrial Revolution machines."
+			hide: true
 		}
 		{
-			x: 0.5d
-			y: 2.5d
-			subtitle: "Can store energy. Necessary component for IndRev generators and some machines."
-			dependencies: ["428D908D1D50663A"]
-			id: "4DCC2E29C8C38EC1"
 			tasks: [{
 				id: "336D6F3948BCD7C7"
 				type: "item"
 				item: "indrev:battery"
 			}]
+			dependencies: ["428D908D1D50663A"]
+			subtitle: "Can store energy. Necessary component for IndRev generators and some machines."
+			id: "4DCC2E29C8C38EC1"
+			y: 2.5d
+			x: 0.5d
 		}
 		{
-			x: -0.5d
-			y: 2.0d
-			dependencies: ["428D908D1D50663A"]
-			id: "245E7355D03D0B5B"
 			tasks: [{
 				id: "188F6433BB0EAD1F"
 				type: "item"
 				item: "indrev:circuit_mk1"
 			}]
+			dependencies: ["428D908D1D50663A"]
+			id: "245E7355D03D0B5B"
+			y: 2.0d
+			x: -0.5d
 		}
 		{
-			x: -1.5d
-			y: 2.5d
-			dependencies: ["245E7355D03D0B5B"]
-			id: "617653EA5DA787D8"
 			tasks: [{
 				id: "3386A31EA649048B"
 				type: "item"
 				item: "indrev:circuit_mk2"
 			}]
+			dependencies: ["245E7355D03D0B5B"]
+			id: "617653EA5DA787D8"
+			y: 2.5d
+			x: -1.5d
 		}
 		{
-			x: -0.5d
-			y: 3.0d
-			dependencies: ["617653EA5DA787D8"]
-			id: "2812C0109ACEF9AD"
 			tasks: [{
 				id: "3A5AB8A2241D3C2E"
 				type: "item"
 				item: "indrev:circuit_mk3"
 			}]
+			dependencies: ["617653EA5DA787D8"]
+			id: "2812C0109ACEF9AD"
+			y: 3.0d
+			x: -0.5d
 		}
 		{
-			x: -1.5d
-			y: 3.5d
-			dependencies: ["2812C0109ACEF9AD"]
-			id: "385090906E0A8E18"
 			tasks: [{
 				id: "6BAD0A433DD3500B"
 				type: "item"
 				item: "indrev:circuit_mk4"
 			}]
+			dependencies: ["2812C0109ACEF9AD"]
+			id: "385090906E0A8E18"
+			y: 3.5d
+			x: -1.5d
 		}
 		{
-			x: 1.5d
-			y: 2.0d
-			dependencies: ["428D908D1D50663A"]
-			id: "70B2F3CEE9B60339"
 			tasks: [{
 				id: "6BA7E98598847E8E"
 				type: "item"
 				item: "indrev:cable_mk1"
 			}]
+			dependencies: ["428D908D1D50663A"]
+			id: "70B2F3CEE9B60339"
+			y: 2.0d
+			x: 1.5d
 		}
 		{
-			x: 2.5d
-			y: 2.5d
-			dependencies: ["70B2F3CEE9B60339"]
-			id: "6A00D6AC2A102E90"
 			tasks: [{
 				id: "2048710F1129BED2"
 				type: "item"
 				item: "indrev:cable_mk2"
 			}]
+			dependencies: ["70B2F3CEE9B60339"]
+			id: "6A00D6AC2A102E90"
+			y: 2.5d
+			x: 2.5d
 		}
 		{
-			x: 1.5d
-			y: 3.0d
-			dependencies: ["6A00D6AC2A102E90"]
-			id: "5D963FF7D56AE8BA"
 			tasks: [{
 				id: "4AE406CE61975A36"
 				type: "item"
 				item: "indrev:cable_mk3"
 			}]
+			dependencies: ["6A00D6AC2A102E90"]
+			id: "5D963FF7D56AE8BA"
+			y: 3.0d
+			x: 1.5d
 		}
 		{
-			x: 2.5d
-			y: 3.5d
-			dependencies: ["5D963FF7D56AE8BA"]
-			id: "6E475FEF7A259851"
 			tasks: [{
 				id: "40E80EEF935C2BDC"
 				type: "item"
 				item: "indrev:cable_mk4"
 			}]
+			dependencies: ["5D963FF7D56AE8BA"]
+			id: "6E475FEF7A259851"
+			y: 3.5d
+			x: 2.5d
 		}
 		{
-			x: 1.5d
-			y: -2.0d
-			dependencies: ["2681D79AC994F938"]
-			id: "34CB6B9511E3A181"
 			tasks: [{
 				id: "2220DECB715FB9A6"
 				type: "item"
 				item: "indrev:machine_block"
 			}]
+			dependencies: ["2681D79AC994F938"]
+			id: "34CB6B9511E3A181"
+			y: -2.0d
+			x: 1.5d
 		}
 		{
-			title: "Useful Machines"
-			x: 0.5d
-			y: -3.5d
-			description: [
-				"Compressor will compress Ingots into Plates and Curved Plates. It's also the only machine that can craft Basic Enhancers."
-				""
-				"Solid Infuser is mainly used to create Nikolite Ingots and Enriched Nikolite (Dust and Ingots) necessary for upgrades!"
-			]
-			dependencies: ["34CB6B9511E3A181"]
-			id: "289277F2CC26EA5C"
 			tasks: [
 				{
 					id: "5132CEAC048CA51C"
@@ -159,20 +150,18 @@
 					item: "indrev:solid_infuser_mk1"
 				}
 			]
+			description: [
+				"Compressor will compress Ingots into Plates and Curved Plates. It's also the only machine that can craft Basic Enhancers."
+				""
+				"Solid Infuser is mainly used to create Nikolite Ingots and Enriched Nikolite (Dust and Ingots) necessary for upgrades!"
+			]
+			id: "289277F2CC26EA5C"
+			x: 0.5d
+			y: -3.5d
+			title: "Useful Machines"
+			dependencies: ["34CB6B9511E3A181"]
 		}
 		{
-			title: "Early IndRev Generators"
-			x: 1.5d
-			y: 0.0d
-			description: [
-				"The Coal Generator will burn furnace fuel to generate Energy."
-				""
-				"The Solar Generator will produce energy, when exposed to sunlight."
-				""
-				"Heat Generator will generate energy from lava."
-			]
-			dependencies: ["34CB6B9511E3A181"]
-			id: "6E4BAB70886BD52F"
 			tasks: [
 				{
 					id: "5450CA8A7BC9A8C2"
@@ -194,28 +183,20 @@
 					item: "indrev:heat_generator_mk4"
 				}
 			]
+			description: [
+				"The Coal Generator will burn furnace fuel to generate Energy."
+				""
+				"The Solar Generator will produce energy, when exposed to sunlight."
+				""
+				"Heat Generator will generate energy from lava."
+			]
+			id: "6E4BAB70886BD52F"
+			x: 1.5d
+			y: 0.0d
+			title: "Early IndRev Generators"
+			dependencies: ["34CB6B9511E3A181"]
 		}
 		{
-			title: "Everyday Life Automation"
-			x: 2.5d
-			y: -0.5d
-			subtitle: "When you are not feeling very Create-ive."
-			description: [
-				"Chopper will chop nearby trees! Just give it an axe and watch it go!"
-				""
-				"Rancher will feed nearby animals with food and kill excess animals using a Sword."
-				"Also can milk Cows, if you give it some Buckets."
-				""
-				"Slaughter will kill nearby mobs (but not players) using a Sword."
-				""
-				"Farmer will automatically plant seeds onto Farmland and fertilize them with Bone Meal."
-				""
-				"Fisher will fish §nvanilla§r fish, junk and treasure."
-				""
-				"Pump will pump out liquids. No infinite lava with this, sorry."
-			]
-			dependencies: ["34CB6B9511E3A181"]
-			id: "71F58B6350BD82CD"
 			tasks: [
 				{
 					id: "53A655EB3EC645AA"
@@ -252,51 +233,71 @@
 					item: "indrev:pump_mk1"
 				}
 			]
+			description: [
+				"Chopper will chop nearby trees! Just give it an axe and watch it go!"
+				""
+				"Rancher will feed nearby animals with food and kill excess animals using a Sword."
+				"Also can milk Cows, if you give it some Buckets."
+				""
+				"Slaughter will kill nearby mobs (but not players) using a Sword."
+				""
+				"Farmer will automatically plant seeds onto Farmland and fertilize them with Bone Meal."
+				""
+				"Fisher will fish §nvanilla§r fish, junk and treasure."
+				""
+				"Pump will pump out liquids. No infinite lava with this, sorry."
+			]
+			id: "71F58B6350BD82CD"
+			x: 2.5d
+			y: -0.5d
+			title: "Everyday Life Automation"
+			subtitle: "When you are not feeling very Create-ive."
+			dependencies: ["34CB6B9511E3A181"]
 		}
 		{
-			x: 3.0d
-			y: -1.5d
-			subtitle: "Recycles plants into Biomass. Useful in Biomass Generator."
-			dependencies: ["34CB6B9511E3A181"]
-			id: "6240B51E9838436B"
 			tasks: [{
 				id: "48EDE8A9F3742FD0"
 				type: "item"
 				item: "indrev:recycler_mk2"
 			}]
+			dependencies: ["34CB6B9511E3A181"]
+			subtitle: "Recycles plants into Biomass. Useful in Biomass Generator."
+			id: "6240B51E9838436B"
+			y: -1.5d
+			x: 3.0d
 		}
 		{
-			x: 4.0d
-			y: -1.5d
-			subtitle: "Generates Energy using Biomass as fuel."
-			dependencies: ["6240B51E9838436B"]
-			id: "399DB13C91286EE5"
 			tasks: [{
 				id: "5675AB31C4A8419D"
 				type: "item"
 				item: "indrev:biomass_generator_mk3"
 			}]
+			dependencies: ["6240B51E9838436B"]
+			subtitle: "Generates Energy using Biomass as fuel."
+			id: "399DB13C91286EE5"
+			y: -1.5d
+			x: 4.0d
 		}
 		{
-			x: 3.0d
-			y: -2.5d
-			dependencies: ["34CB6B9511E3A181"]
-			id: "7F6A049779DF7B77"
 			tasks: [{
 				id: "59E6D7D787DF50FD"
 				type: "item"
 				item: "indrev:laser_emitter_mk4"
 			}]
+			dependencies: ["34CB6B9511E3A181"]
+			id: "7F6A049779DF7B77"
+			y: -2.5d
+			x: 3.0d
 		}
 		{
-			x: 5.75d
-			y: -3.5d
+			size: 1.5d
 			dependencies: [
 				"7F6A049779DF7B77"
 				"5ED3F7AADE5D813D"
 			]
-			size: 1.5d
 			id: "2A086C1BEF19C1B3"
+			y: -3.5d
+			x: 5.75d
 			tasks: [{
 				id: "43B8A2F4FE7B0F5B"
 				type: "item"
@@ -304,74 +305,62 @@
 			}]
 		}
 		{
-			x: 5.75d
-			y: -2.0d
-			hide_dependency_lines: true
-			dependencies: ["428D908D1D50663A"]
-			id: "5ED3F7AADE5D813D"
 			tasks: [{
 				id: "4C4E4443823391C0"
 				type: "item"
 				item: "indrev:modular_core"
 			}]
+			dependencies: ["428D908D1D50663A"]
+			id: "5ED3F7AADE5D813D"
+			hide_dependency_lines: true
+			y: -2.0d
+			x: 5.75d
 		}
 		{
-			x: 4.5d
-			y: -4.25d
-			dependencies: ["2A086C1BEF19C1B3"]
-			id: "16EE0728FF1DBA43"
 			tasks: [{
 				id: "3710EF43A7FD8AD5"
 				type: "item"
 				item: "indrev:modular_armor_helmet"
 			}]
+			dependencies: ["2A086C1BEF19C1B3"]
+			id: "16EE0728FF1DBA43"
+			y: -4.25d
+			x: 4.5d
 		}
 		{
-			x: 5.25d
-			y: -5.0d
-			dependencies: ["2A086C1BEF19C1B3"]
-			id: "5F7A225CCBFD6332"
 			tasks: [{
 				id: "038C042BB5F65ACB"
 				type: "item"
 				item: "indrev:modular_armor_chest"
 			}]
+			dependencies: ["2A086C1BEF19C1B3"]
+			id: "5F7A225CCBFD6332"
+			y: -5.0d
+			x: 5.25d
 		}
 		{
-			x: 6.25d
-			y: -5.0d
-			dependencies: ["2A086C1BEF19C1B3"]
-			id: "40886B9C62B55687"
 			tasks: [{
 				id: "039923E436D94681"
 				type: "item"
 				item: "indrev:modular_armor_legs"
 			}]
+			dependencies: ["2A086C1BEF19C1B3"]
+			id: "40886B9C62B55687"
+			y: -5.0d
+			x: 6.25d
 		}
 		{
-			x: 7.0d
-			y: -4.25d
-			dependencies: ["2A086C1BEF19C1B3"]
-			id: "273B3D8B8A850C8B"
 			tasks: [{
 				id: "524D5B6C713CA128"
 				type: "item"
 				item: "indrev:modular_armor_boots"
 			}]
+			dependencies: ["2A086C1BEF19C1B3"]
+			id: "273B3D8B8A850C8B"
+			y: -4.25d
+			x: 7.0d
 		}
 		{
-			x: 7.5d
-			y: -1.5d
-			subtitle: "§cR§aG§9B§r On!"
-			description: [
-				"A powerful Battle§7§mstation§r Axe!"
-				"Make sure to activate it first."
-				""
-				"It uses a lot of energy when active."
-			]
-			hide_dependency_lines: true
-			dependencies: ["428D908D1D50663A"]
-			id: "1420C663EF1091DF"
 			tasks: [{
 				id: "378A01D702DAB28D"
 				type: "item"
@@ -387,59 +376,65 @@
 					}
 				}
 			}]
+			description: [
+				"A powerful Battle§7§mstation§r Axe!"
+				"Make sure to activate it first."
+				""
+				"It uses a lot of energy when active."
+			]
+			id: "1420C663EF1091DF"
+			x: 7.5d
+			y: -1.5d
+			subtitle: "§cR§aG§9B§r On!"
+			dependencies: ["428D908D1D50663A"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 5.0d
-			y: 0.0d
-			hide_dependency_lines: true
-			dependencies: ["428D908D1D50663A"]
-			id: "772A27C0FEA18CC3"
 			tasks: [{
 				id: "01C75274D029A382"
 				type: "item"
 				item: "indrev:mining_drill_mk1"
 			}]
+			dependencies: ["428D908D1D50663A"]
+			id: "772A27C0FEA18CC3"
+			hide_dependency_lines: true
+			y: 0.0d
+			x: 5.0d
 		}
 		{
-			x: 6.0d
-			y: 0.5d
-			dependencies: ["772A27C0FEA18CC3"]
-			id: "7BABC045AEE32D6B"
 			tasks: [{
 				id: "249DEAB0C2BCEA0F"
 				type: "item"
 				item: "indrev:mining_drill_mk2"
 			}]
+			dependencies: ["772A27C0FEA18CC3"]
+			id: "7BABC045AEE32D6B"
+			y: 0.5d
+			x: 6.0d
 		}
 		{
-			x: 5.0d
-			y: 1.0d
-			dependencies: ["7BABC045AEE32D6B"]
-			id: "50EB6F30AF7D5196"
 			tasks: [{
 				id: "464D9AC4B47A8637"
 				type: "item"
 				item: "indrev:mining_drill_mk3"
 			}]
+			dependencies: ["7BABC045AEE32D6B"]
+			id: "50EB6F30AF7D5196"
+			y: 1.0d
+			x: 5.0d
 		}
 		{
-			x: 6.0d
-			y: 1.5d
-			dependencies: ["50EB6F30AF7D5196"]
-			id: "0E14F16C796D52F4"
 			tasks: [{
 				id: "2B15BF240D95FFD9"
 				type: "item"
 				item: "indrev:mining_drill_mk4"
 			}]
+			dependencies: ["50EB6F30AF7D5196"]
+			id: "0E14F16C796D52F4"
+			y: 1.5d
+			x: 6.0d
 		}
 		{
-			x: 0.5d
-			y: 4.5d
-			subtitle: "Pulls from other containers, that do not have Servos on them."
-			hide_dependency_lines: true
-			dependencies: ["428D908D1D50663A"]
-			id: "4322671C875CA6FC"
 			tasks: [{
 				id: "34C6B9481CF10692"
 				type: "item"
@@ -449,13 +444,14 @@
 					tag: { }
 				}
 			}]
+			id: "4322671C875CA6FC"
+			x: 0.5d
+			y: 4.5d
+			subtitle: "Pulls from other containers, that do not have Servos on them."
+			dependencies: ["428D908D1D50663A"]
+			hide_dependency_lines: true
 		}
 		{
-			x: 0.5d
-			y: 3.5d
-			subtitle: "Extracts items or fluids and pushes them to inventories/tanks which have no Servos on them."
-			hide_dependency_lines: true
-			id: "6448FAA4CFC7E232"
 			tasks: [{
 				id: "76D4F972C1A0A633"
 				type: "item"
@@ -465,25 +461,25 @@
 					tag: { }
 				}
 			}]
+			subtitle: "Extracts items or fluids and pushes them to inventories/tanks which have no Servos on them."
+			id: "6448FAA4CFC7E232"
+			hide_dependency_lines: true
+			y: 3.5d
+			x: 0.5d
 		}
 		{
-			x: 2.0d
-			y: -7.0d
-			hide_dependency_lines: true
-			dependencies: ["428D908D1D50663A"]
-			id: "7A49A733257F75CE"
 			tasks: [{
 				id: "10E9DA6F258D5B25"
 				type: "item"
 				item: "indrev:modular_workbench_mk4"
 			}]
+			dependencies: ["428D908D1D50663A"]
+			id: "7A49A733257F75CE"
+			hide_dependency_lines: true
+			y: -7.0d
+			x: 2.0d
 		}
 		{
-			title: "Gamer Axe Modules"
-			x: 1.0d
-			y: -6.5d
-			dependencies: ["7A49A733257F75CE"]
-			id: "27ECDC02B7B9E507"
 			tasks: [
 				{
 					id: "28AD74BA714472A7"
@@ -506,13 +502,13 @@
 					item: "indrev:module_sharpness"
 				}
 			]
+			dependencies: ["7A49A733257F75CE"]
+			id: "27ECDC02B7B9E507"
+			y: -6.5d
+			x: 1.0d
+			title: "Gamer Axe Modules"
 		}
 		{
-			title: "Drill Modules"
-			x: 3.0d
-			y: -6.5d
-			dependencies: ["7A49A733257F75CE"]
-			id: "6B514953DF58B1FB"
 			tasks: [
 				{
 					id: "7C1D44BD1C6D6D5C"
@@ -535,16 +531,13 @@
 					item: "indrev:module_silk_touch"
 				}
 			]
+			dependencies: ["7A49A733257F75CE"]
+			id: "6B514953DF58B1FB"
+			y: -6.5d
+			x: 3.0d
+			title: "Drill Modules"
 		}
 		{
-			title: "§cC§6o§el§ao§br§3s§9!§r"
-			x: 3.0d
-			y: -5.5d
-			subtitle: "Can you find them all?"
-			description: ["Available only in loot chests!"]
-			hide_dependency_lines: true
-			dependencies: ["428D908D1D50663A"]
-			id: "17EC65D282425DF9"
 			tasks: [
 				{
 					id: "4AC6071E697050C4"
@@ -597,19 +590,22 @@
 					item: "indrev:module_color_brown"
 				}
 			]
+			description: ["Available only in loot chests!"]
+			id: "17EC65D282425DF9"
+			x: 3.0d
+			y: -5.5d
+			title: "§cC§6o§el§ao§br§3s§9!§r"
 			rewards: [{
 				id: "139E6603D5857B2D"
 				type: "item"
 				item: "blockus:rainbow_block"
 				count: 256
 			}]
+			subtitle: "Can you find them all?"
+			dependencies: ["428D908D1D50663A"]
+			hide_dependency_lines: true
 		}
 		{
-			title: "Modular Armor Modules"
-			x: 2.0d
-			y: -6.0d
-			dependencies: ["7A49A733257F75CE"]
-			id: "6989E5360556BEA2"
 			tasks: [
 				{
 					id: "44F8B7608583045C"
@@ -672,50 +668,49 @@
 					item: "indrev:module_fire_resistance"
 				}
 			]
+			dependencies: ["7A49A733257F75CE"]
+			id: "6989E5360556BEA2"
+			y: -6.0d
+			x: 2.0d
+			title: "Modular Armor Modules"
 		}
 		{
-			x: -1.5d
-			y: -4.5d
-			subtitle: "A base for all other enhancers."
-			dependencies: ["289277F2CC26EA5C"]
-			id: "52E6CFAF03B88892"
 			tasks: [{
 				id: "6A880D562F340718"
 				type: "item"
 				item: "indrev:empty_enhancer"
 			}]
+			dependencies: ["289277F2CC26EA5C"]
+			subtitle: "A base for all other enhancers."
+			id: "52E6CFAF03B88892"
+			y: -4.5d
+			x: -1.5d
 		}
 		{
-			x: -1.5d
-			y: -5.5d
-			subtitle: "Increases machine's internal energy buffer."
-			dependencies: ["52E6CFAF03B88892"]
-			id: "70FD9D5F81F3D7CF"
 			tasks: [{
 				id: "67F133131E7892CD"
 				type: "item"
 				item: "indrev:buffer_enhancer"
 			}]
+			dependencies: ["52E6CFAF03B88892"]
+			subtitle: "Increases machine's internal energy buffer."
+			id: "70FD9D5F81F3D7CF"
+			y: -5.5d
+			x: -1.5d
 		}
 		{
-			x: -0.5d
-			y: -5.0d
-			subtitle: "Speeds up your machines, at the cost of increased energy consumption."
-			dependencies: ["52E6CFAF03B88892"]
-			id: "3F344986307D0CDD"
 			tasks: [{
 				id: "61EA57661CDD937A"
 				type: "item"
 				item: "indrev:speed_enhancer"
 			}]
+			dependencies: ["52E6CFAF03B88892"]
+			subtitle: "Speeds up your machines, at the cost of increased energy consumption."
+			id: "3F344986307D0CDD"
+			y: -5.0d
+			x: -0.5d
 		}
 		{
-			title: "Furnace Enhancers"
-			x: -2.5d
-			y: -5.0d
-			subtitle: "Wanted your Electric Furnace to be a Smoker or a Blast Furnace? Well, here you go!"
-			dependencies: ["52E6CFAF03B88892"]
-			id: "6E7FDB6D0A6C5990"
 			tasks: [
 				{
 					id: "2BFB8863CEE8F979"
@@ -728,98 +723,104 @@
 					item: "indrev:blast_furnace_enhancer"
 				}
 			]
+			id: "6E7FDB6D0A6C5990"
+			x: -2.5d
+			y: -5.0d
+			title: "Furnace Enhancers"
+			subtitle: "Wanted your Electric Furnace to be a Smoker or a Blast Furnace? Well, here you go!"
+			dependencies: ["52E6CFAF03B88892"]
 		}
 		{
-			x: -2.5d
-			y: -4.0d
-			subtitle: "Increases damage dealt by the Slaughter."
-			dependencies: ["52E6CFAF03B88892"]
-			id: "306312B20D074AC1"
 			tasks: [{
 				id: "6B314C59D898287C"
 				type: "item"
 				item: "indrev:damage_enhancer"
 			}]
+			dependencies: ["52E6CFAF03B88892"]
+			subtitle: "Increases damage dealt by the Slaughter."
+			id: "306312B20D074AC1"
+			y: -4.0d
+			x: -2.5d
 		}
 		{
-			x: -2.5d
-			y: -6.0d
-			hide_dependency_lines: true
-			dependencies: ["428D908D1D50663A"]
-			id: "45B201DECF303FC3"
 			tasks: [{
 				id: "33D2E63BB770BD37"
 				type: "item"
 				item: "indrev:tier_upgrade_mk2"
 			}]
+			dependencies: ["428D908D1D50663A"]
+			id: "45B201DECF303FC3"
+			hide_dependency_lines: true
+			y: -6.0d
+			x: -2.5d
 		}
 		{
-			x: -1.5d
-			y: -6.5d
-			dependencies: ["45B201DECF303FC3"]
-			id: "58F4CF80BA57D131"
 			tasks: [{
 				id: "09D0FD980415BAC5"
 				type: "item"
 				item: "indrev:tier_upgrade_mk3"
 			}]
+			dependencies: ["45B201DECF303FC3"]
+			id: "58F4CF80BA57D131"
+			y: -6.5d
+			x: -1.5d
 		}
 		{
-			x: -0.5d
-			y: -6.0d
-			dependencies: ["58F4CF80BA57D131"]
-			id: "526ACAAFC01D3B83"
 			tasks: [{
 				id: "23DEE37DA3016F67"
 				type: "item"
 				item: "indrev:tier_upgrade_mk4"
 			}]
+			dependencies: ["58F4CF80BA57D131"]
+			id: "526ACAAFC01D3B83"
+			y: -6.0d
+			x: -0.5d
 		}
 		{
-			x: -0.5d
-			y: 4.0d
-			hide_dependency_lines: true
-			dependencies: ["428D908D1D50663A"]
-			hide: true
-			id: "43B60B1316B892EC"
 			tasks: [{
 				id: "4B1E666D688E1991"
 				type: "item"
 				item: "indrev:fluid_pipe_mk1"
 			}]
+			id: "43B60B1316B892EC"
+			x: -0.5d
+			y: 4.0d
+			dependencies: ["428D908D1D50663A"]
+			hide_dependency_lines: true
+			hide: true
 		}
 		{
-			x: -1.5d
-			y: 4.5d
-			dependencies: ["43B60B1316B892EC"]
-			id: "19C02E6D0184BED7"
 			tasks: [{
 				id: "4A4C0210B0992856"
 				type: "item"
 				item: "indrev:fluid_pipe_mk2"
 			}]
+			dependencies: ["43B60B1316B892EC"]
+			id: "19C02E6D0184BED7"
+			y: 4.5d
+			x: -1.5d
 		}
 		{
-			x: -0.5d
-			y: 5.0d
-			dependencies: ["19C02E6D0184BED7"]
-			id: "100E76829F766A5A"
 			tasks: [{
 				id: "1772C504CF4C00F6"
 				type: "item"
 				item: "indrev:fluid_pipe_mk3"
 			}]
+			dependencies: ["19C02E6D0184BED7"]
+			id: "100E76829F766A5A"
+			y: 5.0d
+			x: -0.5d
 		}
 		{
-			x: -1.5d
-			y: 5.5d
-			dependencies: ["100E76829F766A5A"]
-			id: "7B2FB931A6741C82"
 			tasks: [{
 				id: "6BE37E6D1DD530D8"
 				type: "item"
 				item: "indrev:fluid_pipe_mk4"
 			}]
+			dependencies: ["100E76829F766A5A"]
+			id: "7B2FB931A6741C82"
+			y: 5.5d
+			x: -1.5d
 			rewards: [
 				{
 					id: "2C2D90392FE0F96D"
@@ -834,13 +835,6 @@
 			]
 		}
 		{
-			x: -1.5d
-			y: 1.5d
-			subtitle: "Cools down your machines."
-			description: ["Having a hot machine gives it better stats without Enhancers, but it also makes Speed Enhancers less effective!"]
-			hide_dependency_lines: true
-			dependencies: ["428D908D1D50663A"]
-			id: "11242FB4797B538A"
 			tasks: [{
 				id: "724437C91E05D989"
 				type: "item"
@@ -852,14 +846,15 @@
 					}
 				}
 			}]
+			description: ["Having a hot machine gives it better stats without Enhancers, but it also makes Speed Enhancers less effective!"]
+			id: "11242FB4797B538A"
+			x: -1.5d
+			y: 1.5d
+			subtitle: "Cools down your machines."
+			dependencies: ["428D908D1D50663A"]
+			hide_dependency_lines: true
 		}
 		{
-			x: -0.5d
-			y: 1.0d
-			subtitle: "Cools your machine even better than a fan."
-			description: ["Having a hot machine gives it better stats without Enhancers, but it also makes Speed Enhancers less effective!"]
-			dependencies: ["11242FB4797B538A"]
-			id: "164986E5D251C09A"
 			tasks: [{
 				id: "3989D4EC12527835"
 				type: "item"
@@ -871,19 +866,14 @@
 					}
 				}
 			}]
+			description: ["Having a hot machine gives it better stats without Enhancers, but it also makes Speed Enhancers less effective!"]
+			id: "164986E5D251C09A"
+			x: -0.5d
+			y: 1.0d
+			subtitle: "Cools your machine even better than a fan."
+			dependencies: ["11242FB4797B538A"]
 		}
 		{
-			title: "Required ingredients!"
-			disable_toast: true
-			x: 1.5d
-			y: -4.0d
-			subtitle: "A Standard Machine Casing and Nikolite is required to progress here."
-			hide_dependency_lines: true
-			dependencies: [
-				"244120BFE2DF2741"
-				"428D908D1D50663A"
-			]
-			id: "2681D79AC994F938"
 			tasks: [
 				{
 					id: "5BD92F59555258BD"
@@ -896,18 +886,19 @@
 					item: "indrev:nikolite_dust"
 				}
 			]
+			id: "2681D79AC994F938"
+			x: 1.5d
+			disable_toast: true
+			y: -4.0d
+			title: "Required ingredients!"
+			subtitle: "A Standard Machine Casing and Nikolite is required to progress here."
+			dependencies: [
+				"244120BFE2DF2741"
+				"428D908D1D50663A"
+			]
+			hide_dependency_lines: true
 		}
 		{
-			title: "Vanilla Upgrades"
-			x: 2.5d
-			y: -3.5d
-			description: [
-				"Pulverizer will grind your ores into dusts. It can 1.5x your raw ores and 3x your ore blocks."
-				""
-				"Electric Furnace is well, a version of vanilla Furnace that accepts energy and enhancers."
-			]
-			dependencies: ["34CB6B9511E3A181"]
-			id: "40451EEB7512C94B"
 			tasks: [
 				{
 					id: "6F51F096279B10C7"
@@ -920,24 +911,18 @@
 					item: "indrev:electric_furnace_mk1"
 				}
 			]
+			description: [
+				"Pulverizer will grind your ores into dusts. It can 1.5x your raw ores and 3x your ore blocks."
+				""
+				"Electric Furnace is well, a version of vanilla Furnace that accepts energy and enhancers."
+			]
+			id: "40451EEB7512C94B"
+			x: 2.5d
+			y: -3.5d
+			title: "Vanilla Upgrades"
+			dependencies: ["34CB6B9511E3A181"]
 		}
 		{
-			title: "The Mining Rig"
-			x: 0.5d
-			y: -0.5d
-			subtitle: "From where do the Ores come from?"
-			description: [
-				"From below the void, of course!"
-				""
-				"Insert the Data Card that has been encoded in the Data Card Encoder to start mining!"
-				""
-				"You can place up to 8 Mining Rig Drills around the Computer."
-				""
-				"The more and the better the drills are, the faster they mine!"
-				"But remember - more speed = more energy consumed."
-			]
-			dependencies: ["34CB6B9511E3A181"]
-			id: "76C99EA3D7B58C3D"
 			tasks: [
 				{
 					id: "51936BD704A4642E"
@@ -950,25 +935,24 @@
 					item: "indrev:drill_bottom"
 				}
 			]
+			description: [
+				"From below the void, of course!"
+				""
+				"Insert the Data Card that has been encoded in the Data Card Encoder to start mining!"
+				""
+				"You can place up to 8 Mining Rig Drills around the Computer."
+				""
+				"The more and the better the drills are, the faster they mine!"
+				"But remember - more speed = more energy consumed."
+			]
+			id: "76C99EA3D7B58C3D"
+			x: 0.5d
+			y: -0.5d
+			title: "The Mining Rig"
+			subtitle: "From where do the Ores come from?"
+			dependencies: ["34CB6B9511E3A181"]
 		}
 		{
-			x: 0.0d
-			y: -1.5d
-			subtitle: "Smeltery Upgrades!"
-			description: [
-				"The Industrial Smeltery will melt your metal ores into their Hephaestus molten form."
-				""
-				"It also can melt Purified Raw Ores to 2 ingots worth of Molten metal!"
-				""
-				"Due to technical difficulties, it can't melt non-metals."
-				""
-				"The Ingot Former will cool down molten metal, forming it into Ingots!"
-				""
-				"These machines operate at the rate of the default Smeltery melting and Ingot cooling respectively."
-				"You can add up to 16 Speed Enhancers for blast processing!"
-			]
-			dependencies: ["34CB6B9511E3A181"]
-			id: "290344044301C12F"
 			tasks: [
 				{
 					id: "315706CC8080634C"
@@ -981,29 +965,48 @@
 					item: "indrev:condenser_mk4"
 				}
 			]
+			description: [
+				"The Industrial Smeltery will melt your metal ores into their Hephaestus molten form."
+				""
+				"It also can melt Purified Raw Ores to 2 ingots worth of Molten metal!"
+				""
+				"Due to technical difficulties, it can't melt non-metals."
+				""
+				"The Ingot Former will cool down molten metal, forming it into Ingots!"
+				""
+				"These machines operate at the rate of the default Smeltery melting and Ingot cooling respectively."
+				"You can add up to 16 Speed Enhancers for blast processing!"
+			]
+			id: "290344044301C12F"
+			x: 0.0d
+			y: -1.5d
+			subtitle: "Smeltery Upgrades!"
+			dependencies: ["34CB6B9511E3A181"]
 		}
 		{
-			x: 0.0d
-			y: -2.5d
-			subtitle: "Will infuse items with liquids."
-			description: [
-				"A necessary machine, if you want to create some Coolant for your coolers and Speed Enhancers!"
-				""
-				"It also can purify raw ores using 50 mB of MI Sulfuric Acid. These can be later melted in the Industrial Smeltery for getting 2 ingots from 1 raw ore!"
-			]
-			dependencies: ["34CB6B9511E3A181"]
-			min_width: 250
-			id: "393E2DBB6400A2AA"
 			tasks: [{
 				id: "7863115B8EF7BA52"
 				type: "item"
 				item: "indrev:fluid_infuser_mk1"
 			}]
+			description: [
+				"A necessary machine, if you want to create some Coolant for your coolers and Speed Enhancers!"
+				""
+				"It also can purify raw ores using 50 mB of MI Sulfuric Acid. These can be later melted in the Industrial Smeltery for getting 2 ingots from 1 raw ore!"
+			]
+			id: "393E2DBB6400A2AA"
+			x: 0.0d
+			y: -2.5d
+			min_width: 250
+			subtitle: "Will infuse items with liquids."
+			dependencies: ["34CB6B9511E3A181"]
 		}
 		{
-			x: -0.5d
-			y: -0.5d
-			subtitle: "Encodes Data Cards for use in the Mining Rig."
+			tasks: [{
+				id: "33AE48881443CDF1"
+				type: "item"
+				item: "indrev:data_card_writer_mk4"
+			}]
 			description: [
 				"Insert stacks of Ores or Ancient Debris to start encoding!"
 				""
@@ -1017,24 +1020,22 @@
 				""
 				"Encoding too many different ores can also cause the Data Card to be corrupted and unusable."
 			]
-			dependencies: ["76C99EA3D7B58C3D"]
 			id: "075603D7C8FB1B13"
-			tasks: [{
-				id: "33AE48881443CDF1"
-				type: "item"
-				item: "indrev:data_card_writer_mk4"
-			}]
+			x: -0.5d
+			y: -0.5d
+			subtitle: "Encodes Data Cards for use in the Mining Rig."
+			dependencies: ["76C99EA3D7B58C3D"]
 		}
 		{
-			x: -2.5d
-			y: -2.0d
-			subtitle: "Don't screw yourself!"
+			size: 1.5d
 			description: [
 				"It can configure Industrial Revolution Machines."
 				"Right-Click a Machine with a Screwdriver in hand to configure its input and output sides."
 			]
-			size: 1.5d
 			id: "1EE0FFB64F8C8DD1"
+			x: -2.5d
+			y: -2.0d
+			subtitle: "Don't screw yourself!"
 			tasks: [{
 				id: "50AD18D157DED1B0"
 				type: "item"
@@ -1042,5 +1043,4 @@
 			}]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/infinity.snbt
+++ b/config/ftbquests/quests/chapters/infinity.snbt
@@ -1,35 +1,116 @@
 {
-	id: "55534E1BE135C3C1"
-	group: "1FCC565F739A4207"
-	order_index: 0
-	filename: "infinity"
-	title: "Challenges"
-	icon: "croptopia:starfruit"
 	always_invisible: true
-	default_quest_shape: ""
 	default_hide_dependency_lines: false
+	default_quest_shape: ""
+	group: "1FCC565F739A4207"
+	id: "55534E1BE135C3C1"
+	filename: "infinity"
+	icon: "croptopia:starfruit"
+	title: "Challenges"
+	order_index: 0
 	quests: [
 		{
-			title: "Are you worthy?"
-			x: 0.5d
-			y: 0.5d
-			subtitle: "Kill the Ender Dragon to unlock challenges."
 			size: 1.8d
 			id: "512CAEB25CD9B4E2"
+			x: 0.5d
+			y: 0.5d
+			title: "Are you worthy?"
+			subtitle: "Kill the Ender Dragon to unlock challenges."
 			tasks: [{
-				id: "3A9ABB487CD82821"
 				type: "kill"
+				value: 1L
+				id: "3A9ABB487CD82821"
 				icon: "minecraft:dragon_head"
 				entity: "minecraft:ender_dragon"
-				value: 1L
 			}]
 		}
 		{
-			title: "Hell's Kitchen"
-			icon: "farmersdelight:cooking_pot"
-			x: 3.0d
-			y: -1.0d
-			subtitle: "So when people ask me, ‘What do you think of Michelin?’ I don’t cook for guides. I cook for customers."
+			tasks: [
+				{
+					type: "item"
+					count: 2500L
+					consume_items: true
+					id: "6E802DA4BECBA8FD"
+					item: "farmersdelight:steak_and_potatoes"
+				}
+				{
+					type: "item"
+					count: 2500L
+					consume_items: true
+					id: "220729A89B4CACBC"
+					item: "farmersdelight:pasta_with_mutton_chop"
+				}
+				{
+					type: "item"
+					count: 2500L
+					consume_items: true
+					id: "73CDF0DFBCE93D91"
+					item: "farmersdelight:grilled_salmon"
+				}
+				{
+					type: "item"
+					count: 2500L
+					consume_items: true
+					id: "776FA22E4BF48CA4"
+					item: "farmersdelight:stuffed_potato"
+				}
+				{
+					type: "item"
+					count: 2500L
+					consume_items: true
+					id: "116F0EAC536F98E0"
+					item: "farmersdelight:barbecue_stick"
+				}
+				{
+					type: "item"
+					count: 2500L
+					consume_items: true
+					id: "2ECF53D6587A8AA1"
+					item: "farmersdelight:roast_chicken_block"
+				}
+				{
+					type: "item"
+					count: 2500L
+					consume_items: true
+					id: "36AD733AEFC78B15"
+					item: "croptopia:fish_and_chips"
+				}
+				{
+					type: "item"
+					count: 2500L
+					consume_items: true
+					id: "71C16F3D34ABA15E"
+					item: "farmersdelight:dumplings"
+				}
+				{
+					type: "item"
+					count: 2500L
+					consume_items: true
+					id: "2E2A693C93C5A838"
+					item: "croptopia:tres_leche_cake"
+				}
+				{
+					type: "item"
+					count: 2500L
+					consume_items: true
+					id: "0881465B825D57BD"
+					item: "croptopia:trifle"
+				}
+				{
+					type: "item"
+					count: 2500L
+					consume_items: true
+					id: "12D4B1763C101794"
+					item: "croptopia:sticky_toffee_pudding"
+				}
+				{
+					type: "item"
+					count: 2500L
+					consume_items: true
+					id: "3B3A38AFCEE30AD1"
+					item: "croptopia:pumpkin_spice_latte"
+				}
+			]
 			description: [
 				"To submit items, left click the food type of choice and hand in."
 				""
@@ -39,107 +120,72 @@
 				""
 				"Put buckets in said Tank Unit and have them output into either a buffer or directly into ME, craft these into Water Bottles from Croptopia."
 			]
-			dependencies: ["512CAEB25CD9B4E2"]
 			id: "18035D9544EC01DA"
-			tasks: [
-				{
-					id: "6E802DA4BECBA8FD"
-					type: "item"
-					item: "farmersdelight:steak_and_potatoes"
-					count: 2500L
-					consume_items: true
-				}
-				{
-					id: "220729A89B4CACBC"
-					type: "item"
-					item: "farmersdelight:pasta_with_mutton_chop"
-					count: 2500L
-					consume_items: true
-				}
-				{
-					id: "73CDF0DFBCE93D91"
-					type: "item"
-					item: "farmersdelight:grilled_salmon"
-					count: 2500L
-					consume_items: true
-				}
-				{
-					id: "776FA22E4BF48CA4"
-					type: "item"
-					item: "farmersdelight:stuffed_potato"
-					count: 2500L
-					consume_items: true
-				}
-				{
-					id: "116F0EAC536F98E0"
-					type: "item"
-					item: "farmersdelight:barbecue_stick"
-					count: 2500L
-					consume_items: true
-				}
-				{
-					id: "2ECF53D6587A8AA1"
-					type: "item"
-					item: "farmersdelight:roast_chicken_block"
-					count: 2500L
-					consume_items: true
-				}
-				{
-					id: "36AD733AEFC78B15"
-					type: "item"
-					item: "croptopia:fish_and_chips"
-					count: 2500L
-					consume_items: true
-				}
-				{
-					id: "71C16F3D34ABA15E"
-					type: "item"
-					item: "farmersdelight:dumplings"
-					count: 2500L
-					consume_items: true
-				}
-				{
-					id: "2E2A693C93C5A838"
-					type: "item"
-					item: "croptopia:tres_leche_cake"
-					count: 2500L
-					consume_items: true
-				}
-				{
-					id: "0881465B825D57BD"
-					type: "item"
-					item: "croptopia:trifle"
-					count: 2500L
-					consume_items: true
-				}
-				{
-					id: "12D4B1763C101794"
-					type: "item"
-					item: "croptopia:sticky_toffee_pudding"
-					count: 2500L
-					consume_items: true
-				}
-				{
-					id: "3B3A38AFCEE30AD1"
-					type: "item"
-					item: "croptopia:pumpkin_spice_latte"
-					count: 2500L
-					consume_items: true
-				}
-			]
+			icon: "farmersdelight:cooking_pot"
+			x: 3.0d
+			y: -1.0d
+			title: "Hell's Kitchen"
+			subtitle: "So when people ask me, ‘What do you think of Michelin?’ I don’t cook for guides. I cook for customers."
+			dependencies: ["512CAEB25CD9B4E2"]
 		}
 		{
-			title: "Boss Rush"
-			icon: {
-				id: "dragonloot:dragon_helmet"
-				Count: 1b
-				tag: {
-					Damage: 0
+			tasks: [
+				{
+					type: "kill"
+					value: 1L
+					id: "6E33DDB7EF109050"
+					icon: "adventurez:stone_golem_heart"
+					entity: "adventurez:stone_golem"
 				}
-			}
-			x: 0.5d
-			y: 2.5d
-			subtitle: "Slay 'em All"
+				{
+					type: "kill"
+					value: 1L
+					id: "4DA5F492F8AD4449"
+					icon: {
+						id: "adventurez:prime_eye"
+						Count: 1b
+						tag: {
+							Damage: 0
+						}
+					}
+					entity: "adventurez:the_eye"
+				}
+				{
+					type: "kill"
+					value: 1L
+					id: "1A43CE833FBD4D06"
+					icon: "bosses_of_mass_destruction:ancient_anima"
+					entity: "bosses_of_mass_destruction:lich"
+				}
+				{
+					type: "kill"
+					value: 1L
+					id: "0FA9460CCC66FF44"
+					icon: "bosses_of_mass_destruction:obsidian_heart"
+					entity: "bosses_of_mass_destruction:obsidilith"
+				}
+				{
+					type: "kill"
+					value: 1L
+					id: "799C560B71E547C7"
+					icon: "bosses_of_mass_destruction:blazing_eye"
+					entity: "bosses_of_mass_destruction:gauntlet"
+				}
+				{
+					type: "kill"
+					value: 1L
+					id: "31C60566337BA9C2"
+					icon: "bosses_of_mass_destruction:void_thorn"
+					entity: "bosses_of_mass_destruction:void_blossom"
+				}
+				{
+					type: "kill"
+					value: 1L
+					id: "1C502D06D2093A4F"
+					icon: "botania:gaia_head"
+					entity: "botania:doppleganger"
+				}
+			]
 			description: [
 				"King Slime:"
 				"Craft a Slime Crown and spawn on use."
@@ -165,71 +211,28 @@
 				"Guardian of Gaia:"
 				"To summon the boss, shift right-click a Terrasteel Ingot on an active Beacon with 4 Gaia Pylons nearby. Using a Gaia Spirit Ingot will summon a harder version of the boss instead."
 			]
-			dependencies: ["512CAEB25CD9B4E2"]
 			id: "1F0EE1298663FE88"
-			tasks: [
-				{
-					id: "6E33DDB7EF109050"
-					type: "kill"
-					icon: "adventurez:stone_golem_heart"
-					entity: "adventurez:stone_golem"
-					value: 1L
+			icon: {
+				id: "dragonloot:dragon_helmet"
+				Count: 1b
+				tag: {
+					Damage: 0
 				}
-				{
-					id: "4DA5F492F8AD4449"
-					type: "kill"
-					icon: {
-						id: "adventurez:prime_eye"
-						Count: 1b
-						tag: {
-							Damage: 0
-						}
-					}
-					entity: "adventurez:the_eye"
-					value: 1L
-				}
-				{
-					id: "1A43CE833FBD4D06"
-					type: "kill"
-					icon: "bosses_of_mass_destruction:ancient_anima"
-					entity: "bosses_of_mass_destruction:lich"
-					value: 1L
-				}
-				{
-					id: "0FA9460CCC66FF44"
-					type: "kill"
-					icon: "bosses_of_mass_destruction:obsidian_heart"
-					entity: "bosses_of_mass_destruction:obsidilith"
-					value: 1L
-				}
-				{
-					id: "799C560B71E547C7"
-					type: "kill"
-					icon: "bosses_of_mass_destruction:blazing_eye"
-					entity: "bosses_of_mass_destruction:gauntlet"
-					value: 1L
-				}
-				{
-					id: "31C60566337BA9C2"
-					type: "kill"
-					icon: "bosses_of_mass_destruction:void_thorn"
-					entity: "bosses_of_mass_destruction:void_blossom"
-					value: 1L
-				}
-				{
-					id: "1C502D06D2093A4F"
-					type: "kill"
-					icon: "botania:gaia_head"
-					entity: "botania:doppleganger"
-					value: 1L
-				}
-			]
+			}
+			x: 0.5d
+			y: 2.5d
+			title: "Boss Rush"
+			subtitle: "Slay 'em All"
+			dependencies: ["512CAEB25CD9B4E2"]
 		}
 		{
-			icon: "farmingforblockheads:feeding_trough"
-			x: 3.5d
-			y: 0.5d
-			subtitle: "Breed all the animals!"
+			tasks: [{
+				type: "advancement"
+				advancement: "minecraft:husbandry/bred_all_animals"
+				criterion: ""
+				id: "4D25DE5A135D9B75"
+				icon: "spectrum:pig_head"
+			}]
 			description: [
 				"> Bee"
 				"> Cat"
@@ -251,23 +254,14 @@
 				"> Turtle"
 				"> Wolf"
 			]
-			dependencies: ["512CAEB25CD9B4E2"]
+			icon: "farmingforblockheads:feeding_trough"
 			id: "6F99E812CEAA9DCA"
-			tasks: [{
-				id: "4D25DE5A135D9B75"
-				type: "advancement"
-				icon: "spectrum:pig_head"
-				advancement: "minecraft:husbandry/bred_all_animals"
-				criterion: ""
-			}]
+			x: 3.5d
+			y: 0.5d
+			subtitle: "Breed all the animals!"
+			dependencies: ["512CAEB25CD9B4E2"]
 		}
 		{
-			title: "Ring of Angels"
-			x: -2.0d
-			y: -1.0d
-			subtitle: "Creative flight at your disposal."
-			dependencies: ["512CAEB25CD9B4E2"]
-			id: "4394FBA9FF34416C"
 			tasks: [{
 				id: "64A0A716321AC14E"
 				type: "item"
@@ -277,29 +271,14 @@
 					tag: { }
 				}
 			}]
+			id: "4394FBA9FF34416C"
+			x: -2.0d
+			y: -1.0d
+			title: "Ring of Angels"
+			subtitle: "Creative flight at your disposal."
+			dependencies: ["512CAEB25CD9B4E2"]
 		}
 		{
-			title: "Quantum Physics"
-			icon: "modern_industrialization:quantum_circuit"
-			x: -2.5d
-			y: 0.5d
-			subtitle: "Ethereal powers!"
-			description: [
-				"Craft everything quantum and shape your own future."
-				""
-				"It'll be a long journey, can you do it?"
-				""
-				"- Quantum Sword"
-				"Uses the raw power of the Schrödinger equation to instantly vaporize any foe (or friend!) you hit with it."
-				""
-				"- Quantum Armor"
-				"Through the gravitational effect of the Heisenberg uncertainty principle, the full Quantum Armor set makes you immune to all damage and grants you creative flight. Each new piece of armour increases by 25% the likelihood of nullifying any damage taken."
-				""
-				"- Replicator"
-				"With 100 mB of UU Matter, the replicator can duplicate (almost) any item in the game!"
-			]
-			dependencies: ["512CAEB25CD9B4E2"]
-			id: "0A87F01B58718A44"
 			tasks: [
 				{
 					id: "2C0CB64FEB3B5231"
@@ -332,12 +311,34 @@
 					item: "modern_industrialization:replicator"
 				}
 			]
+			description: [
+				"Craft everything quantum and shape your own future."
+				""
+				"It'll be a long journey, can you do it?"
+				""
+				"- Quantum Sword"
+				"Uses the raw power of the Schrödinger equation to instantly vaporize any foe (or friend!) you hit with it."
+				""
+				"- Quantum Armor"
+				"Through the gravitational effect of the Heisenberg uncertainty principle, the full Quantum Armor set makes you immune to all damage and grants you creative flight. Each new piece of armour increases by 25% the likelihood of nullifying any damage taken."
+				""
+				"- Replicator"
+				"With 100 mB of UU Matter, the replicator can duplicate (almost) any item in the game!"
+			]
+			id: "0A87F01B58718A44"
+			icon: "modern_industrialization:quantum_circuit"
+			x: -2.5d
+			y: 0.5d
+			title: "Quantum Physics"
+			subtitle: "Ethereal powers!"
+			dependencies: ["512CAEB25CD9B4E2"]
 		}
 		{
+			size: 1.5d
+			id: "28E4C9B8787B595A"
 			x: 0.5d
 			y: -3.0d
 			subtitle: "Complete all the challenges!"
-			hide_dependency_lines: true
 			dependencies: [
 				"4394FBA9FF34416C"
 				"0A87F01B58718A44"
@@ -345,8 +346,7 @@
 				"6F99E812CEAA9DCA"
 				"18035D9544EC01DA"
 			]
-			size: 1.5d
-			id: "28E4C9B8787B595A"
+			hide_dependency_lines: true
 			tasks: [{
 				id: "1662F63BB2C25243"
 				type: "checkmark"
@@ -355,9 +355,12 @@
 			}]
 		}
 		{
-			x: 0.5d
-			y: -1.5d
-			subtitle: "Are you worthy? Become the completionist!"
+			tasks: [{
+				id: "7E0EE4376BC378B3"
+				type: "checkmark"
+				title: "Challenges"
+				icon: "croptopia:starfruit"
+			}]
 			description: [
 				"Challenges are unlocked when you've killed the Ender Dragon."
 				""
@@ -379,14 +382,11 @@
 				"CURRENTLY NOT IN THE PACK!"
 				"CURRENTLY NOT IN THE PACK!"
 			]
-			dependencies: ["175F5611FB7716A4"]
 			id: "477ECBF67056BF45"
-			tasks: [{
-				id: "7E0EE4376BC378B3"
-				type: "checkmark"
-				title: "Challenges"
-				icon: "croptopia:starfruit"
-			}]
+			x: 0.5d
+			y: -1.5d
+			subtitle: "Are you worthy? Become the completionist!"
+			dependencies: ["175F5611FB7716A4"]
 		}
 	]
 	quest_links: [ ]

--- a/config/ftbquests/quests/chapters/kibe.snbt
+++ b/config/ftbquests/quests/chapters/kibe.snbt
@@ -1,40 +1,41 @@
 {
-	id: "3B75DF2FD2A978FF"
-	group: "76C22988F9A7C9CE"
-	order_index: 1
-	filename: "kibe"
-	title: "Kibe Utilities"
-	icon: "kibe:slime_sling"
-	default_quest_shape: "hexagon"
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "76C22988F9A7C9CE"
+	id: "3B75DF2FD2A978FF"
+	filename: "kibe"
+	default_quest_shape: "hexagon"
+	icon: "kibe:slime_sling"
+	title: "Kibe Utilities"
+	order_index: 1
 	quests: [
 		{
-			x: 6.5d
-			y: -0.5d
-			subtitle: "Bunch of random, and mostly unoriginal things but aswell useful utilities!"
-			dependencies: ["7AA36A1A2308EDFF"]
-			id: "3E1A0192F2A00E6E"
 			tasks: [{
 				id: "3931534EE6E5F653"
 				type: "checkmark"
 				title: "Kibe Utilities!"
 				icon: "kibe:kibe"
 			}]
+			id: "3E1A0192F2A00E6E"
+			x: 6.5d
+			y: -0.5d
 			rewards: [{
 				id: "182279AEE38B3466"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Bunch of random, and mostly unoriginal things but aswell useful utilities!"
+			dependencies: ["7AA36A1A2308EDFF"]
 		}
 		{
-			x: -2.0d
-			y: -1.0d
-			id: "20EE964677BF776B"
 			tasks: [{
 				id: "1482B0FA2EB22760"
 				type: "item"
 				item: "kibe:cobblestone_generator_mk1"
 			}]
+			id: "20EE964677BF776B"
+			y: -1.0d
+			x: -2.0d
 			rewards: [{
 				id: "2CA127A3EEB32A56"
 				type: "loot"
@@ -42,15 +43,15 @@
 			}]
 		}
 		{
-			x: -3.5d
-			y: -0.5d
-			dependencies: ["20EE964677BF776B"]
-			id: "4CD54BA3EBFD0234"
 			tasks: [{
 				id: "37A5A44C9F193EC8"
 				type: "item"
 				item: "kibe:cobblestone_generator_mk2"
 			}]
+			dependencies: ["20EE964677BF776B"]
+			id: "4CD54BA3EBFD0234"
+			y: -0.5d
+			x: -3.5d
 			rewards: [{
 				id: "74ACE22199B8984F"
 				type: "loot"
@@ -58,15 +59,15 @@
 			}]
 		}
 		{
-			x: -3.5d
-			y: 0.5d
-			dependencies: ["4CD54BA3EBFD0234"]
-			id: "5F1542DFE1A7D796"
 			tasks: [{
 				id: "7945059FC4BAF633"
 				type: "item"
 				item: "kibe:cobblestone_generator_mk3"
 			}]
+			dependencies: ["4CD54BA3EBFD0234"]
+			id: "5F1542DFE1A7D796"
+			y: 0.5d
+			x: -3.5d
 			rewards: [{
 				id: "4071511857A418CC"
 				type: "loot"
@@ -74,32 +75,32 @@
 			}]
 		}
 		{
-			x: -3.5d
-			y: 1.5d
-			description: ["Go do some farming now."]
-			dependencies: ["5F1542DFE1A7D796"]
-			id: "71961FC5DAAC33AB"
 			tasks: [{
 				id: "3A90C7EF9408C4F4"
 				type: "item"
 				item: "kibe:cobblestone_generator_mk4"
 			}]
+			description: ["Go do some farming now."]
+			id: "71961FC5DAAC33AB"
+			x: -3.5d
+			y: 1.5d
 			rewards: [{
 				id: "72F31E6CE8DEDB5C"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["5F1542DFE1A7D796"]
 		}
 		{
-			x: -3.5d
-			y: 2.5d
-			dependencies: ["71961FC5DAAC33AB"]
-			id: "572CC0E117B699E9"
 			tasks: [{
 				id: "38C35D7B6C49C7AB"
 				type: "item"
 				item: "kibe:cobblestone_generator_mk5"
 			}]
+			dependencies: ["71961FC5DAAC33AB"]
+			id: "572CC0E117B699E9"
+			y: 2.5d
+			x: -3.5d
 			rewards: [{
 				id: "59305A24CDA39C88"
 				type: "loot"
@@ -107,14 +108,14 @@
 			}]
 		}
 		{
-			x: 1.0d
-			y: -1.0d
-			id: "3AB8D21E8188D30B"
 			tasks: [{
 				id: "08FB10212C97A9D8"
 				type: "item"
 				item: "kibe:basalt_generator_mk1"
 			}]
+			id: "3AB8D21E8188D30B"
+			y: -1.0d
+			x: 1.0d
 			rewards: [{
 				id: "53420773440BB5D4"
 				type: "loot"
@@ -122,15 +123,15 @@
 			}]
 		}
 		{
-			x: 2.5d
-			y: -0.5d
-			dependencies: ["3AB8D21E8188D30B"]
-			id: "5BDABC4E3DAC25D3"
 			tasks: [{
 				id: "7DCD9A3794551BF2"
 				type: "item"
 				item: "kibe:basalt_generator_mk2"
 			}]
+			dependencies: ["3AB8D21E8188D30B"]
+			id: "5BDABC4E3DAC25D3"
+			y: -0.5d
+			x: 2.5d
 			rewards: [{
 				id: "3A58FDAFDC650747"
 				type: "loot"
@@ -138,15 +139,15 @@
 			}]
 		}
 		{
-			x: 2.5d
-			y: 0.5d
-			dependencies: ["5BDABC4E3DAC25D3"]
-			id: "30974A8C1EF063E4"
 			tasks: [{
 				id: "58ED61DA1C7E66B8"
 				type: "item"
 				item: "kibe:basalt_generator_mk3"
 			}]
+			dependencies: ["5BDABC4E3DAC25D3"]
+			id: "30974A8C1EF063E4"
+			y: 0.5d
+			x: 2.5d
 			rewards: [{
 				id: "05DA790D757FBB2B"
 				type: "loot"
@@ -154,15 +155,15 @@
 			}]
 		}
 		{
-			x: 2.5d
-			y: 1.5d
-			dependencies: ["30974A8C1EF063E4"]
-			id: "6868C14ADB823A0C"
 			tasks: [{
 				id: "5189E357486D70CD"
 				type: "item"
 				item: "kibe:basalt_generator_mk4"
 			}]
+			dependencies: ["30974A8C1EF063E4"]
+			id: "6868C14ADB823A0C"
+			y: 1.5d
+			x: 2.5d
 			rewards: [{
 				id: "2690130DBF1A01A2"
 				type: "loot"
@@ -170,15 +171,15 @@
 			}]
 		}
 		{
-			x: 2.5d
-			y: 2.5d
-			dependencies: ["6868C14ADB823A0C"]
-			id: "65776A57E9979D88"
 			tasks: [{
 				id: "0139CDB35A6C73EB"
 				type: "item"
 				item: "kibe:basalt_generator_mk5"
 			}]
+			dependencies: ["6868C14ADB823A0C"]
+			id: "65776A57E9979D88"
+			y: 2.5d
+			x: 2.5d
 			rewards: [{
 				id: "30D2A2F5F6E4BFC6"
 				type: "loot"
@@ -186,79 +187,74 @@
 			}]
 		}
 		{
-			x: 8.5d
-			y: -1.0d
-			subtitle: "Perhaps some of the greatest food ever."
-			dependencies: ["3E1A0192F2A00E6E"]
-			id: "489617A7727233D7"
 			tasks: [{
 				id: "550AD130B1B271BD"
 				type: "item"
 				item: "kibe:golden_kibe"
 			}]
+			id: "489617A7727233D7"
+			x: 8.5d
+			y: -1.0d
 			rewards: [{
 				id: "317BFAD7D9251F2C"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Perhaps some of the greatest food ever."
+			dependencies: ["3E1A0192F2A00E6E"]
 		}
 		{
-			x: 4.5d
-			y: -1.0d
-			subtitle: "Only the best for you"
-			dependencies: ["3E1A0192F2A00E6E"]
-			id: "249C89B94048A585"
 			tasks: [{
 				id: "166D7DD64BEA9D21"
 				type: "item"
 				item: "kibe:diamond_kibe"
 			}]
+			id: "249C89B94048A585"
+			x: 4.5d
+			y: -1.0d
 			rewards: [{
 				id: "46752D8F0EC3910A"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Only the best for you"
+			dependencies: ["3E1A0192F2A00E6E"]
 		}
 		{
-			x: 6.5d
-			y: -2.0d
-			subtitle: "Heals a lot. Small chance of instant death."
-			dependencies: ["3E1A0192F2A00E6E"]
-			id: "3AEF4D4334846377"
 			tasks: [{
 				id: "74B922352AFCC2C1"
 				type: "item"
 				item: "kibe:cursed_kibe"
 			}]
+			id: "3AEF4D4334846377"
+			x: 6.5d
+			y: -2.0d
 			rewards: [{
 				id: "1B8CC735D5AEC99A"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Heals a lot. Small chance of instant death."
+			dependencies: ["3E1A0192F2A00E6E"]
 		}
 		{
-			x: 6.5d
-			y: 2.5d
-			subtitle: "Used for crafting other rings."
-			dependencies: ["7AA36A1A2308EDFF"]
-			id: "3E58A201EA40B757"
 			tasks: [{
 				id: "017BC2F70596CEBC"
 				type: "item"
 				item: "kibe:diamond_ring"
 			}]
+			id: "3E58A201EA40B757"
+			x: 6.5d
+			y: 2.5d
 			rewards: [{
 				id: "1D851BB7FB144D34"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Used for crafting other rings."
+			dependencies: ["7AA36A1A2308EDFF"]
 		}
 		{
-			x: 8.5d
-			y: 3.0d
-			subtitle: "Gives an infinite Fire Resistance status to the wearer."
-			dependencies: ["3E58A201EA40B757"]
-			id: "3BE35A9CDD2E461D"
 			tasks: [{
 				id: "629D1D4982FE2971"
 				type: "item"
@@ -268,18 +264,18 @@
 					tag: { }
 				}
 			}]
+			id: "3BE35A9CDD2E461D"
+			x: 8.5d
+			y: 3.0d
 			rewards: [{
 				id: "40835DAD975CECBF"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Gives an infinite Fire Resistance status to the wearer."
+			dependencies: ["3E58A201EA40B757"]
 		}
 		{
-			x: 4.5d
-			y: 3.0d
-			subtitle: "Gives an infinite Water Breathing status to the wearer."
-			dependencies: ["3E58A201EA40B757"]
-			id: "7E300E8876853BB1"
 			tasks: [{
 				id: "37C52C86B6E0FA4A"
 				type: "item"
@@ -289,23 +285,26 @@
 					tag: { }
 				}
 			}]
+			id: "7E300E8876853BB1"
+			x: 4.5d
+			y: 3.0d
 			rewards: [{
 				id: "55FF10D7ABFD1DBB"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Gives an infinite Water Breathing status to the wearer."
+			dependencies: ["3E58A201EA40B757"]
 		}
 		{
-			x: -0.5d
-			y: 2.5d
-			subtitle: "Universally linked chests that work across dimensions and stores the same items as long as they are color-coded the same."
-			dependencies: ["1C9883ACFF33E397"]
-			id: "5C390D0E8AA56F83"
 			tasks: [{
 				id: "0ED500FB5F9B7C7F"
 				type: "item"
 				item: "kibe:entangled_chest"
 			}]
+			id: "5C390D0E8AA56F83"
+			x: -0.5d
+			y: 2.5d
 			rewards: [
 				{
 					id: "0C67585728F46B4B"
@@ -332,18 +331,18 @@
 					count: 2
 				}
 			]
+			subtitle: "Universally linked chests that work across dimensions and stores the same items as long as they are color-coded the same."
+			dependencies: ["1C9883ACFF33E397"]
 		}
 		{
-			x: -2.0d
-			y: 1.0d
-			subtitle: "Exactly like Entangled Chests but they store fluids instead."
-			dependencies: ["1C9883ACFF33E397"]
-			id: "238AC181848E3D72"
 			tasks: [{
 				id: "78A859B3D0017802"
 				type: "item"
 				item: "kibe:entangled_tank"
 			}]
+			id: "238AC181848E3D72"
+			x: -2.0d
+			y: 1.0d
 			rewards: [
 				{
 					id: "6FD99B307FD8C5CD"
@@ -370,18 +369,18 @@
 					count: 2
 				}
 			]
+			subtitle: "Exactly like Entangled Chests but they store fluids instead."
+			dependencies: ["1C9883ACFF33E397"]
 		}
 		{
-			x: 1.0d
-			y: 1.0d
-			subtitle: "Access the contents of your Entangled Chest directly in your inventory."
-			dependencies: ["1C9883ACFF33E397"]
-			id: "34CB73ED88C89889"
 			tasks: [{
 				id: "37E61672584DFB3B"
 				type: "item"
 				item: "kibe:entangled_bag"
 			}]
+			id: "34CB73ED88C89889"
+			x: 1.0d
+			y: 1.0d
 			rewards: [
 				{
 					id: "5745345A15F02D93"
@@ -408,18 +407,18 @@
 					count: 2
 				}
 			]
+			subtitle: "Access the contents of your Entangled Chest directly in your inventory."
+			dependencies: ["1C9883ACFF33E397"]
 		}
 		{
-			x: -0.5d
-			y: -0.5d
-			subtitle: "Access the contents of your Entangled Tank directly in your inventory."
-			dependencies: ["1C9883ACFF33E397"]
-			id: "4B282EE884728242"
 			tasks: [{
 				id: "1DC913CFADDF163B"
 				type: "item"
 				item: "kibe:entangled_bucket"
 			}]
+			id: "4B282EE884728242"
+			x: -0.5d
+			y: -0.5d
 			rewards: [
 				{
 					id: "50150A1DF7286ABD"
@@ -440,17 +439,19 @@
 					count: 2
 				}
 			]
+			subtitle: "Access the contents of your Entangled Tank directly in your inventory."
+			dependencies: ["1C9883ACFF33E397"]
 		}
 		{
-			x: 6.5d
-			y: 1.0d
-			shape: "hexagon"
-			id: "7AA36A1A2308EDFF"
 			tasks: [{
 				id: "714E9C63DE4504CF"
 				type: "checkmark"
 				title: "Kibe and Rings"
 			}]
+			id: "7AA36A1A2308EDFF"
+			shape: "hexagon"
+			y: 1.0d
+			x: 6.5d
 			rewards: [{
 				id: "2C01628132B04859"
 				type: "xp"
@@ -458,80 +459,80 @@
 			}]
 		}
 		{
-			x: -0.5d
-			y: 1.0d
-			shape: "hexagon"
-			subtitle: "Using kibe runes, you can code your linked chests and have as many different ones that your heart desires."
-			id: "1C9883ACFF33E397"
 			tasks: [{
 				id: "7C9B04C717763B2B"
 				type: "checkmark"
 				title: "Entangle your mind."
 			}]
+			subtitle: "Using kibe runes, you can code your linked chests and have as many different ones that your heart desires."
+			id: "1C9883ACFF33E397"
+			shape: "hexagon"
+			y: 1.0d
+			x: -0.5d
 		}
 		{
-			title: "XP Shower"
-			x: 15.5d
-			y: 0.0d
-			subtitle: "Transforms the liquid XP from tanks behind it into experience orbs that players can absorb."
-			dependencies: ["2EA53113508BD436"]
-			id: "3F4D2B9AA752B3FB"
 			tasks: [{
 				id: "3207E34716A01F5A"
 				type: "item"
 				item: "kibe:xp_shower"
 			}]
+			id: "3F4D2B9AA752B3FB"
+			x: 15.5d
+			y: 0.0d
+			title: "XP Shower"
 			rewards: [{
 				id: "6ECD882C62A9B230"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Transforms the liquid XP from tanks behind it into experience orbs that players can absorb."
+			dependencies: ["2EA53113508BD436"]
 		}
 		{
-			title: "XP Drain"
-			x: 16.0d
-			y: 1.0d
-			subtitle: "Will drain XP from a player and store it in a fluid container placed directly below it."
-			dependencies: ["2EA53113508BD436"]
-			id: "4AC90C2DA686B95E"
 			tasks: [{
 				id: "68B7BE2C6D332A76"
 				type: "item"
 				item: "kibe:xp_drain"
 			}]
+			id: "4AC90C2DA686B95E"
+			x: 16.0d
+			y: 1.0d
+			title: "XP Drain"
 			rewards: [{
 				id: "4EB1F6BFC1F8AC9B"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Will drain XP from a player and store it in a fluid container placed directly below it."
+			dependencies: ["2EA53113508BD436"]
 		}
 		{
-			x: 11.5d
-			y: 0.0d
-			subtitle: "It's a trashcan, nothing more to it."
-			dependencies: ["2EA53113508BD436"]
-			id: "68C9B9EB5E7C680F"
 			tasks: [{
 				id: "2CA4CC93439BB357"
 				type: "item"
 				item: "kibe:trash_can"
 			}]
+			id: "68C9B9EB5E7C680F"
+			x: 11.5d
+			y: 0.0d
 			rewards: [{
 				id: "25F6FB26D790C78A"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "It's a trashcan, nothing more to it."
+			dependencies: ["2EA53113508BD436"]
 		}
 		{
-			x: 12.0d
-			y: -1.0d
-			dependencies: ["2EA53113508BD436"]
-			id: "7F240BDC84E49D4A"
 			tasks: [{
 				id: "38230005D69B4184"
 				type: "item"
 				item: "kibe:stone_spikes"
 			}]
+			dependencies: ["2EA53113508BD436"]
+			id: "7F240BDC84E49D4A"
+			y: -1.0d
+			x: 12.0d
 			rewards: [{
 				id: "106E864E88ECD3B1"
 				type: "loot"
@@ -539,15 +540,15 @@
 			}]
 		}
 		{
-			x: 13.0d
-			y: -1.5d
-			dependencies: ["2EA53113508BD436"]
-			id: "06089519F402F05D"
 			tasks: [{
 				id: "42E2BF8B278B6FEA"
 				type: "item"
 				item: "kibe:iron_spikes"
 			}]
+			dependencies: ["2EA53113508BD436"]
+			id: "06089519F402F05D"
+			y: -1.5d
+			x: 13.0d
 			rewards: [{
 				id: "672CA6C0946CD1ED"
 				type: "loot"
@@ -555,15 +556,15 @@
 			}]
 		}
 		{
-			x: 14.0d
-			y: -1.5d
-			dependencies: ["2EA53113508BD436"]
-			id: "315C879AAB4BFDA9"
 			tasks: [{
 				id: "2B470452DA5633D2"
 				type: "item"
 				item: "kibe:gold_spikes"
 			}]
+			dependencies: ["2EA53113508BD436"]
+			id: "315C879AAB4BFDA9"
+			y: -1.5d
+			x: 14.0d
 			rewards: [{
 				id: "6CE5B559C1C504FD"
 				type: "loot"
@@ -571,15 +572,15 @@
 			}]
 		}
 		{
-			x: 15.0d
-			y: -1.0d
-			dependencies: ["2EA53113508BD436"]
-			id: "0B5054BC06FD07E3"
 			tasks: [{
 				id: "66567097A995AF54"
 				type: "item"
 				item: "kibe:diamond_spikes"
 			}]
+			dependencies: ["2EA53113508BD436"]
+			id: "0B5054BC06FD07E3"
+			y: -1.0d
+			x: 15.0d
 			rewards: [{
 				id: "1035B291D565BA25"
 				type: "loot"
@@ -587,45 +588,40 @@
 			}]
 		}
 		{
-			x: 11.0d
-			y: 1.0d
-			subtitle: "Gathered from Wither Skeletons."
-			dependencies: ["2EA53113508BD436"]
-			id: "1405E9DA1177BF0E"
 			tasks: [{
 				id: "6B2D4FA7B4449E85"
 				type: "item"
 				item: "kibe:cursed_droplets"
 			}]
+			id: "1405E9DA1177BF0E"
+			x: 11.0d
+			y: 1.0d
 			rewards: [{
 				id: "51A242AEB94A9DFC"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Gathered from Wither Skeletons."
+			dependencies: ["2EA53113508BD436"]
 		}
 		{
-			x: 12.5d
-			y: 3.0d
-			subtitle: "Using Cursed Seeds on regular grass or dirt block will create Cursed Dirt, and can only spread 16 blocks from the center."
-			dependencies: ["2EA53113508BD436"]
-			id: "269C02E46D4F41F9"
 			tasks: [{
 				id: "157E7A93B794012C"
 				type: "item"
 				item: "kibe:cursed_seeds"
 			}]
+			id: "269C02E46D4F41F9"
+			x: 12.5d
+			y: 3.0d
 			rewards: [{
 				id: "5C8D244C580972C3"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Using Cursed Seeds on regular grass or dirt block will create Cursed Dirt, and can only spread 16 blocks from the center."
+			dependencies: ["2EA53113508BD436"]
 		}
 		{
-			x: 13.5d
-			y: 3.5d
-			subtitle: "Can only hold passive animals."
-			dependencies: ["2EA53113508BD436"]
-			id: "216F02E8D4A1FD2F"
 			tasks: [{
 				id: "41C4364D32E8FB5E"
 				type: "item"
@@ -635,18 +631,18 @@
 					tag: { }
 				}
 			}]
+			id: "216F02E8D4A1FD2F"
+			x: 13.5d
+			y: 3.5d
 			rewards: [{
 				id: "56FE2C47F438FC82"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Can only hold passive animals."
+			dependencies: ["2EA53113508BD436"]
 		}
 		{
-			x: 14.5d
-			y: 3.0d
-			subtitle: "Can hold aggressive entities but will add the curse effect to them upon release."
-			dependencies: ["2EA53113508BD436"]
-			id: "2BA5649A45BC563B"
 			tasks: [{
 				id: "65970F825BC4D9C4"
 				type: "item"
@@ -656,18 +652,18 @@
 					tag: { }
 				}
 			}]
+			id: "2BA5649A45BC563B"
+			x: 14.5d
+			y: 3.0d
 			rewards: [{
 				id: "3B178DB0DBDBA8F9"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Can hold aggressive entities but will add the curse effect to them upon release."
+			dependencies: ["2EA53113508BD436"]
 		}
 		{
-			x: 15.5d
-			y: 2.5d
-			subtitle: "Can hold almost any entity without debuffs."
-			dependencies: ["2EA53113508BD436"]
-			id: "6AFEFF91DB337139"
 			tasks: [{
 				id: "4F0EC7C4BA0E965A"
 				type: "item"
@@ -677,16 +673,23 @@
 					tag: { }
 				}
 			}]
+			id: "6AFEFF91DB337139"
+			x: 15.5d
+			y: 2.5d
 			rewards: [{
 				id: "679AA5AC2A39862E"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Can hold almost any entity without debuffs."
+			dependencies: ["2EA53113508BD436"]
 		}
 		{
-			x: 13.5d
-			y: 1.0d
-			shape: "hexagon"
+			tasks: [{
+				id: "7F9BE20A484C8715"
+				type: "checkmark"
+				title: "Kibe Mob Farm Utilities"
+			}]
 			description: [
 				"Use the various levels of spikes to leave at the bottom of your mob farm."
 				""
@@ -705,131 +708,129 @@
 				"Once you have mastered the mob farm, can you claim your reward."
 			]
 			id: "2EA53113508BD436"
-			tasks: [{
-				id: "7F9BE20A484C8715"
-				type: "checkmark"
-				title: "Kibe Mob Farm Utilities"
-			}]
+			shape: "hexagon"
+			y: 1.0d
+			x: 13.5d
 		}
 		{
-			x: 11.5d
-			y: 2.5d
-			subtitle: "Pulls nearby dropped items and experience orbs to their own inventory."
-			description: [
-				"Stored items can be accessed by opening the block's GUI or by using regular Hoppers."
-				""
-				"Stored XP can be used to craft Bottle o' Enchanting or Liquid XP buckets."
-			]
-			dependencies: ["2EA53113508BD436"]
-			id: "6F48F204E6E04D94"
 			tasks: [{
 				id: "5C49C0A15140D59C"
 				type: "item"
 				item: "kibe:vacuum_hopper"
 			}]
+			description: [
+				"Stored items can be accessed by opening the block's GUI or by using regular Hoppers."
+				""
+				"Stored XP can be used to craft Bottle o' Enchanting or Liquid XP buckets."
+			]
+			id: "6F48F204E6E04D94"
+			x: 11.5d
+			y: 2.5d
 			rewards: [{
 				id: "57A1BF74F7A4655C"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Pulls nearby dropped items and experience orbs to their own inventory."
+			dependencies: ["2EA53113508BD436"]
 		}
 		{
-			x: 12.0d
-			y: -6.0d
-			subtitle: "Cannot be destroyed by the wither boss."
-			dependencies: ["5EDF1BBEEBED927F"]
-			id: "06E66DB0079C1C33"
 			tasks: [{
 				id: "6246ADA7C69387FD"
 				type: "item"
 				item: "kibe:wither_proof_glass"
 			}]
+			id: "06E66DB0079C1C33"
+			x: 12.0d
+			y: -6.0d
 			rewards: [{
 				id: "6680183C6F65F5F4"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			x: 12.5d
-			y: -3.5d
 			subtitle: "Cannot be destroyed by the wither boss."
 			dependencies: ["5EDF1BBEEBED927F"]
-			id: "32223B3C4D82A24B"
+		}
+		{
 			tasks: [{
 				id: "60F565C1307D35D8"
 				type: "item"
 				item: "kibe:wither_proof_sand"
 			}]
+			id: "32223B3C4D82A24B"
+			x: 12.5d
+			y: -3.5d
 			rewards: [{
 				id: "58578D45619EE901"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			x: 13.5d
-			y: -7.0d
 			subtitle: "Cannot be destroyed by the wither boss."
 			dependencies: ["5EDF1BBEEBED927F"]
-			id: "5006788393F2C549"
+		}
+		{
 			tasks: [{
 				id: "5F64773A4D914C46"
 				type: "item"
 				item: "kibe:wither_proof_block"
 			}]
+			id: "5006788393F2C549"
+			x: 13.5d
+			y: -7.0d
 			rewards: [{
 				id: "08DE8010DAB48ACE"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Cannot be destroyed by the wither boss."
+			dependencies: ["5EDF1BBEEBED927F"]
 		}
 		{
-			x: 14.5d
-			y: -3.5d
-			subtitle: "Activated by a redstone signal, will summon a wither if there's enough building material in its inventory and available space in front of it."
-			dependencies: ["5EDF1BBEEBED927F"]
-			id: "38447A3B73A23497"
 			tasks: [{
 				id: "5F15D847732F2F5A"
 				type: "item"
 				item: "kibe:wither_builder"
 			}]
+			id: "38447A3B73A23497"
+			x: 14.5d
+			y: -3.5d
 			rewards: [{
 				id: "72126637843E21DE"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Activated by a redstone signal, will summon a wither if there's enough building material in its inventory and available space in front of it."
+			dependencies: ["5EDF1BBEEBED927F"]
 		}
 		{
-			x: 15.0d
-			y: -6.0d
-			subtitle: "Cannot be destroyed by the wither boss."
-			dependencies: ["5EDF1BBEEBED927F"]
-			id: "425EE3501EE44BFC"
 			tasks: [{
 				id: "0DBD9671347434C7"
 				type: "item"
 				item: "indrev:wither_proof_obsidian"
 			}]
+			id: "425EE3501EE44BFC"
+			x: 15.0d
+			y: -6.0d
 			rewards: [{
 				id: "65BDF6E13A3475B2"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Cannot be destroyed by the wither boss."
+			dependencies: ["5EDF1BBEEBED927F"]
 		}
 		{
-			title: "Automate Wither building and killing"
-			x: 13.5d
-			y: -5.0d
-			shape: "hexagon"
-			description: ["Use the following to create an automatic Wither-slaying machine."]
-			id: "5EDF1BBEEBED927F"
 			tasks: [{
 				id: "24A1862F0308DA6E"
 				type: "checkmark"
 				title: "Wither machine"
 			}]
+			description: ["Use the following to create an automatic Wither-slaying machine."]
+			x: 13.5d
+			id: "5EDF1BBEEBED927F"
+			y: -5.0d
+			shape: "hexagon"
+			title: "Automate Wither building and killing"
 			rewards: [{
 				id: "7716261A55143011"
 				type: "xp"
@@ -837,46 +838,40 @@
 			}]
 		}
 		{
-			x: 7.5d
-			y: -7.0d
-			subtitle: "Throws the player in the sky when charged while aiming at a block."
-			dependencies: ["168F737F6246967F"]
-			id: "020189CFCFC6C06B"
 			tasks: [{
 				id: "17F6FAC5607F17D5"
 				type: "item"
 				item: "kibe:slime_sling"
 			}]
+			id: "020189CFCFC6C06B"
+			x: 7.5d
+			y: -7.0d
 			rewards: [{
 				id: "4C342EAB6E5B7817"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Throws the player in the sky when charged while aiming at a block."
+			dependencies: ["168F737F6246967F"]
 		}
 		{
-			x: 5.5d
-			y: -7.0d
-			subtitle: "It slings torches, pretty obvious."
-			dependencies: ["168F737F6246967F"]
-			id: "1BD0C018E49A7DD9"
 			tasks: [{
 				id: "61A61B471BE66608"
 				type: "item"
 				item: "kibe:torch_sling"
 			}]
+			id: "1BD0C018E49A7DD9"
+			x: 5.5d
+			y: -7.0d
 			rewards: [{
 				id: "17A06289AE3B26B0"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "It slings torches, pretty obvious."
+			dependencies: ["168F737F6246967F"]
 		}
 		{
-			x: 7.5d
-			y: -4.0d
-			subtitle: "It does what a magnet does, magnetize items towards you."
-			description: ["Solegnolia won't prevent magnetizing by this magnet, so be aware!"]
-			dependencies: ["168F737F6246967F"]
-			id: "1043B10D063173A3"
 			tasks: [{
 				id: "7AD6BA51329E082C"
 				type: "item"
@@ -886,18 +881,19 @@
 					tag: { }
 				}
 			}]
+			description: ["Solegnolia won't prevent magnetizing by this magnet, so be aware!"]
+			id: "1043B10D063173A3"
+			x: 7.5d
+			y: -4.0d
 			rewards: [{
 				id: "377CFE97A2EF2714"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "It does what a magnet does, magnetize items towards you."
+			dependencies: ["168F737F6246967F"]
 		}
 		{
-			title: "Sleeping Bag"
-			x: 8.5d
-			y: -5.0d
-			dependencies: ["168F737F6246967F"]
-			id: "55A6E90245D38B8B"
 			tasks: [{
 				id: "263FDBA937D650EB"
 				type: "item"
@@ -978,17 +974,18 @@
 					}
 				}
 			}]
+			id: "55A6E90245D38B8B"
+			x: 8.5d
+			y: -5.0d
+			title: "Sleeping Bag"
 			rewards: [{
 				id: "15C177CAC83BD508"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["168F737F6246967F"]
 		}
 		{
-			x: 6.5d
-			y: -3.5d
-			dependencies: ["168F737F6246967F"]
-			id: "070E67FCDB179F5C"
 			tasks: [{
 				id: "75C42B370A6BECF0"
 				type: "item"
@@ -1000,6 +997,10 @@
 					}
 				}
 			}]
+			dependencies: ["168F737F6246967F"]
+			id: "070E67FCDB179F5C"
+			y: -3.5d
+			x: 6.5d
 			rewards: [{
 				id: "499817B60CE72976"
 				type: "loot"
@@ -1007,15 +1008,15 @@
 			}]
 		}
 		{
-			x: 6.5d
-			y: -7.5d
-			dependencies: ["168F737F6246967F"]
-			id: "52D48B65A5F04D87"
 			tasks: [{
 				id: "1ED3DDCCED07436B"
 				type: "item"
 				item: "kibe:wooden_bucket"
 			}]
+			dependencies: ["168F737F6246967F"]
+			id: "52D48B65A5F04D87"
+			y: -7.5d
+			x: 6.5d
 			rewards: [{
 				id: "6C9B8CEB41A6B2B1"
 				type: "loot"
@@ -1023,11 +1024,6 @@
 			}]
 		}
 		{
-			x: 4.5d
-			y: -5.0d
-			subtitle: "Negates fall damage and makes the player bounce when hitting the floor with considerable speed."
-			dependencies: ["168F737F6246967F"]
-			id: "4E0CC10FCA19F0FF"
 			tasks: [{
 				id: "4DAE46A25DF5971F"
 				type: "item"
@@ -1039,19 +1035,18 @@
 					}
 				}
 			}]
+			id: "4E0CC10FCA19F0FF"
+			x: 4.5d
+			y: -5.0d
 			rewards: [{
 				id: "4C96DE02671BCB57"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Negates fall damage and makes the player bounce when hitting the floor with considerable speed."
+			dependencies: ["168F737F6246967F"]
 		}
 		{
-			title: "Gliders"
-			x: 5.5d
-			y: -4.0d
-			subtitle: "Held by a player, will allow them to glide through the skies instead of falling normally."
-			dependencies: ["168F737F6246967F"]
-			id: "5348E2881E7A3F7D"
 			tasks: [{
 				id: "461A8026187F0779"
 				type: "item"
@@ -1151,17 +1146,19 @@
 					}
 				}
 			}]
+			id: "5348E2881E7A3F7D"
+			x: 5.5d
+			y: -4.0d
+			title: "Gliders"
 			rewards: [{
 				id: "64EBC1FF2855F827"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Held by a player, will allow them to glide through the skies instead of falling normally."
+			dependencies: ["168F737F6246967F"]
 		}
 		{
-			title: "Handy Dandy Utilities"
-			x: 6.5d
-			y: -5.5d
-			id: "168F737F6246967F"
 			tasks: [{
 				id: "4B6651B07849440F"
 				type: "checkmark"
@@ -1178,34 +1175,38 @@
 					}
 				}
 			}]
+			id: "168F737F6246967F"
+			y: -5.5d
+			x: 6.5d
+			title: "Handy Dandy Utilities"
 		}
 		{
-			x: -2.0d
-			y: -3.5d
-			subtitle: "Activated by a redstone signal, will place any block in its inventory in front of it, if possible."
-			dependencies: ["08F0301F0C8D7013"]
-			id: "6305856C330E4CEB"
 			tasks: [{
 				id: "0FC05324880FB6B9"
 				type: "item"
 				item: "kibe:placer"
 			}]
+			id: "6305856C330E4CEB"
+			x: -2.0d
+			y: -3.5d
 			rewards: [{
 				id: "142FF17693F992B9"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Activated by a redstone signal, will place any block in its inventory in front of it, if possible."
+			dependencies: ["08F0301F0C8D7013"]
 		}
 		{
-			x: 1.0d
-			y: -3.5d
-			dependencies: ["08F0301F0C8D7013"]
-			id: "54078EAC76C5BAC8"
 			tasks: [{
 				id: "6B26491A205CD947"
 				type: "item"
 				item: "kibe:drawbridge"
 			}]
+			dependencies: ["08F0301F0C8D7013"]
+			id: "54078EAC76C5BAC8"
+			y: -3.5d
+			x: 1.0d
 			rewards: [{
 				id: "3DFBD4EC2B3FC622"
 				type: "loot"
@@ -1213,32 +1214,32 @@
 			}]
 		}
 		{
-			x: -2.0d
-			y: -6.5d
-			subtitle: "Activated by a redstone signal, will break any block in front of it and store its drops in its inventory, if possible."
-			dependencies: ["08F0301F0C8D7013"]
-			id: "508129EE5F19EE89"
 			tasks: [{
 				id: "3343274513277EB6"
 				type: "item"
 				item: "kibe:breaker"
 			}]
+			id: "508129EE5F19EE89"
+			x: -2.0d
+			y: -6.5d
 			rewards: [{
 				id: "53E64710C29094C1"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Activated by a redstone signal, will break any block in front of it and store its drops in its inventory, if possible."
+			dependencies: ["08F0301F0C8D7013"]
 		}
 		{
-			x: 1.5d
-			y: -5.0d
-			dependencies: ["08F0301F0C8D7013"]
-			id: "3B020F4B1968FDB0"
 			tasks: [{
 				id: "3C9068E99A18D305"
 				type: "item"
 				item: "kibe:igniter"
 			}]
+			dependencies: ["08F0301F0C8D7013"]
+			id: "3B020F4B1968FDB0"
+			y: -5.0d
+			x: 1.5d
 			rewards: [{
 				id: "012435C34F9D4744"
 				type: "loot"
@@ -1246,15 +1247,15 @@
 			}]
 		}
 		{
-			x: -2.5d
-			y: -5.0d
-			dependencies: ["08F0301F0C8D7013"]
-			id: "6C642DEC901512BF"
 			tasks: [{
 				id: "255905463378A934"
 				type: "item"
 				item: "kibe:dehumidifier"
 			}]
+			dependencies: ["08F0301F0C8D7013"]
+			id: "6C642DEC901512BF"
+			y: -5.0d
+			x: -2.5d
 			rewards: [{
 				id: "14D4E70A1C5663F5"
 				type: "loot"
@@ -1262,15 +1263,15 @@
 			}]
 		}
 		{
-			x: -0.5d
-			y: -3.0d
-			dependencies: ["08F0301F0C8D7013"]
-			id: "17C1D819D9227486"
 			tasks: [{
 				id: "792CDF0A914EFC9C"
 				type: "item"
 				item: "kibe:heater"
 			}]
+			dependencies: ["08F0301F0C8D7013"]
+			id: "17C1D819D9227486"
+			y: -3.0d
+			x: -0.5d
 			rewards: [{
 				id: "34BCCBA2520A0142"
 				type: "loot"
@@ -1278,32 +1279,32 @@
 			}]
 		}
 		{
-			x: -0.5d
-			y: -7.0d
-			subtitle: "Exactly like vanilla Hoppers but that moves fluids instead of items."
-			dependencies: ["08F0301F0C8D7013"]
-			id: "76B5524C1838F058"
 			tasks: [{
 				id: "17E02EA331F7D7A6"
 				type: "item"
 				item: "kibe:fluid_hopper"
 			}]
+			id: "76B5524C1838F058"
+			x: -0.5d
+			y: -7.0d
 			rewards: [{
 				id: "1ED5E238DD403F5B"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Exactly like vanilla Hoppers but that moves fluids instead of items."
+			dependencies: ["08F0301F0C8D7013"]
 		}
 		{
-			x: 1.0d
-			y: -6.5d
-			dependencies: ["08F0301F0C8D7013"]
-			id: "40387D638061A2C3"
 			tasks: [{
 				id: "02D63A4D997340CA"
 				type: "item"
 				item: "kibe:redstone_timer"
 			}]
+			dependencies: ["08F0301F0C8D7013"]
+			id: "40387D638061A2C3"
+			y: -6.5d
+			x: 1.0d
 			rewards: [{
 				id: "435B08ADE0E7D4B7"
 				type: "loot"
@@ -1311,51 +1312,50 @@
 			}]
 		}
 		{
-			x: -0.5d
-			y: -5.0d
-			subtitle: "Use these various machines to do all kinds of things."
-			description: ["TIP: They are activated by redstone."]
-			id: "08F0301F0C8D7013"
 			tasks: [{
 				id: "093B8ECB1B60CFD3"
 				type: "checkmark"
 				title: "Machines to automate"
 			}]
+			description: ["TIP: They are activated by redstone."]
+			subtitle: "Use these various machines to do all kinds of things."
+			id: "08F0301F0C8D7013"
+			y: -5.0d
+			x: -0.5d
 		}
 		{
-			x: 8.5d
-			y: -6.0d
-			subtitle: "Cancels any mob spawning that requires no light in a configurable area. Useful to protect your base!"
-			dependencies: ["168F737F6246967F"]
-			id: "15D2E510EC4863F0"
 			tasks: [{
 				id: "679DE0A266DE5437"
 				type: "item"
 				item: "kibe:big_torch"
 			}]
+			id: "15D2E510EC4863F0"
+			x: 8.5d
+			y: -6.0d
 			rewards: [{
 				id: "4CF5D3C09B700FA7"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Cancels any mob spawning that requires no light in a configurable area. Useful to protect your base!"
+			dependencies: ["168F737F6246967F"]
 		}
 		{
-			x: 4.5d
-			y: -6.0d
-			subtitle: "When stepped upon, can teleport the player upwards and downwards, as long as it finds another elevator directly above or below it."
-			dependencies: ["168F737F6246967F"]
-			id: "1F7A66B361535659"
 			tasks: [{
 				id: "5E20F61EB482457C"
 				type: "item"
 				item: "kibe:white_elevator"
 			}]
+			id: "1F7A66B361535659"
+			x: 4.5d
+			y: -6.0d
 			rewards: [{
 				id: "4F75B5B694D289A2"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "When stepped upon, can teleport the player upwards and downwards, as long as it finds another elevator directly above or below it."
+			dependencies: ["168F737F6246967F"]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/mechanical_age.snbt
+++ b/config/ftbquests/quests/chapters/mechanical_age.snbt
@@ -1,65 +1,54 @@
 {
-	id: "7712ECFF0A903A7B"
-	group: "38633DD49534BFCD"
-	order_index: 1
-	filename: "mechanical_age"
-	title: "Mechanical Age"
-	icon: "create:cogwheel"
-	default_quest_shape: ""
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "38633DD49534BFCD"
+	id: "7712ECFF0A903A7B"
+	filename: "mechanical_age"
+	default_quest_shape: ""
+	icon: "create:cogwheel"
+	title: "Mechanical Age"
+	order_index: 1
 	quests: [
 		{
-			x: -24.0d
-			y: 3.0d
-			subtitle: "The base ingredient for the Create mod."
-			dependencies: ["725237684B3596F1"]
 			size: 1.5d
 			id: "126ACAE113ADC877"
-			tasks: [{
-				id: "772A3E3AA31E1680"
-				type: "item"
-				item: "create:andesite_alloy"
-				count: 16L
-			}]
+			x: -24.0d
+			y: 3.0d
 			rewards: [{
 				id: "4021A7365FAFC40E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The base ingredient for the Create mod."
+			dependencies: ["725237684B3596F1"]
+			tasks: [{
+				id: "772A3E3AA31E1680"
+				type: "item"
+				item: "create:andesite_alloy"
+				count: 16L
+			}]
 		}
 		{
-			x: -22.0d
-			y: 3.0d
-			shape: "square"
-			subtitle: "Used to transfer Rotational Force."
-			dependencies: ["126ACAE113ADC877"]
-			id: "4200194006454664"
 			tasks: [{
 				id: "32A062AB0F6A5FA1"
 				type: "item"
 				item: "create:shaft"
 			}]
+			x: -22.0d
+			id: "4200194006454664"
+			y: 3.0d
+			shape: "square"
 			rewards: [{
 				id: "200779CDFCF569AF"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Used to transfer Rotational Force."
+			dependencies: ["126ACAE113ADC877"]
 		}
 		{
-			title: "Cogwheels"
-			x: -20.0d
-			y: 3.0d
-			shape: "square"
-			description: [
-				"Placing a Cogwheel diagonally to a powered Large Cogwheel will double the rotational speed."
-				"In reverse case, it will halve the rotational speed."
-				""
-				"The speed cannot exceed 256 RPM, else the cogwheels will break!"
-			]
-			dependencies: ["4200194006454664"]
-			id: "160951F6A70A85ED"
 			tasks: [
 				{
 					id: "570F6703D5CB1C86"
@@ -72,59 +61,73 @@
 					item: "create:large_cogwheel"
 				}
 			]
+			description: [
+				"Placing a Cogwheel diagonally to a powered Large Cogwheel will double the rotational speed."
+				"In reverse case, it will halve the rotational speed."
+				""
+				"The speed cannot exceed 256 RPM, else the cogwheels will break!"
+			]
+			x: -20.0d
+			id: "160951F6A70A85ED"
+			y: 3.0d
+			shape: "square"
+			title: "Cogwheels"
 			rewards: [{
 				id: "6608A7E4E47B0BFF"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["4200194006454664"]
 		}
 		{
-			x: -21.0d
-			y: 9.0d
-			subtitle: "Item transportation!"
-			description: [
-				"Right-click on a Shaft to start placing a Belt."
-				"Right-Click on the other Shaft to place it."
-				"Belts can be horizontal, diagonal (upwards 45°) or vertical."
-			]
-			dependencies: ["28533D71EED27C29"]
-			id: "08E0C40F00BA45B0"
 			tasks: [{
 				id: "01ED017765F2E1B0"
 				type: "item"
 				item: "create:belt_connector"
 			}]
+			description: [
+				"Right-click on a Shaft to start placing a Belt."
+				"Right-Click on the other Shaft to place it."
+				"Belts can be horizontal, diagonal (upwards 45°) or vertical."
+			]
+			id: "08E0C40F00BA45B0"
+			x: -21.0d
+			y: 9.0d
 			rewards: [{
 				id: "609E77743AE18E1A"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Item transportation!"
+			dependencies: ["28533D71EED27C29"]
 		}
 		{
-			x: -16.5d
-			y: 0.0d
-			subtitle: "Used to relay the rotational force to other directions."
-			description: ["You can put it into the Crafting Table to turn it into the Vertical Gearbox, and vice versa."]
-			dependencies: ["5715F503D92DEE95"]
-			id: "1F1EC128BCC3144E"
 			tasks: [{
 				id: "72ADAE4755D6B8F1"
 				type: "item"
 				item: "create:gearbox"
 			}]
+			description: ["You can put it into the Crafting Table to turn it into the Vertical Gearbox, and vice versa."]
+			id: "1F1EC128BCC3144E"
+			x: -16.5d
+			y: 0.0d
 			rewards: [{
 				id: "47BA5581E7AF6DFB"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Used to relay the rotational force to other directions."
+			dependencies: ["5715F503D92DEE95"]
 		}
 		{
-			x: -19.0d
-			y: 4.0d
-			subtitle: "I'm a big fan of this!"
+			tasks: [{
+				id: "22136FF9A6E5D613"
+				type: "item"
+				item: "create:encased_fan"
+			}]
 			description: [
 				"Blows or sucks air in front of itself, depending on rotation."
 				""
@@ -133,42 +136,42 @@
 				""
 				"Consult its Ponder Scene for more information."
 			]
-			dependencies: ["18E391B45D935712"]
 			id: "3ECCC092EB52FE86"
-			tasks: [{
-				id: "22136FF9A6E5D613"
-				type: "item"
-				item: "create:encased_fan"
-			}]
+			x: -19.0d
+			y: 4.0d
 			rewards: [{
 				id: "42DAAEE757463DAB"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "I'm a big fan of this!"
+			dependencies: ["18E391B45D935712"]
 		}
 		{
-			x: -16.0d
-			y: 6.0d
-			subtitle: "Can mill some items, when tossed on top or pushed by automation."
-			dependencies: ["18E391B45D935712"]
-			id: "513640F0E05D9804"
 			tasks: [{
 				id: "4A39BB22B1377F74"
 				type: "item"
 				item: "create:millstone"
 			}]
+			id: "513640F0E05D9804"
+			x: -16.0d
+			y: 6.0d
 			rewards: [{
 				id: "677E90A202DD810F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Can mill some items, when tossed on top or pushed by automation."
+			dependencies: ["18E391B45D935712"]
 		}
 		{
-			x: -15.5d
-			y: 4.5d
-			subtitle: "Mix it!"
+			tasks: [{
+				id: "75A0FA05575C117E"
+				type: "item"
+				item: "create:mechanical_mixer"
+			}]
 			description: [
 				"Powered by cogwheels, this machine can mix different items cointained in the Basin below."
 				""
@@ -176,33 +179,37 @@
 				""
 				"The Mixer can also automatically craft shapeless recipes and potions."
 			]
-			dependencies: ["18E391B45D935712"]
 			id: "7C76819CB83F2D93"
-			tasks: [{
-				id: "75A0FA05575C117E"
-				type: "item"
-				item: "create:mechanical_mixer"
-			}]
+			x: -15.5d
+			y: 4.5d
 			rewards: [{
 				id: "4B6965C63551044F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Mix it!"
+			dependencies: ["18E391B45D935712"]
 		}
 		{
-			icon: "create:mechanical_press"
-			x: -14.5d
-			y: 3.0d
-			shape: "octagon"
+			size: 1.5d
 			description: [
 				"To get your first Plates, you need to press the Ingots using the Mechanical Press."
 				"You can either toss them on the ground, put them on a Depot, or being automatically provided by Belts."
 				"You will need a Basin, if you want to automatically compress items into blocks."
 			]
-			dependencies: ["18E391B45D935712"]
-			size: 1.5d
 			id: "30CFBDB612551DE7"
+			icon: "create:mechanical_press"
+			x: -14.5d
+			y: 3.0d
+			shape: "octagon"
+			rewards: [{
+				id: "60ECAFF032A5C3EE"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 13756307348121783L
+			}]
+			dependencies: ["18E391B45D935712"]
 			tasks: [
 				{
 					id: "1DC90473D1312566"
@@ -233,21 +240,8 @@
 					}
 				}
 			]
-			rewards: [{
-				id: "60ECAFF032A5C3EE"
-				type: "random"
-				exclude_from_claim_all: true
-				table_id: 13756307348121783L
-			}]
 		}
 		{
-			title: "Blaze Burner"
-			x: -10.0d
-			y: 0.5d
-			subtitle: "Can you capture a Blaze in it?"
-			description: ["Feed it with burnable material to heat it up."]
-			dependencies: ["626D5BD796C10F29"]
-			id: "5212BF6AA5940CA1"
 			tasks: [
 				{
 					id: "1EE86BD121D575A7"
@@ -260,27 +254,21 @@
 					item: "create:blaze_burner"
 				}
 			]
+			description: ["Feed it with burnable material to heat it up."]
+			id: "5212BF6AA5940CA1"
+			x: -10.0d
+			y: 0.5d
+			title: "Blaze Burner"
 			rewards: [{
 				id: "6EEF554E630C6CF2"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Can you capture a Blaze in it?"
+			dependencies: ["626D5BD796C10F29"]
 		}
 		{
-			x: -13.5d
-			y: -1.0d
-			description: [
-				"Portable Fluid Interfaces can interact with Contraptions, extracting from or loading into the Contraption."
-				""
-				"Spouts can automatically fill up Buckets and Bottles with fluid."
-				""
-				"Item Drains drain fluids from Fluid containing items."
-				"Basins can also auto-output fluids to a diagonally down Item Drain!"
-			]
-			dependencies: ["34B606914797FB12"]
-			min_required_tasks: 1
-			id: "62A78C1DEB1B231A"
 			tasks: [
 				{
 					id: "1F3A92127194A218"
@@ -325,19 +313,28 @@
 					item: "create:item_drain"
 				}
 			]
+			description: [
+				"Portable Fluid Interfaces can interact with Contraptions, extracting from or loading into the Contraption."
+				""
+				"Spouts can automatically fill up Buckets and Bottles with fluid."
+				""
+				"Item Drains drain fluids from Fluid containing items."
+				"Basins can also auto-output fluids to a diagonally down Item Drain!"
+			]
+			id: "62A78C1DEB1B231A"
+			x: -13.5d
+			y: -1.0d
 			rewards: [{
 				id: "5B80A9B31877D3E8"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["34B606914797FB12"]
+			min_required_tasks: 1
 		}
 		{
-			title: "Sequenced Assembly"
-			x: -12.5d
-			y: 6.0d
-			shape: "gear"
-			subtitle: "Some assembly required"
+			size: 1.5d
 			description: [
 				"Some Items, like a Precision Mechanism or a Bronze Boiler, require a seqence of operations for output."
 				""
@@ -345,52 +342,58 @@
 				""
 				"Check REI \"Recipe Sequence\" recipes for more information."
 			]
-			dependencies: [
-				"3568FE880980DB5D"
-				"22D1C5AA8F750CC1"
-			]
-			size: 1.5d
 			id: "6B39422421203401"
-			tasks: [{
-				id: "2876B04225348D12"
-				type: "item"
-				item: "create:deployer"
-			}]
+			x: -12.5d
+			y: 6.0d
+			shape: "gear"
+			title: "Sequenced Assembly"
 			rewards: [{
 				id: "6A3B73BC46D1FE1D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Some assembly required"
+			dependencies: [
+				"3568FE880980DB5D"
+				"22D1C5AA8F750CC1"
+			]
+			tasks: [{
+				id: "2876B04225348D12"
+				type: "item"
+				item: "create:deployer"
+			}]
 		}
 		{
-			x: -8.5d
-			y: 8.0d
-			subtitle: "Don't get crushed!"
+			tasks: [{
+				id: "334ABF83A5847E28"
+				type: "item"
+				item: "create:crushing_wheel"
+			}]
 			description: [
 				"One of them are the Crushing Wheels."
 				"Place them next to each other."
 				"When spinning in the opposite directions, it can crush items in bulk."
 				"Speed depends on rotational speed."
 			]
-			dependencies: ["12A116542970EECB"]
 			id: "25786BA1415B9756"
-			tasks: [{
-				id: "334ABF83A5847E28"
-				type: "item"
-				item: "create:crushing_wheel"
-			}]
+			x: -8.5d
+			y: 8.0d
 			rewards: [{
 				id: "33795860A2A98296"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Don't get crushed!"
+			dependencies: ["12A116542970EECB"]
 		}
 		{
-			x: -18.0d
-			y: 6.0d
-			subtitle: "How much wood would a woodchuck chuck, if a woodchuck could chuck wood?"
+			tasks: [{
+				id: "0A589D4398A0C5D7"
+				type: "item"
+				item: "create:mechanical_saw"
+			}]
 			description: [
 				"Has 2 modes of operation:"
 				"1. When placed on the side, applying Rotational Force will automatically cut down trees in front of it."
@@ -399,104 +402,93 @@
 				""
 				"If you want to use it on a belt line, it must spin in opposite direction to the belt."
 			]
-			hide_dependency_lines: false
-			dependencies: ["18E391B45D935712"]
 			id: "4E258638E399B7EC"
-			tasks: [{
-				id: "0A589D4398A0C5D7"
-				type: "item"
-				item: "create:mechanical_saw"
-			}]
+			x: -18.0d
+			y: 6.0d
 			rewards: [{
 				id: "14C7A1BAB6542D47"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "How much wood would a woodchuck chuck, if a woodchuck could chuck wood?"
+			dependencies: ["18E391B45D935712"]
+			hide_dependency_lines: false
 		}
 		{
+			size: 1.5d
+			description: ["It can automatically curve Plates and make Rods from Ingots!"]
+			id: "116FC0E7285D0BF4"
 			x: -17.0d
 			y: 7.5d
 			shape: "gear"
-			subtitle: "A step into Steam Age!"
-			description: ["It can automatically curve Plates and make Rods from Ingots!"]
-			hide_dependency_lines: false
-			dependencies: ["18E391B45D935712"]
-			size: 1.5d
-			id: "116FC0E7285D0BF4"
-			tasks: [{
-				id: "37550D1B57DCBAEE"
-				type: "item"
-				item: "createaddition:rolling_mill"
-			}]
 			rewards: [{
 				id: "26F4C7B346B848AB"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A step into Steam Age!"
+			dependencies: ["18E391B45D935712"]
+			hide_dependency_lines: false
+			tasks: [{
+				id: "37550D1B57DCBAEE"
+				type: "item"
+				item: "createaddition:rolling_mill"
+			}]
 		}
 		{
-			x: -7.5d
-			y: 6.0d
-			subtitle: "First Autocrafting!"
-			description: [
-				"It can automate crafting recipes, small and big."
-				""
-				"They are required for some recipes."
-			]
-			dependencies: [
-				"0E4D3F62160BA382"
-				"3E3F2A0D09B1C534"
-			]
-			id: "12A116542970EECB"
 			tasks: [{
 				id: "4E84B144567CAD32"
 				type: "item"
 				item: "create:mechanical_crafter"
 			}]
+			description: [
+				"It can automate crafting recipes, small and big."
+				""
+				"They are required for some recipes."
+			]
+			id: "12A116542970EECB"
+			x: -7.5d
+			y: 6.0d
 			rewards: [{
 				id: "1551BB81E6F12C39"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "First Autocrafting!"
+			dependencies: [
+				"0E4D3F62160BA382"
+				"3E3F2A0D09B1C534"
+			]
 		}
 		{
-			x: -4.5d
-			y: 5.0d
-			subtitle: "The first Energy source!"
-			description: [
-				"(the Tech Reborn one, to be exact.)"
-				"When powered by kinetics, generates Energy."
-			]
-			dependencies: [
-				"71B164CE2086EBB0"
-				"12A116542970EECB"
-			]
-			id: "3F02A6EB74C47752"
 			tasks: [{
 				id: "6105D9F5C53D01D0"
 				type: "item"
 				item: "createaddition:alternator"
 			}]
+			description: [
+				"(the Tech Reborn one, to be exact.)"
+				"When powered by kinetics, generates Energy."
+			]
+			id: "3F02A6EB74C47752"
+			x: -4.5d
+			y: 5.0d
 			rewards: [{
 				id: "62F06C7E8B9150FC"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The first Energy source!"
+			dependencies: [
+				"71B164CE2086EBB0"
+				"12A116542970EECB"
+			]
 		}
 		{
-			x: -3.5d
-			y: 6.0d
-			subtitle: "Wires that can transmit Energy."
-			description: [
-				"Right-Click on a Connector with a Spool in hand."
-				"These wires do not electrocute you, and can pass through walls."
-			]
-			dependencies: ["64623A40FA9ED518"]
-			id: "71B164CE2086EBB0"
 			tasks: [
 				{
 					id: "594594233AE3E90A"
@@ -509,90 +501,91 @@
 					item: "createaddition:copper_spool"
 				}
 			]
+			description: [
+				"Right-Click on a Connector with a Spool in hand."
+				"These wires do not electrocute you, and can pass through walls."
+			]
+			id: "71B164CE2086EBB0"
+			x: -3.5d
+			y: 6.0d
 			rewards: [{
 				id: "024BE09CCE515B20"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Wires that can transmit Energy."
+			dependencies: ["64623A40FA9ED518"]
 		}
 		{
-			x: -21.0d
-			y: 0.5d
-			subtitle: "Generates rotational force from energy."
+			tasks: [{
+				id: "66DB9069AFE1B840"
+				type: "item"
+				item: "createaddition:electric_motor"
+			}]
 			description: [
 				"You can adjust the speed just like you would do on a Creative Motor."
 				"The higher the speed of the Motor, the more energy it needs to operate."
 				""
 				"Bonus: It can be used as a ComputerCraft peripheral!"
 			]
-			dependencies: ["15C5FE720715D50F"]
 			id: "78EE2AD247E2123F"
-			tasks: [{
-				id: "66DB9069AFE1B840"
-				type: "item"
-				item: "createaddition:electric_motor"
-			}]
+			x: -21.0d
+			y: 0.5d
 			rewards: [{
 				id: "347B4D6B479141EA"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates rotational force from energy."
+			dependencies: ["15C5FE720715D50F"]
 		}
 		{
-			x: -4.5d
-			y: 6.0d
-			subtitle: "It can charge items or damage mobs in an area."
-			dependencies: [
-				"71B164CE2086EBB0"
-				"12A116542970EECB"
-			]
-			id: "288BAAECAEC8C241"
 			tasks: [{
 				id: "62CBA67DA84BC287"
 				type: "item"
 				item: "createaddition:tesla_coil"
 			}]
+			id: "288BAAECAEC8C241"
+			x: -4.5d
+			y: 6.0d
 			rewards: [{
 				id: "7D94E08B60AA6CE8"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "It can charge items or damage mobs in an area."
+			dependencies: [
+				"71B164CE2086EBB0"
+				"12A116542970EECB"
+			]
 		}
 		{
-			x: -11.5d
-			y: 3.5d
-			subtitle: "An Engineer's friend."
-			description: [
-				"Can instantly dismantle certain Minecraft and Create Blocks."
-				""
-				"It can also rotate Create Machines and configure the range of various Chassis."
-			]
-			dependencies: ["30CFBDB612551DE7"]
-			id: "777F0AFE1186E482"
 			tasks: [{
 				id: "014EAC5BB3388961"
 				type: "item"
 				item: "create:wrench"
 			}]
+			description: [
+				"Can instantly dismantle certain Minecraft and Create Blocks."
+				""
+				"It can also rotate Create Machines and configure the range of various Chassis."
+			]
+			id: "777F0AFE1186E482"
+			x: -11.5d
+			y: 3.5d
 			rewards: [{
 				id: "7C61B6E5525B5D6C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "An Engineer's friend."
+			dependencies: ["30CFBDB612551DE7"]
 		}
 		{
-			x: -7.5d
-			y: 8.0d
-			subtitle: "Increases your Reach while in offhand."
-			dependencies: [
-				"12A116542970EECB"
-				"5CD46451E8E482DE"
-			]
-			id: "5BC223157F0F95B7"
 			tasks: [{
 				id: "64A14FB7838D53B6"
 				type: "item"
@@ -604,46 +597,46 @@
 					}
 				}
 			}]
+			id: "5BC223157F0F95B7"
+			x: -7.5d
+			y: 8.0d
 			rewards: [{
 				id: "5D1F36A294C3384D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Increases your Reach while in offhand."
+			dependencies: [
+				"12A116542970EECB"
+				"5CD46451E8E482DE"
+			]
 		}
 		{
-			x: -5.5d
-			y: 8.0d
-			subtitle: "Perfectly Symmetrical."
+			tasks: [{
+				id: "0E42DD1D623CB639"
+				type: "item"
+				item: "create:wand_of_symmetry"
+			}]
 			description: [
 				"Use it on the ground to place a mirror."
 				"Shift-Right Click to open a GUI in which you can change a symmetry mode."
 				""
 				"Every action made (breaking/placing blocks) will be reflected across configured Planes."
 			]
-			dependencies: ["12A116542970EECB"]
 			id: "02275F76722E63CB"
-			tasks: [{
-				id: "0E42DD1D623CB639"
-				type: "item"
-				item: "create:wand_of_symmetry"
-			}]
+			x: -5.5d
+			y: 8.0d
 			rewards: [{
 				id: "2DDB668B725E3095"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Perfectly Symmetrical."
+			dependencies: ["12A116542970EECB"]
 		}
 		{
-			x: -6.5d
-			y: 8.0d
-			subtitle: "Shoots a variety of vegetables as ammo."
-			dependencies: [
-				"12A116542970EECB"
-				"5CD46451E8E482DE"
-			]
-			id: "5F35AFB3825D5087"
 			tasks: [{
 				id: "7D2DAA841F051B2F"
 				type: "item"
@@ -655,23 +648,31 @@
 					}
 				}
 			}]
+			id: "5F35AFB3825D5087"
+			x: -6.5d
+			y: 8.0d
 			rewards: [{
 				id: "34949FEF6F7AF5D5"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Shoots a variety of vegetables as ammo."
+			dependencies: [
+				"12A116542970EECB"
+				"5CD46451E8E482DE"
+			]
 		}
 		{
-			x: -7.5d
-			y: 2.5d
-			dependencies: ["4D59FB0ACC00C03E"]
-			id: "1AE5C3C8ABCEA03C"
 			tasks: [{
 				id: "04C2E4C61E9B2702"
 				type: "item"
 				item: "create:peculiar_bell"
 			}]
+			dependencies: ["4D59FB0ACC00C03E"]
+			id: "1AE5C3C8ABCEA03C"
+			y: 2.5d
+			x: -7.5d
 			rewards: [{
 				id: "5BA8403316389BF4"
 				type: "random"
@@ -680,29 +681,24 @@
 			}]
 		}
 		{
-			x: -8.5d
-			y: 2.5d
-			subtitle: "The cooler F7."
-			dependencies: ["1AE5C3C8ABCEA03C"]
-			id: "532595E68952CD9B"
 			tasks: [{
 				id: "20B1374964C0CC05"
 				type: "item"
 				item: "create:haunted_bell"
 			}]
+			id: "532595E68952CD9B"
+			x: -8.5d
+			y: 2.5d
 			rewards: [{
 				id: "42B7528894D6FAEC"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The cooler F7."
+			dependencies: ["1AE5C3C8ABCEA03C"]
 		}
 		{
-			title: "Diving Equipment"
-			x: -5.5d
-			y: 1.5d
-			dependencies: ["3A20A7BE25BB48A0"]
-			id: "1C5C658FD5A5D276"
 			tasks: [
 				{
 					id: "2D6244B4FF1F2EC4"
@@ -727,24 +723,19 @@
 					}
 				}
 			]
+			id: "1C5C658FD5A5D276"
+			x: -5.5d
+			y: 1.5d
+			title: "Diving Equipment"
 			rewards: [{
 				id: "39942F3BFDC28406"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["3A20A7BE25BB48A0"]
 		}
 		{
-			x: -5.5d
-			y: 2.5d
-			subtitle: "Contains pressurized air."
-			description: [
-				"Place it on the ground and apply Rotational Force to fill it with air."
-				""
-				"Can be enchanted with Capacity to increase its air capacity."
-			]
-			dependencies: ["4D59FB0ACC00C03E"]
-			id: "3A20A7BE25BB48A0"
 			tasks: [{
 				id: "76020106E2A481BF"
 				type: "item"
@@ -756,19 +747,24 @@
 					}
 				}
 			}]
+			description: [
+				"Place it on the ground and apply Rotational Force to fill it with air."
+				""
+				"Can be enchanted with Capacity to increase its air capacity."
+			]
+			id: "3A20A7BE25BB48A0"
+			x: -5.5d
+			y: 2.5d
 			rewards: [{
 				id: "2A12CE21093CFF06"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Contains pressurized air."
+			dependencies: ["4D59FB0ACC00C03E"]
 		}
 		{
-			x: -9.5d
-			y: 8.0d
-			subtitle: "Allows printing Schematics into the world."
-			dependencies: ["5CD46451E8E482DE"]
-			id: "72DE0448AFC8A7C8"
 			tasks: [
 				{
 					id: "1D60AD352E511181"
@@ -781,34 +777,19 @@
 					item: "create:schematicannon"
 				}
 			]
+			id: "72DE0448AFC8A7C8"
+			x: -9.5d
+			y: 8.0d
 			rewards: [{
 				id: "7A553B8F67E40BDD"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Allows printing Schematics into the world."
+			dependencies: ["5CD46451E8E482DE"]
 		}
 		{
-			title: "Pipes"
-			x: -13.5d
-			y: 0.5d
-			subtitle: "Fluid Transport!"
-			description: [
-				"Pipes transfer fluids. The fluid contained can spill out if the fluid is pumped into the open pipe!"
-				"They can be encased with Copper Casings - this will lock connections, so putting new pipes won't interrupt the encased Pipe."
-				"You can also toggle a window using a Wrench - windowed pipes can't bend."
-				""
-				"Smart Fluid Pipes only lets through fluids specified by the filter."
-				""
-				"Fluid Valves can block fluid transfer when Rotational Force is applied."
-				"Pairs nicely with Valve Handles!"
-				""
-				"Fluid Pumps, when powered by a Cogwheel, pumps fluids."
-				"It can transfer fluid up from 15 blocks back to 15 blocks forward."
-			]
-			dependencies: ["749FDD2830BBF0F2"]
-			min_required_tasks: 1
-			id: "4C75EAA98DA35CBC"
 			tasks: [
 				{
 					id: "4ED217851B7DA1E7"
@@ -831,65 +812,80 @@
 					item: "create:mechanical_pump"
 				}
 			]
+			description: [
+				"Pipes transfer fluids. The fluid contained can spill out if the fluid is pumped into the open pipe!"
+				"They can be encased with Copper Casings - this will lock connections, so putting new pipes won't interrupt the encased Pipe."
+				"You can also toggle a window using a Wrench - windowed pipes can't bend."
+				""
+				"Smart Fluid Pipes only lets through fluids specified by the filter."
+				""
+				"Fluid Valves can block fluid transfer when Rotational Force is applied."
+				"Pairs nicely with Valve Handles!"
+				""
+				"Fluid Pumps, when powered by a Cogwheel, pumps fluids."
+				"It can transfer fluid up from 15 blocks back to 15 blocks forward."
+			]
+			id: "4C75EAA98DA35CBC"
+			x: -13.5d
+			y: 0.5d
+			title: "Pipes"
 			rewards: [{
 				id: "4EF59763916D4F4B"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Fluid Transport!"
+			dependencies: ["749FDD2830BBF0F2"]
+			min_required_tasks: 1
 		}
 		{
-			x: -11.5d
-			y: -1.0d
-			subtitle: "Not used for war."
-			description: [
-				"Each Fluid Tank can hold 8 buckets of fluid, and can form multiblocks with a base of 1x1, 2x2 or 3x3."
-				""
-				"Fluids can be insterted and extracted only by automation."
-			]
-			dependencies: ["34B606914797FB12"]
-			id: "5FE72794BF29DCC4"
 			tasks: [{
 				id: "3F3F4F75B680C53F"
 				type: "item"
 				item: "create:fluid_tank"
 			}]
+			description: [
+				"Each Fluid Tank can hold 8 buckets of fluid, and can form multiblocks with a base of 1x1, 2x2 or 3x3."
+				""
+				"Fluids can be insterted and extracted only by automation."
+			]
+			id: "5FE72794BF29DCC4"
+			x: -11.5d
+			y: -1.0d
 			rewards: [{
 				id: "01175EADF638F4A1"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Not used for war."
+			dependencies: ["34B606914797FB12"]
 		}
 		{
-			x: -12.5d
-			y: -1.0d
-			subtitle: "Slurping Machine."
-			description: [
-				"It can flood an area with fluid or pull from a pool of fluid."
-				""
-				"If a body of water or lava contains more than 10,000 buckets of fluid, it will be considered infinite!"
-			]
-			dependencies: ["34B606914797FB12"]
-			id: "430CCC837C1A9E84"
 			tasks: [{
 				id: "30ABF9CAC4B428B3"
 				type: "item"
 				item: "create:hose_pulley"
 			}]
+			description: [
+				"It can flood an area with fluid or pull from a pool of fluid."
+				""
+				"If a body of water or lava contains more than 10,000 buckets of fluid, it will be considered infinite!"
+			]
+			id: "430CCC837C1A9E84"
+			x: -12.5d
+			y: -1.0d
 			rewards: [{
 				id: "62CE3465DBECB70C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Slurping Machine."
+			dependencies: ["34B606914797FB12"]
 		}
 		{
-			x: -5.0d
-			y: 3.5d
-			subtitle: "Can measure statistics, such as rotation speed or network stress."
-			dependencies: ["4D59FB0ACC00C03E"]
-			id: "29C654FC753FDDFC"
 			tasks: [
 				{
 					id: "50F5DD2DF3B8BDB8"
@@ -902,17 +898,24 @@
 					item: "create:stressometer"
 				}
 			]
+			id: "29C654FC753FDDFC"
+			x: -5.0d
+			y: 3.5d
 			rewards: [{
 				id: "67D630E80D55C53D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Can measure statistics, such as rotation speed or network stress."
+			dependencies: ["4D59FB0ACC00C03E"]
 		}
 		{
-			x: -11.5d
-			y: 8.0d
-			subtitle: "Full Control!"
+			tasks: [{
+				id: "40E7A5D9289B536B"
+				type: "item"
+				item: "create:rotation_speed_controller"
+			}]
 			description: [
 				"Allows you to choose a speed that will be relayed."
 				"If you power a controller block, the speed will be relayed to the Large Cogwheel above."
@@ -920,152 +923,138 @@
 				""
 				"Consult its Ponder Scene for more information."
 			]
-			dependencies: ["5CD46451E8E482DE"]
 			id: "1C3E78573A6CD0BB"
-			tasks: [{
-				id: "40E7A5D9289B536B"
-				type: "item"
-				item: "create:rotation_speed_controller"
-			}]
+			x: -11.5d
+			y: 8.0d
 			rewards: [{
 				id: "378833AE259CFF51"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Full Control!"
+			dependencies: ["5CD46451E8E482DE"]
 		}
 		{
-			x: -5.5d
-			y: 0.0d
-			subtitle: "Wireless Redstone."
-			description: [
-				"Right-Click it with a Wrench to switch it to the \"Reciever Mode\"."
-				"You can set the frequency by placing items in the frequency slots."
-			]
-			dependencies: ["09C258CD619B2B88"]
-			id: "3F30A44F874A5161"
 			tasks: [{
 				id: "3F73EA7553A12682"
 				type: "item"
 				item: "create:redstone_link"
 			}]
+			description: [
+				"Right-Click it with a Wrench to switch it to the \"Reciever Mode\"."
+				"You can set the frequency by placing items in the frequency slots."
+			]
+			id: "3F30A44F874A5161"
+			x: -5.5d
+			y: 0.0d
 			rewards: [{
 				id: "5CBB460460137A89"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Wireless Redstone."
+			dependencies: ["09C258CD619B2B88"]
 		}
 		{
-			x: -21.5d
-			y: 10.5d
-			subtitle: "Can extract or insert items, one at the time."
-			description: ["Cannot be filtered."]
-			dependencies: ["08E0C40F00BA45B0"]
-			id: "39ABA3673A5A8CD7"
 			tasks: [{
 				id: "631ABD996F6C3FC6"
 				type: "item"
 				item: "create:andesite_funnel"
 			}]
+			description: ["Cannot be filtered."]
+			id: "39ABA3673A5A8CD7"
+			x: -21.5d
+			y: 10.5d
 			rewards: [{
 				id: "7138540609F55C89"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Can extract or insert items, one at the time."
+			dependencies: ["08E0C40F00BA45B0"]
 		}
 		{
-			x: -21.5d
-			y: 11.5d
-			description: ["Bras Funnels have a configurable input/output rate, are filterable and can be blocked by redstone."]
-			dependencies: ["08E0C40F00BA45B0"]
-			id: "234612F78EFE056E"
 			tasks: [{
 				id: "05E5C93DDA12E3A4"
 				type: "item"
 				item: "create:brass_funnel"
 			}]
+			description: ["Bras Funnels have a configurable input/output rate, are filterable and can be blocked by redstone."]
+			id: "234612F78EFE056E"
+			x: -21.5d
+			y: 11.5d
 			rewards: [{
 				id: "4B697C3A2332AB55"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["08E0C40F00BA45B0"]
 		}
 		{
-			x: -20.5d
-			y: 10.5d
-			subtitle: "Can cover Belts or split single items."
-			description: [
-				"If a Tunnel is placed on an intersection between two belts, it will place 1 item on the perpendicular belt."
-				""
-				"Cannot be filtered."
-			]
-			dependencies: ["08E0C40F00BA45B0"]
-			id: "37EB5A80EB20E6A3"
 			tasks: [{
 				id: "2E72B0F8B4BC63AF"
 				type: "item"
 				item: "create:andesite_tunnel"
 			}]
+			description: [
+				"If a Tunnel is placed on an intersection between two belts, it will place 1 item on the perpendicular belt."
+				""
+				"Cannot be filtered."
+			]
+			id: "37EB5A80EB20E6A3"
+			x: -20.5d
+			y: 10.5d
 			rewards: [{
 				id: "246AD390A73F9FF3"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Can cover Belts or split single items."
+			dependencies: ["08E0C40F00BA45B0"]
 		}
 		{
-			x: -20.5d
-			y: 11.5d
-			description: ["If a Brass Tunnel is placed on an intersection between two belts, it will place a stack of items on the perpendicular belt if the filter matches."]
-			dependencies: ["08E0C40F00BA45B0"]
-			id: "071583B5D4CC582E"
 			tasks: [{
 				id: "4031102D9AABE84D"
 				type: "item"
 				item: "create:brass_tunnel"
 			}]
+			description: ["If a Brass Tunnel is placed on an intersection between two belts, it will place a stack of items on the perpendicular belt if the filter matches."]
+			id: "071583B5D4CC582E"
+			x: -20.5d
+			y: 11.5d
 			rewards: [{
 				id: "1950626DE2B73200"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["08E0C40F00BA45B0"]
 		}
 		{
-			x: -18.0d
-			y: 1.0d
-			subtitle: "Phew. That was close!"
-			description: ["It can stop Rotation using a redstone signal."]
-			dependencies: ["5715F503D92DEE95"]
-			id: "48EE84396682C6C1"
 			tasks: [{
 				id: "2528CA79F746C090"
 				type: "item"
 				item: "create:clutch"
 			}]
+			description: ["It can stop Rotation using a redstone signal."]
+			id: "48EE84396682C6C1"
+			x: -18.0d
+			y: 1.0d
 			rewards: [{
 				id: "2AFB19D43E80A424"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Phew. That was close!"
+			dependencies: ["5715F503D92DEE95"]
 		}
 		{
-			title: "Gearshifts"
-			x: -16.0d
-			y: 1.0d
-			subtitle: "Reverse!"
-			description: [
-				"A regular Gearshift can reverse rotation when powered by redstone."
-				""
-				"Sequenced Gearshifts can hold 5 different instructions which are executed on redstone pulse."
-			]
-			dependencies: ["5715F503D92DEE95"]
-			min_required_tasks: 1
-			id: "43AD4C293E97E9B3"
 			tasks: [
 				{
 					id: "108555FCE260FDFC"
@@ -1078,25 +1067,26 @@
 					item: "create:sequenced_gearshift"
 				}
 			]
+			description: [
+				"A regular Gearshift can reverse rotation when powered by redstone."
+				""
+				"Sequenced Gearshifts can hold 5 different instructions which are executed on redstone pulse."
+			]
+			id: "43AD4C293E97E9B3"
+			x: -16.0d
+			y: 1.0d
+			title: "Gearshifts"
 			rewards: [{
 				id: "3CC4C41E4F0B9A8E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Reverse!"
+			dependencies: ["5715F503D92DEE95"]
+			min_required_tasks: 1
 		}
 		{
-			title: "Toolboxes"
-			x: -6.5d
-			y: 2.0d
-			subtitle: "Helps in inventory management."
-			description: [
-				"Simply put them on the ground!"
-				"By pressing [Alt - by default], you can access nearby Toolboxes."
-				"When an item is selected, the Toolbox will automatically stock items into your inventory."
-			]
-			dependencies: ["4D59FB0ACC00C03E"]
-			id: "18392B26224F9EF2"
 			tasks: [{
 				id: "1C2BE7A5452A1934"
 				type: "item"
@@ -1111,19 +1101,25 @@
 					}
 				}
 			}]
+			description: [
+				"Simply put them on the ground!"
+				"By pressing [Alt - by default], you can access nearby Toolboxes."
+				"When an item is selected, the Toolbox will automatically stock items into your inventory."
+			]
+			id: "18392B26224F9EF2"
+			x: -6.5d
+			y: 2.0d
+			title: "Toolboxes"
 			rewards: [{
 				id: "02B5131C181B1EEF"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Helps in inventory management."
+			dependencies: ["4D59FB0ACC00C03E"]
 		}
 		{
-			x: -6.5d
-			y: 0.5d
-			subtitle: "Changes output state on redstone pulse."
-			dependencies: ["09C258CD619B2B88"]
-			id: "25411C841A50AA4B"
 			tasks: [
 				{
 					id: "16A0DECFD149BBCA"
@@ -1136,17 +1132,24 @@
 					item: "create:powered_latch"
 				}
 			]
+			id: "25411C841A50AA4B"
+			x: -6.5d
+			y: 0.5d
 			rewards: [{
 				id: "14AB6AB7A0DDAE5E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Changes output state on redstone pulse."
+			dependencies: ["09C258CD619B2B88"]
 		}
 		{
-			x: -19.5d
-			y: 9.0d
-			subtitle: "Mass Item Storage."
+			tasks: [{
+				id: "15FF95A044C91807"
+				type: "item"
+				item: "create:item_vault"
+			}]
 			description: [
 				"Stores 20 stacks of Items per one Item Vault block."
 				""
@@ -1154,356 +1157,346 @@
 				""
 				"Items can be inserted and extracted only by automation."
 			]
-			dependencies: ["28533D71EED27C29"]
 			id: "7F5E02EC685422BC"
-			tasks: [{
-				id: "15FF95A044C91807"
-				type: "item"
-				item: "create:item_vault"
-			}]
+			x: -19.5d
+			y: 9.0d
 			rewards: [{
 				id: "6727F9220106BF99"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Mass Item Storage."
+			dependencies: ["28533D71EED27C29"]
 		}
 		{
-			x: -8.0d
-			y: -1.0d
-			subtitle: "On redstone pulse, it will repeat that pulse after a configured amount of time."
-			dependencies: ["09C258CD619B2B88"]
-			id: "1BD6976E5D728365"
 			tasks: [{
 				id: "358F68E24488DCB1"
 				type: "item"
 				item: "create:pulse_repeater"
 			}]
+			id: "1BD6976E5D728365"
+			x: -8.0d
+			y: -1.0d
 			rewards: [{
 				id: "3081067E87375831"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "On redstone pulse, it will repeat that pulse after a configured amount of time."
+			dependencies: ["09C258CD619B2B88"]
 		}
 		{
-			x: -7.5d
-			y: 0.0d
-			subtitle: "On redstone pulse, it will emit redstone signal for a configured amount of time."
-			dependencies: ["09C258CD619B2B88"]
-			id: "1E7315E648C21711"
 			tasks: [{
 				id: "35A54224DCABD3AC"
 				type: "item"
 				item: "create:pulse_extender"
 			}]
+			id: "1E7315E648C21711"
+			x: -7.5d
+			y: 0.0d
 			rewards: [{
 				id: "7B29F68AC0DE591D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "On redstone pulse, it will emit redstone signal for a configured amount of time."
+			dependencies: ["09C258CD619B2B88"]
 		}
 		{
-			x: -10.5d
-			y: 6.5d
-			subtitle: "An important ingredient for very advanced Create Machines."
-			dependencies: ["6B39422421203401"]
-			id: "5CD46451E8E482DE"
 			tasks: [{
 				id: "09764CF678C50B77"
 				type: "item"
 				item: "create:precision_mechanism"
 			}]
+			id: "5CD46451E8E482DE"
+			x: -10.5d
+			y: 6.5d
 			rewards: [{
 				id: "2283120C65B8D359"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "An important ingredient for very advanced Create Machines."
+			dependencies: ["6B39422421203401"]
 		}
 		{
-			x: -12.5d
-			y: 0.5d
-			subtitle: "The Casing for fluid-related Create Machines."
-			dependencies: ["749FDD2830BBF0F2"]
-			id: "34B606914797FB12"
 			tasks: [{
 				id: "5090EE18445881B3"
 				type: "item"
 				item: "create:copper_casing"
 			}]
+			id: "34B606914797FB12"
+			x: -12.5d
+			y: 0.5d
 			rewards: [{
 				id: "3543F0223E9A896A"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The Casing for fluid-related Create Machines."
+			dependencies: ["749FDD2830BBF0F2"]
 		}
 		{
-			x: -13.0d
-			y: 1.5d
-			shape: "square"
-			subtitle: "An important ingredient for Fluid Transportation blocks."
-			dependencies: ["30CFBDB612551DE7"]
-			id: "749FDD2830BBF0F2"
 			tasks: [{
 				id: "0F236DC41CF28789"
 				type: "item"
 				item: "modern_industrialization:copper_plate"
 				count: 16L
 			}]
+			x: -13.0d
+			id: "749FDD2830BBF0F2"
+			y: 1.5d
+			shape: "square"
 			rewards: [{
 				id: "14E4AEA58D8DCBA2"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "An important ingredient for Fluid Transportation blocks."
+			dependencies: ["30CFBDB612551DE7"]
 		}
 		{
-			x: -10.5d
-			y: 5.5d
-			subtitle: "Sequenced Assembly makes it easier!"
-			description: ["Now you don't need to rely on Shroomlights anymore!"]
-			dependencies: ["6B39422421203401"]
-			id: "0E4D3F62160BA382"
 			tasks: [{
 				id: "7EAA95B108E610B9"
 				type: "item"
 				item: "create:electron_tube"
 			}]
+			description: ["Now you don't need to rely on Shroomlights anymore!"]
+			id: "0E4D3F62160BA382"
+			x: -10.5d
+			y: 5.5d
 			rewards: [{
 				id: "67821783DB6CAA34"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Sequenced Assembly makes it easier!"
+			dependencies: ["6B39422421203401"]
 		}
 		{
-			x: -11.5d
-			y: 1.5d
-			shape: "square"
-			subtitle: "An important ingredient for various Create Machines and the Steam Age."
-			dependencies: ["30CFBDB612551DE7"]
-			id: "626D5BD796C10F29"
 			tasks: [{
 				id: "59369D7015603FF7"
 				type: "item"
 				item: "modern_industrialization:iron_plate"
 				count: 16L
 			}]
+			x: -11.5d
+			id: "626D5BD796C10F29"
+			y: 1.5d
+			shape: "square"
 			rewards: [{
 				id: "08B79ACA4373885F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "An important ingredient for various Create Machines and the Steam Age."
+			dependencies: ["30CFBDB612551DE7"]
 		}
 		{
-			x: -14.0d
-			y: 4.5d
-			subtitle: "Copper + Zinc = Brass"
-			description: [
-				"But where to get Zinc?"
-				"Use at least a Iron Mesh to sieve some Crushed Andesite. This will give you the chance to get some crushed Zinc Ore."
-			]
-			dependencies: ["7C76819CB83F2D93"]
-			id: "4E76A136735F7D0D"
 			tasks: [{
 				id: "538357865119A8E7"
 				type: "item"
 				item: "techreborn:brass_ingot"
 				count: 16L
 			}]
+			description: [
+				"But where to get Zinc?"
+				"Use at least a Iron Mesh to sieve some Crushed Andesite. This will give you the chance to get some crushed Zinc Ore."
+			]
+			id: "4E76A136735F7D0D"
+			x: -14.0d
+			y: 4.5d
 			rewards: [{
 				id: "0569A87387CD7099"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Copper + Zinc = Brass"
+			dependencies: ["7C76819CB83F2D93"]
 		}
 		{
-			x: -5.0d
-			y: -1.0d
-			subtitle: "An NES Controller???"
+			tasks: [{
+				id: "4F69D9ECB8523058"
+				type: "item"
+				item: "create:linked_controller"
+			}]
 			description: [
 				"Shift-Right Click to open a GUI, in which you can setup six different frequencies to which Redstone Links can react."
 				""
 				"To use it, right-click with the Linked Controller in hand."
 				"Then, you can use movement keys to activate Redstone Links."
 			]
-			dependencies: [
-				"3F30A44F874A5161"
-				"09C258CD619B2B88"
-			]
 			id: "3911DC5F9D11D139"
-			tasks: [{
-				id: "4F69D9ECB8523058"
-				type: "item"
-				item: "create:linked_controller"
-			}]
+			x: -5.0d
+			y: -1.0d
 			rewards: [{
 				id: "7319326F13B9356D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "An NES Controller???"
+			dependencies: [
+				"3F30A44F874A5161"
+				"09C258CD619B2B88"
+			]
 		}
 		{
-			x: -14.0d
-			y: 6.0d
-			subtitle: "An important ingredient for advanced Create Machines."
-			dependencies: ["4E76A136735F7D0D"]
-			id: "3568FE880980DB5D"
 			tasks: [{
 				id: "4AD6B8F05AB1F0E3"
 				type: "item"
 				item: "techreborn:brass_plate"
 				count: 16L
 			}]
+			id: "3568FE880980DB5D"
+			x: -14.0d
+			y: 6.0d
 			rewards: [{
 				id: "6FAC72BCAF17AA69"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "An important ingredient for advanced Create Machines."
+			dependencies: ["4E76A136735F7D0D"]
 		}
 		{
-			x: -11.5d
-			y: 2.5d
-			shape: "rsquare"
-			subtitle: "I can see now!"
-			description: ["Wear it as a helmet or in the \"Face\" Trinket Slot to get precise readouts on your Create Machines!"]
-			dependencies: ["30CFBDB612551DE7"]
-			id: "3DC7E2ED2D626251"
 			tasks: [{
 				id: "13A3B7C2C9918981"
 				type: "item"
 				item: "create:goggles"
 			}]
+			description: ["Wear it as a helmet or in the \"Face\" Trinket Slot to get precise readouts on your Create Machines!"]
+			x: -11.5d
+			id: "3DC7E2ED2D626251"
+			y: 2.5d
+			shape: "rsquare"
 			rewards: [{
 				id: "3B72C4E58A7F23D5"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "I can see now!"
+			dependencies: ["30CFBDB612551DE7"]
 		}
 		{
-			title: "Super Heated"
-			x: -10.0d
-			y: -1.0d
-			subtitle: "Feed it to the Blaze Burner to make it Super-Heated!"
-			dependencies: ["5212BF6AA5940CA1"]
-			id: "1297718C59DC86E0"
 			tasks: [{
 				id: "1AC781E364C4A36D"
 				type: "item"
 				item: "create:blaze_cake"
 			}]
+			id: "1297718C59DC86E0"
+			x: -10.0d
+			y: -1.0d
+			title: "Super Heated"
 			rewards: [{
 				id: "0FA3F1B721DA034C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Feed it to the Blaze Burner to make it Super-Heated!"
+			dependencies: ["5212BF6AA5940CA1"]
 		}
 		{
-			x: -12.5d
-			y: 7.5d
-			subtitle: "Tracks for your trains!"
-			dependencies: ["6B39422421203401"]
-			id: "4EB081E5673A5787"
 			tasks: [{
 				id: "0BD48C4CDDF2CBD0"
 				type: "item"
 				item: "create:track"
 			}]
+			id: "4EB081E5673A5787"
+			x: -12.5d
+			y: 7.5d
 			rewards: [{
 				id: "3AF77354B3412C06"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Tracks for your trains!"
+			dependencies: ["6B39422421203401"]
 		}
 		{
-			x: -12.5d
-			y: 8.5d
-			subtitle: "A Casing for Train-related things."
-			dependencies: ["4EB081E5673A5787"]
-			id: "7A7255A547D710A2"
 			tasks: [{
 				id: "1349C35F81D75A28"
 				type: "item"
 				item: "create:railway_casing"
 			}]
+			id: "7A7255A547D710A2"
+			x: -12.5d
+			y: 8.5d
 			rewards: [{
 				id: "340212AEABD012E8"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A Casing for Train-related things."
+			dependencies: ["4EB081E5673A5787"]
 		}
 		{
-			x: -12.0d
-			y: 9.5d
-			subtitle: "A Station. Nessecary for assembling Trains and scheduled departures."
-			dependencies: ["7A7255A547D710A2"]
-			id: "66DBB273A2D2556A"
 			tasks: [{
 				id: "7E57AE00569B36BF"
 				type: "item"
 				item: "create:track_station"
 			}]
+			id: "66DBB273A2D2556A"
+			x: -12.0d
+			y: 9.5d
 			rewards: [{
 				id: "0EC124D903DB6CBC"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A Station. Nessecary for assembling Trains and scheduled departures."
+			dependencies: ["7A7255A547D710A2"]
 		}
 		{
-			x: -13.0d
-			y: 9.5d
-			subtitle: "When on a Carriage, you can Right-Click it to control a train."
-			description: [
-				"You can also add a conductor (a Blaze Burner or any mob seating in front of the Train Controls) to automate train departures."
-				""
-				"Automatically departed trains are ⁴/₃x faster than manually-controlled trains."
-			]
-			dependencies: ["7A7255A547D710A2"]
-			id: "191C01687DBD75A6"
 			tasks: [{
 				id: "71E7A0E92C88BAC1"
 				type: "item"
 				item: "create:controls"
 			}]
+			description: [
+				"You can also add a conductor (a Blaze Burner or any mob seating in front of the Train Controls) to automate train departures."
+				""
+				"Automatically departed trains are ⁴/₃x faster than manually-controlled trains."
+			]
+			id: "191C01687DBD75A6"
+			x: -13.0d
+			y: 9.5d
 			rewards: [{
 				id: "079C3B69D41B3B57"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "When on a Carriage, you can Right-Click it to control a train."
+			dependencies: ["7A7255A547D710A2"]
 		}
 		{
-			x: -22.0d
-			y: 4.5d
-			dependencies: ["4200194006454664"]
-			id: "472797892FBE6911"
 			tasks: [{
 				id: "645A8C6858AF261A"
 				type: "checkmark"
 				title: "Contraption Blocks"
 			}]
+			dependencies: ["4200194006454664"]
+			id: "472797892FBE6911"
+			y: 4.5d
+			x: -22.0d
 		}
 		{
-			title: "Linking Contraption Blocks together"
-			x: -23.5d
-			y: 4.5d
-			subtitle: "Consult the Ponder Scenes of those blocks/items for more info."
-			description: ["(Craft one of these to complete this Quest.)"]
-			dependencies: ["472797892FBE6911"]
-			min_required_tasks: 1
-			id: "66384691DD260C9B"
 			tasks: [
 				{
 					id: "44392B70E46B1BE3"
@@ -1547,26 +1540,22 @@
 					item: "create:sticker"
 				}
 			]
+			description: ["(Craft one of these to complete this Quest.)"]
+			id: "66384691DD260C9B"
+			x: -23.5d
+			y: 4.5d
+			title: "Linking Contraption Blocks together"
 			rewards: [{
 				id: "7E1D8D8D7F312DFF"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			title: "Contraption Anchors"
-			x: -22.0d
-			y: 6.0d
-			subtitle: "You can build contraptions using these blocks as a base."
-			description: [
-				"Consult their respective Ponder Scenes for more information."
-				""
-				"(Craft one of these to complete this Quest.)"
-			]
+			subtitle: "Consult the Ponder Scenes of those blocks/items for more info."
 			dependencies: ["472797892FBE6911"]
 			min_required_tasks: 1
-			id: "31E1C09A9BDE34E8"
+		}
+		{
 			tasks: [
 				{
 					id: "2ED40A9EED52EBEC"
@@ -1614,36 +1603,26 @@
 					item: "create:track_station"
 				}
 			]
+			description: [
+				"Consult their respective Ponder Scenes for more information."
+				""
+				"(Craft one of these to complete this Quest.)"
+			]
+			id: "31E1C09A9BDE34E8"
+			x: -22.0d
+			y: 6.0d
+			title: "Contraption Anchors"
 			rewards: [{
 				id: "0DEA803D6A23C86E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "You can build contraptions using these blocks as a base."
+			dependencies: ["472797892FBE6911"]
+			min_required_tasks: 1
 		}
 		{
-			title: "Contraption Actors"
-			x: -20.5d
-			y: 4.5d
-			subtitle: "Functional on active Contraptions."
-			description: [
-				"> Chutes, Funnels: Pick up or drop items."
-				"> Chests, Barrels, Shulker Boxes, Item Vaults - valid inventories for Contraptions."
-				"> Basin - when upside down, dumps its storage into Basins below."
-				"> Deployer - places/uses items from the Contraption's internal inventory."
-				"> Mechanical Drill, Saw, Plough, Harvester - Mines, cuts, tills, harvests various blocks. Breaking speed depends on the speed of the Contraption."
-				"> Dispensers and Droppers - dispenses automatically items depending on the speed of the Contraption, or every 1 second if the Contraption is stationary."
-				"> Mechanical Bearing - the Contraption placed on it will stay level no matter how the parent Contraption moves."
-				"> Fluid Tank (Create) - valid fluid storage for Contraptions."
-				"> Portable Item/Fluid Interface - The Contraption will stop for a while to transfer items between the Contraption and another Portable Interface."
-				"After the transfer is done, the Contraption starts moving again."
-				"> Redstone Contact - when contacts with the Redstone Contact outside of the Contraption, that Contact will emit a redstone signal."
-				"> Seats - you can sit on these on Contraptions."
-			]
-			dependencies: ["472797892FBE6911"]
-			min_width: 300
-			min_required_tasks: 1
-			id: "56247605846B8F5B"
 			tasks: [
 				{
 					id: "15C969A2182EA462"
@@ -1755,61 +1734,72 @@
 					}
 				}
 			]
+			description: [
+				"> Chutes, Funnels: Pick up or drop items."
+				"> Chests, Barrels, Shulker Boxes, Item Vaults - valid inventories for Contraptions."
+				"> Basin - when upside down, dumps its storage into Basins below."
+				"> Deployer - places/uses items from the Contraption's internal inventory."
+				"> Mechanical Drill, Saw, Plough, Harvester - Mines, cuts, tills, harvests various blocks. Breaking speed depends on the speed of the Contraption."
+				"> Dispensers and Droppers - dispenses automatically items depending on the speed of the Contraption, or every 1 second if the Contraption is stationary."
+				"> Mechanical Bearing - the Contraption placed on it will stay level no matter how the parent Contraption moves."
+				"> Fluid Tank (Create) - valid fluid storage for Contraptions."
+				"> Portable Item/Fluid Interface - The Contraption will stop for a while to transfer items between the Contraption and another Portable Interface."
+				"After the transfer is done, the Contraption starts moving again."
+				"> Redstone Contact - when contacts with the Redstone Contact outside of the Contraption, that Contact will emit a redstone signal."
+				"> Seats - you can sit on these on Contraptions."
+			]
 			rewards: [{
 				id: "4FD800F45C3AFE81"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			id: "56247605846B8F5B"
+			x: -20.5d
+			y: 4.5d
+			title: "Contraption Actors"
+			min_width: 300
+			subtitle: "Functional on active Contraptions."
+			dependencies: ["472797892FBE6911"]
+			min_required_tasks: 1
 		}
 		{
-			disable_toast: true
-			x: -22.0d
-			y: 1.5d
-			subtitle: "These blocks generate Stress Units (su). Stress Units are required to power Create's Machines."
-			dependencies: ["4200194006454664"]
-			id: "15C5FE720715D50F"
 			tasks: [{
 				id: "3AC98D2979AD6206"
 				type: "checkmark"
 				title: "Stress Generators"
 			}]
+			x: -22.0d
+			id: "15C5FE720715D50F"
+			disable_toast: true
+			y: 1.5d
+			subtitle: "These blocks generate Stress Units (su). Stress Units are required to power Create's Machines."
+			dependencies: ["4200194006454664"]
 		}
 		{
-			x: -23.5d
-			y: 1.5d
-			subtitle: "Water Power!"
-			description: [
-				"A Water Wheel can generate between 6 and 20 RPM (96-320 su), depending on how the water flows."
-				"It is most effective, when the water is flowing against the blades, on all 4 sides."
-				"If you plan to use them vertically, consider using Soul Sand for an upward stream of Water."
-			]
-			dependencies: ["15C5FE720715D50F"]
-			id: "483FA9CD5FE385ED"
 			tasks: [{
 				id: "16290740D20DDAA9"
 				type: "item"
 				item: "create:water_wheel"
 			}]
+			description: [
+				"A Water Wheel can generate between 6 and 20 RPM (96-320 su), depending on how the water flows."
+				"It is most effective, when the water is flowing against the blades, on all 4 sides."
+				"If you plan to use them vertically, consider using Soul Sand for an upward stream of Water."
+			]
+			id: "483FA9CD5FE385ED"
+			x: -23.5d
+			y: 1.5d
 			rewards: [{
 				id: "46F707D02B086EB7"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Water Power!"
+			dependencies: ["15C5FE720715D50F"]
 		}
 		{
-			title: "Manual Cranking"
-			x: -20.5d
-			y: 1.5d
-			subtitle: "Crank it up!"
-			description: [
-				"Hand Cranks generate 256 su at 32 RPM when spun manually. It uses hunger to do so."
-				"The Valves give out 128 su at 16 RPM, but they look stylish on Fluid Valves!"
-			]
-			dependencies: ["15C5FE720715D50F"]
-			min_required_tasks: 1
-			id: "23920EF54F04FC89"
 			tasks: [
 				{
 					id: "0CF7112C1709D0B1"
@@ -1831,36 +1821,25 @@
 					}
 				}
 			]
+			description: [
+				"Hand Cranks generate 256 su at 32 RPM when spun manually. It uses hunger to do so."
+				"The Valves give out 128 su at 16 RPM, but they look stylish on Fluid Valves!"
+			]
+			id: "23920EF54F04FC89"
+			x: -20.5d
+			y: 1.5d
+			title: "Manual Cranking"
 			rewards: [{
 				id: "114148C46D9C4A18"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Crank it up!"
+			dependencies: ["15C5FE720715D50F"]
+			min_required_tasks: 1
 		}
 		{
-			icon: "create:steam_engine"
-			x: -22.0d
-			y: 0.0d
-			subtitle: "Full Power!"
-			description: [
-				"Steam Engines must be built from at least 4 Fluid Tanks, 1 Heat Source and 1 Steam Boiler."
-				""
-				"It will generate Stress Units dependent on:"
-				"- Size of Fluid Tank,"
-				"- how fast you can pump Water into the Tank,"
-				"- Heat, whether its passive or powered by a Blaze Burner."
-				""
-				"Passively heated Boiler will always generate 2,048 su no matter how big the tank is or how much passive Heat Sources there are under the Tank."
-				""
-				"A Boiler heated by active Blaze Burners will generate 16,384 su per level."
-				""
-				"1 active Blaze Burner counts as 1 level towards heat. "
-				""
-				"If the Blaze Burner is Super-Heated, it counts as 2 levels towards heat."
-			]
-			dependencies: ["15C5FE720715D50F"]
-			id: "1A8F9F5DF74394D5"
 			tasks: [
 				{
 					id: "40F347300E427A24"
@@ -1909,39 +1888,48 @@
 					}
 				}
 			]
+			description: [
+				"Steam Engines must be built from at least 4 Fluid Tanks, 1 Heat Source and 1 Steam Boiler."
+				""
+				"It will generate Stress Units dependent on:"
+				"- Size of Fluid Tank,"
+				"- how fast you can pump Water into the Tank,"
+				"- Heat, whether its passive or powered by a Blaze Burner."
+				""
+				"Passively heated Boiler will always generate 2,048 su no matter how big the tank is or how much passive Heat Sources there are under the Tank."
+				""
+				"A Boiler heated by active Blaze Burners will generate 16,384 su per level."
+				""
+				"1 active Blaze Burner counts as 1 level towards heat. "
+				""
+				"If the Blaze Burner is Super-Heated, it counts as 2 levels towards heat."
+			]
+			icon: "create:steam_engine"
+			id: "1A8F9F5DF74394D5"
+			x: -22.0d
+			y: 0.0d
 			rewards: [{
 				id: "5845E3E73C51179F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Full Power!"
+			dependencies: ["15C5FE720715D50F"]
 		}
 		{
-			title: "Rotation Relayers"
-			disable_toast: true
-			x: -17.0d
-			y: 1.5d
-			dependencies: ["18E391B45D935712"]
-			id: "5715F503D92DEE95"
 			tasks: [{
 				id: "353D0CE4C3478865"
 				type: "checkmark"
 			}]
+			x: -17.0d
+			id: "5715F503D92DEE95"
+			disable_toast: true
+			y: 1.5d
+			title: "Rotation Relayers"
+			dependencies: ["18E391B45D935712"]
 		}
 		{
-			title: "Chain Drives"
-			x: -17.5d
-			y: 0.0d
-			subtitle: "- Better Flavor Text Here -"
-			description: [
-				"Consult their respective Ponder Scenes for more information."
-				""
-				"Bonus fact:"
-				"Adjustable Chain Gearshifts can just fine connect to regular Chain Drives."
-			]
-			dependencies: ["5715F503D92DEE95"]
-			min_required_tasks: 1
-			id: "7F5147ADA288F917"
 			tasks: [
 				{
 					id: "1C906663F8E19FBC"
@@ -1954,47 +1942,50 @@
 					item: "create:adjustable_chain_gearshift"
 				}
 			]
+			description: [
+				"Consult their respective Ponder Scenes for more information."
+				""
+				"Bonus fact:"
+				"Adjustable Chain Gearshifts can just fine connect to regular Chain Drives."
+			]
+			id: "7F5147ADA288F917"
+			x: -17.5d
+			y: 0.0d
+			title: "Chain Drives"
 			rewards: [{
 				id: "3DCA4BD43DC9DB4D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "- Better Flavor Text Here -"
+			dependencies: ["5715F503D92DEE95"]
+			min_required_tasks: 1
 		}
 		{
-			x: -17.0d
-			y: 3.0d
-			shape: "square"
-			subtitle: "The Casing for basic Create Machines."
-			description: [
-				"You can encase your Shafts, Cogwheels and Belts with this!"
-				"Encasing does not use up Casings."
-			]
-			dependencies: ["160951F6A70A85ED"]
-			id: "18E391B45D935712"
 			tasks: [{
 				id: "4C048F1AF0E8982A"
 				type: "item"
 				item: "create:andesite_casing"
 			}]
+			description: [
+				"You can encase your Shafts, Cogwheels and Belts with this!"
+				"Encasing does not use up Casings."
+			]
+			x: -17.0d
+			id: "18E391B45D935712"
+			y: 3.0d
+			shape: "square"
 			rewards: [{
 				id: "2D19293EA8629064"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The Casing for basic Create Machines."
+			dependencies: ["160951F6A70A85ED"]
 		}
 		{
-			x: -23.0d
-			y: 0.5d
-			subtitle: "Wind Power!"
-			description: [
-				"A Windmill Bearing can attach a Contraption containing Wool or Sails."
-				"8 Sail-like Blocks are required on the Contraption to start spinning."
-				"It rotates at 1 RPM (giving 512 su) per 8 Sail-like Blocks on the Contraption, and maxes out at 128 Sail-like blocks."
-			]
-			dependencies: ["15C5FE720715D50F"]
-			id: "37802EBEFD9CF876"
 			tasks: [
 				{
 					id: "54270B557FC5C5EF"
@@ -2030,63 +2021,59 @@
 					count: 8L
 				}
 			]
+			description: [
+				"A Windmill Bearing can attach a Contraption containing Wool or Sails."
+				"8 Sail-like Blocks are required on the Contraption to start spinning."
+				"It rotates at 1 RPM (giving 512 su) per 8 Sail-like Blocks on the Contraption, and maxes out at 128 Sail-like blocks."
+			]
+			id: "37802EBEFD9CF876"
+			x: -23.0d
+			y: 0.5d
 			rewards: [{
 				id: "7C61FF3BDE17059C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Wind Power!"
+			dependencies: ["15C5FE720715D50F"]
 		}
 		{
-			x: -18.5d
-			y: 5.0d
-			subtitle: "A Tunnel Bore."
-			description: [
-				"It automatically breaks blocks in front of it."
-				"The faster it spins, the faster it breaks blocks."
-			]
-			hide_dependency_lines: false
-			dependencies: ["18E391B45D935712"]
-			id: "341519818567FD32"
 			tasks: [{
 				id: "04B4419DE4674075"
 				type: "item"
 				item: "create:mechanical_drill"
 			}]
+			description: [
+				"It automatically breaks blocks in front of it."
+				"The faster it spins, the faster it breaks blocks."
+			]
+			id: "341519818567FD32"
+			x: -18.5d
+			y: 5.0d
 			rewards: [{
 				id: "5135E256435971D4"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A Tunnel Bore."
+			dependencies: ["18E391B45D935712"]
+			hide_dependency_lines: false
 		}
 		{
-			disable_toast: true
-			x: -21.0d
-			y: 7.5d
-			dependencies: ["725237684B3596F1"]
-			id: "28533D71EED27C29"
 			tasks: [{
 				id: "538727A1D7D5E1C1"
 				type: "checkmark"
 				title: "Item Transportation"
 			}]
+			dependencies: ["725237684B3596F1"]
+			id: "28533D71EED27C29"
+			y: 7.5d
+			disable_toast: true
+			x: -21.0d
 		}
 		{
-			title: "Item Filters"
-			x: -22.5d
-			y: 7.5d
-			description: [
-				"Filters can filter items based on their contents."
-				"They have an allow- and block-list options and NBT sensitivity option."
-				""
-				"Attribute Filters can filter items based on their properties!"
-				""
-				"The filters can be nested inside of each other, so don't worry about the lack of slots."
-			]
-			dependencies: ["28533D71EED27C29"]
-			min_required_tasks: 1
-			id: "0AF538D54BE1CFFA"
 			tasks: [
 				{
 					id: "208FD2A264FABE04"
@@ -2109,26 +2096,28 @@
 					}
 				}
 			]
+			description: [
+				"Filters can filter items based on their contents."
+				"They have an allow- and block-list options and NBT sensitivity option."
+				""
+				"Attribute Filters can filter items based on their properties!"
+				""
+				"The filters can be nested inside of each other, so don't worry about the lack of slots."
+			]
+			id: "0AF538D54BE1CFFA"
+			x: -22.5d
+			y: 7.5d
+			title: "Item Filters"
 			rewards: [{
 				id: "3B698C3C9BF546E6"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			title: "Chutes"
-			x: -19.5d
-			y: 7.5d
-			subtitle: "The Cooler Hopper."
-			description: [
-				"Regular Chutes can collect or transfer items from above, up to 16 items at the time."
-				""
-				"Smart Chutes have a configurable input rate, are filterable and can be blocked by redstone."
-			]
 			dependencies: ["28533D71EED27C29"]
 			min_required_tasks: 1
-			id: "1D45E3B9943DDC9A"
+		}
+		{
 			tasks: [
 				{
 					id: "4E8ED2122EBCE0AE"
@@ -2141,95 +2130,109 @@
 					item: "create:smart_chute"
 				}
 			]
+			description: [
+				"Regular Chutes can collect or transfer items from above, up to 16 items at the time."
+				""
+				"Smart Chutes have a configurable input rate, are filterable and can be blocked by redstone."
+			]
+			id: "1D45E3B9943DDC9A"
+			x: -19.5d
+			y: 7.5d
+			title: "Chutes"
 			rewards: [{
 				id: "1B566E461C61A2EC"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The Cooler Hopper."
+			dependencies: ["28533D71EED27C29"]
+			min_required_tasks: 1
 		}
 		{
-			x: -7.5d
-			y: 4.5d
-			subtitle: "The Casing for advanced Create Machines."
-			dependencies: ["4E76A136735F7D0D"]
-			id: "3E3F2A0D09B1C534"
 			tasks: [{
 				id: "1BC15AD70247FFEB"
 				type: "item"
 				item: "create:brass_casing"
 			}]
+			id: "3E3F2A0D09B1C534"
+			x: -7.5d
+			y: 4.5d
 			rewards: [{
 				id: "311A90837B6C4F2B"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The Casing for advanced Create Machines."
+			dependencies: ["4E76A136735F7D0D"]
 		}
 		{
-			x: -4.5d
-			y: 7.0d
-			subtitle: "It can store energy."
-			description: ["And it's quite a large accumulator - it can store 4.2M Energy!"]
-			dependencies: [
-				"71B164CE2086EBB0"
-				"12A116542970EECB"
-			]
-			id: "43224CE65782120C"
 			tasks: [{
 				id: "608FDE13BBD80D2E"
 				type: "item"
 				item: "createaddition:accumulator"
 			}]
+			description: ["And it's quite a large accumulator - it can store 4.2M Energy!"]
+			id: "43224CE65782120C"
+			x: -4.5d
+			y: 7.0d
 			rewards: [{
 				id: "2E3D9EE8F3507097"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "It can store energy."
+			dependencies: [
+				"71B164CE2086EBB0"
+				"12A116542970EECB"
+			]
 		}
 		{
-			icon: "minecraft:redstone"
-			disable_toast: true
-			x: -6.5d
-			y: -1.0d
-			dependencies: ["725237684B3596F1"]
-			id: "09C258CD619B2B88"
 			tasks: [{
 				id: "322AE9C596D8935D"
 				type: "checkmark"
 				title: "Redstone Utilities"
 			}]
+			icon: "minecraft:redstone"
+			disable_toast: true
+			id: "09C258CD619B2B88"
+			x: -6.5d
+			y: -1.0d
+			dependencies: ["725237684B3596F1"]
 		}
 		{
-			disable_toast: true
-			x: -6.5d
-			y: 3.5d
-			dependencies: ["725237684B3596F1"]
-			id: "4D59FB0ACC00C03E"
 			tasks: [{
 				id: "381405D90A57FB3D"
 				type: "checkmark"
 				title: "Other goodies"
 			}]
+			dependencies: ["725237684B3596F1"]
+			id: "4D59FB0ACC00C03E"
+			y: 3.5d
+			disable_toast: true
+			x: -6.5d
 		}
 		{
-			disable_toast: true
-			x: -2.5d
-			y: 6.0d
-			subtitle: "Craft a Steel Wiremill. Copper Spools require Copper Fine Wires, which are craftable there."
-			dependencies: ["43F43FB0B9ED0818"]
-			id: "64623A40FA9ED518"
 			tasks: [{
 				id: "022FAC5C08365D67"
 				type: "item"
 				item: "modern_industrialization:steel_wiremill"
 			}]
+			x: -2.5d
+			id: "64623A40FA9ED518"
+			disable_toast: true
+			y: 6.0d
+			subtitle: "Craft a Steel Wiremill. Copper Spools require Copper Fine Wires, which are craftable there."
+			dependencies: ["43F43FB0B9ED0818"]
 		}
 		{
-			x: -10.5d
-			y: 8.0d
-			subtitle: "Busy hand."
+			tasks: [{
+				id: "2C798A1FDDF3B4BB"
+				type: "item"
+				item: "create:mechanical_arm"
+			}]
 			description: [
 				"With the Mechanical Arm in hand, Right Click on your desired inputs and outputs to program the Mechanical Arm."
 				""
@@ -2237,24 +2240,24 @@
 				""
 				"Useful for automatic item filtering (with Brass Funnels), or to feed your Blaze Burners (Works with Lava Buckets!)."
 			]
-			dependencies: ["5CD46451E8E482DE"]
 			id: "3497F54E743F9B2E"
-			tasks: [{
-				id: "2C798A1FDDF3B4BB"
-				type: "item"
-				item: "create:mechanical_arm"
-			}]
+			x: -10.5d
+			y: 8.0d
 			rewards: [{
 				id: "70485344CDA06FEA"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Busy hand."
+			dependencies: ["5CD46451E8E482DE"]
 		}
 		{
-			x: -8.5d
-			y: 0.5d
-			subtitle: "*slurp*"
+			tasks: [{
+				id: "2FD848C7153EF50C"
+				type: "item"
+				item: "createaddition:straw"
+			}]
 			description: [
 				"Right-Click a Blaze Burner with the Straw in hand."
 				"It will then accept fluids as fuel:"
@@ -2262,62 +2265,59 @@
 				"> Bioethanol - 1 bucket lasts for 4 minutes,"
 				"> Lava - 1 bucket lasts for 16m 40s."
 			]
-			dependencies: ["5212BF6AA5940CA1"]
-			min_width: 250
 			id: "01F494CB9517D433"
-			tasks: [{
-				id: "2FD848C7153EF50C"
-				type: "item"
-				item: "createaddition:straw"
-			}]
+			x: -8.5d
+			y: 0.5d
 			rewards: [{
 				id: "3E3573F18C9A92DA"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			min_width: 250
+			subtitle: "*slurp*"
+			dependencies: ["5212BF6AA5940CA1"]
 		}
 		{
-			x: -14.0d
-			y: 7.5d
-			subtitle: "Crafted with primitive Nether Technology."
-			dependencies: [
-				"7C849186AE44FAE5"
-				"40A2DD1A3BC48568"
-			]
-			id: "22D1C5AA8F750CC1"
 			tasks: [{
 				id: "16D0474278311DB5"
 				type: "item"
 				item: "create:electron_tube"
 			}]
+			dependencies: [
+				"7C849186AE44FAE5"
+				"40A2DD1A3BC48568"
+			]
+			subtitle: "Crafted with primitive Nether Technology."
+			id: "22D1C5AA8F750CC1"
+			y: 7.5d
+			x: -14.0d
 		}
 		{
-			x: -15.5d
-			y: 7.5d
-			subtitle: "Mill your Shroomlights using a Millstone."
-			dependencies: [
-				"513640F0E05D9804"
-				"5CB1E23795D87A85"
-			]
-			id: "7C849186AE44FAE5"
 			tasks: [{
 				id: "6DA3A2BC79E2403D"
 				type: "item"
 				item: "techreborn:glowstone_small_dust"
 			}]
+			dependencies: [
+				"513640F0E05D9804"
+				"5CB1E23795D87A85"
+			]
+			subtitle: "Mill your Shroomlights using a Millstone."
+			id: "7C849186AE44FAE5"
+			y: 7.5d
+			x: -15.5d
 		}
 		{
-			x: -14.0d
-			y: 9.0d
-			subtitle: "Polish some Rose Quartz using a Sand Paper."
-			id: "40A2DD1A3BC48568"
 			tasks: [{
 				id: "2E0E9A08B6A20D0F"
 				type: "item"
 				item: "create:polished_rose_quartz"
 			}]
+			subtitle: "Polish some Rose Quartz using a Sand Paper."
+			id: "40A2DD1A3BC48568"
+			y: 9.0d
+			x: -14.0d
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/modern_industrialization.snbt
+++ b/config/ftbquests/quests/chapters/modern_industrialization.snbt
@@ -1,19 +1,16 @@
 {
-	id: "5BB4D2FC1908D3D1"
-	group: "38633DD49534BFCD"
-	order_index: 2
-	filename: "modern_industrialization"
-	title: "Steam Age"
-	icon: "modern_industrialization:steam_blast_furnace"
-	default_quest_shape: "rsquare"
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "38633DD49534BFCD"
+	id: "5BB4D2FC1908D3D1"
+	filename: "modern_industrialization"
+	default_quest_shape: "rsquare"
+	icon: "modern_industrialization:steam_blast_furnace"
+	title: "Steam Age"
+	order_index: 2
 	quests: [
 		{
-			title: "Modern Industrialization"
-			icon: "modern_industrialization:guidebook"
-			x: -13.5d
-			y: -1.5d
-			subtitle: "Technology for Newbies!"
+			size: 1.25d
 			description: [
 				"Modern Industrialization offers:"
 				""
@@ -34,25 +31,30 @@
 				""
 				"TIP: Hold the book in your main hand while hovering over a machine/multiblock for more info."
 			]
-			dependencies: ["6B39422421203401"]
-			size: 1.25d
 			id: "6F6196A606D3A8EF"
-			tasks: [{
-				id: "3E45F701C61708E1"
-				type: "checkmark"
-			}]
+			icon: "modern_industrialization:guidebook"
+			x: -13.5d
+			y: -1.5d
+			title: "Modern Industrialization"
 			rewards: [{
 				id: "3CC4D443B33915F5"
 				type: "item"
 				item: "modern_industrialization:guidebook"
 			}]
+			subtitle: "Technology for Newbies!"
+			dependencies: ["6B39422421203401"]
+			tasks: [{
+				id: "3E45F701C61708E1"
+				type: "checkmark"
+			}]
 		}
 		{
-			title: "Your first bronze!"
-			icon: "modern_industrialization:bronze_ingot"
-			x: -12.0d
-			y: -1.5d
-			subtitle: "Welcome to the Steam Age!"
+			tasks: [{
+				id: "393032946BC049BC"
+				type: "item"
+				item: "modern_industrialization:bronze_ingot"
+				count: 32L
+			}]
 			description: [
 				"First, you need to make Bronze Ingots in either a Heated Create Mixer (more efficient) or in the Alloy Forge (less efficient)."
 				""
@@ -66,49 +68,50 @@
 				""
 				"You can also reduce the maximum number of items in a slot by scrolling."
 			]
-			dependencies: [
-				"7C76819CB83F2D93"
-				"6F6196A606D3A8EF"
-			]
 			id: "4661838E492BDE53"
-			tasks: [{
-				id: "393032946BC049BC"
-				type: "item"
-				item: "modern_industrialization:bronze_ingot"
-				count: 32L
-			}]
+			icon: "modern_industrialization:bronze_ingot"
+			x: -12.0d
+			y: -1.5d
+			title: "Your first bronze!"
 			rewards: [{
 				id: "3E441C535BFEFCAD"
 				type: "item"
 				item: "modern_industrialization:bucket_steam"
 			}]
+			subtitle: "Welcome to the Steam Age!"
+			dependencies: [
+				"7C76819CB83F2D93"
+				"6F6196A606D3A8EF"
+			]
 		}
 		{
-			x: -9.5d
-			y: 0.5d
-			subtitle: "This is probably the first machine you will want to build!"
-			description: [
-				"The Compressor will turn ingots into plates at 1:1 ratio."
-				""
-				"It can also turn each double ingot into 2 plates."
-			]
-			dependencies: ["4661838E492BDE53"]
-			id: "7F96B49412F52611"
 			tasks: [{
 				id: "3F8C83D99FC1C002"
 				type: "item"
 				item: "modern_industrialization:bronze_compressor"
 			}]
+			description: [
+				"The Compressor will turn ingots into plates at 1:1 ratio."
+				""
+				"It can also turn each double ingot into 2 plates."
+			]
+			id: "7F96B49412F52611"
+			x: -9.5d
+			y: 0.5d
 			rewards: [{
 				id: "5C3930FAAC5AFBB7"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "This is probably the first machine you will want to build!"
+			dependencies: ["4661838E492BDE53"]
 		}
 		{
-			x: -9.5d
-			y: -0.5d
-			subtitle: "Oh, That's Hot!"
+			tasks: [{
+				id: "047BE723A63F9E5F"
+				type: "item"
+				item: "modern_industrialization:bronze_boiler"
+			}]
 			description: [
 				"Steam machines need steam to function, and that's exactly what the boiler provides. It will slowly use fuel to heat up. When it's hot enough, it will start to produce steam. Don't forget to feed it with water or your fuel will burn for nothing."
 				""
@@ -120,34 +123,18 @@
 				""
 				"Bronze machines can only process recipes up to 2 EU/t, meaning that the recipe will use 2 Energy Units per Tick. As 1 mB of steam = 1 EU, a boiler at max temperature can power 4 machines simultaneously!"
 			]
-			dependencies: ["4661838E492BDE53"]
 			id: "0BAB52BE15CE157F"
-			tasks: [{
-				id: "047BE723A63F9E5F"
-				type: "item"
-				item: "modern_industrialization:bronze_boiler"
-			}]
+			x: -9.5d
+			y: -0.5d
 			rewards: [{
 				id: "6D8ABEBC370E900C"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Oh, That's Hot!"
+			dependencies: ["4661838E492BDE53"]
 		}
 		{
-			title: "Steam Blast Furnace"
-			icon: "modern_industrialization:steam_blast_furnace"
-			x: -5.5d
-			y: -1.5d
-			subtitle: "One doesn't seem enough"
-			description: [
-				"The Blast Furnace's structure is the same as the Coke Oven's, with Bricks replaced by Fire Clay Bricks and one extra hollow layer on top."
-				""
-				"Now, you will need a Steam Blast Furnace to turn that into steel."
-				""
-				"Craft the controller, 29 Fire Clay Bricks and the same three hatches as the Coke Oven."
-			]
-			dependencies: ["748D2241F66FF644"]
-			id: "586CB8FEAA0A50C6"
 			tasks: [
 				{
 					id: "34C10A32EE244F3F"
@@ -176,65 +163,68 @@
 					item: "modern_industrialization:bronze_item_output_hatch"
 				}
 			]
+			description: [
+				"The Blast Furnace's structure is the same as the Coke Oven's, with Bricks replaced by Fire Clay Bricks and one extra hollow layer on top."
+				""
+				"Now, you will need a Steam Blast Furnace to turn that into steel."
+				""
+				"Craft the controller, 29 Fire Clay Bricks and the same three hatches as the Coke Oven."
+			]
+			id: "586CB8FEAA0A50C6"
+			icon: "modern_industrialization:steam_blast_furnace"
+			x: -5.5d
+			y: -1.5d
+			title: "Steam Blast Furnace"
 			rewards: [{
 				id: "28716AEA84F1837D"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "One doesn't seem enough"
+			dependencies: ["748D2241F66FF644"]
 		}
 		{
-			x: -9.5d
-			y: 1.5d
-			subtitle: "Ore hemiquadrupling for the win!"
+			tasks: [{
+				id: "7799145BACA36D6A"
+				type: "item"
+				item: "modern_industrialization:bronze_macerator"
+			}]
 			description: [
 				"The Macerator will turn 1 ore into 3 crushed dusts/raw ores, which can be later processed into 4.5 dusts at average."
 				"Make sure to not grind your precious gem ores!"
 				""
 				"It can also recycle all kinds of materials by turning them into dust."
 			]
-			dependencies: ["4661838E492BDE53"]
 			id: "5A27B361EF71A4DF"
-			tasks: [{
-				id: "7799145BACA36D6A"
-				type: "item"
-				item: "modern_industrialization:bronze_macerator"
-			}]
+			x: -9.5d
+			y: 1.5d
 			rewards: [{
 				id: "3F303241ADEBDFBC"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Ore hemiquadrupling for the win!"
+			dependencies: ["4661838E492BDE53"]
 		}
 		{
-			x: -9.5d
-			y: -3.5d
-			subtitle: "The Mixer will help you mix dusts for a cheaper price."
-			dependencies: ["4661838E492BDE53"]
-			dependency_requirement: "one_started"
-			id: "4575644C7E5F2DEE"
 			tasks: [{
 				id: "1CCFC1ADFBB4F858"
 				type: "item"
 				item: "modern_industrialization:bronze_mixer"
 			}]
+			id: "4575644C7E5F2DEE"
+			x: -9.5d
+			y: -3.5d
 			rewards: [{
 				id: "3BF5F814E7572F46"
 				type: "item"
 				item: "farmersdelight:mixed_salad"
 			}]
+			subtitle: "The Mixer will help you mix dusts for a cheaper price."
+			dependencies: ["4661838E492BDE53"]
+			dependency_requirement: "one_started"
 		}
 		{
-			icon: "modern_industrialization:bronze_cutting_machine"
-			x: -9.5d
-			y: -4.5d
-			subtitle: "Better cutting ratios!"
-			description: [
-				"The Cutting Machine will give you better ratios for bolts, gears, rings and rods."
-				""
-				"It uses a little bit of lubricant every time."
-			]
-			dependencies: ["4661838E492BDE53"]
-			id: "68E8311AC3140A56"
 			tasks: [
 				{
 					id: "05C1EB3A2AEB99EF"
@@ -248,17 +238,30 @@
 					item: "modern_industrialization:bucket_lubricant"
 				}
 			]
+			description: [
+				"The Cutting Machine will give you better ratios for bolts, gears, rings and rods."
+				""
+				"It uses a little bit of lubricant every time."
+			]
+			icon: "modern_industrialization:bronze_cutting_machine"
+			id: "68E8311AC3140A56"
+			x: -9.5d
+			y: -4.5d
 			rewards: [{
 				id: "5F81597D83BEA432"
 				type: "item"
 				item: "modern_industrialization:bucket_lubricant"
 			}]
+			subtitle: "Better cutting ratios!"
+			dependencies: ["4661838E492BDE53"]
 		}
 		{
-			title: "Fire Clay"
-			x: -9.5d
-			y: -2.5d
-			subtitle: "Dust into bricks!"
+			tasks: [{
+				id: "5FB4F9E06ED83BA2"
+				type: "item"
+				item: "modern_industrialization:fire_clay_brick"
+				count: 12L
+			}]
 			description: [
 				"To make fire clay bricks, you will need to cook fire clay dusts and in order to craft these, you will need brick dusts."
 				""
@@ -266,63 +269,38 @@
 				""
 				"The process efficiency can be improved in steam machines."
 			]
-			dependencies: ["4661838E492BDE53"]
 			id: "39FADF9C0442304F"
-			tasks: [{
-				id: "5FB4F9E06ED83BA2"
-				type: "item"
-				item: "modern_industrialization:fire_clay_brick"
-				count: 12L
-			}]
+			x: -9.5d
+			y: -2.5d
+			title: "Fire Clay"
 			rewards: [{
 				id: "12FF8CCB7F2657F8"
 				type: "item"
 				item: "minecraft:clay_ball"
 				count: 16
 			}]
+			subtitle: "Dust into bricks!"
+			dependencies: ["4661838E492BDE53"]
 		}
 		{
-			x: -8.0d
-			y: -2.5d
-			subtitle: "The Furnace is... well... a Furnace."
-			description: ["It is as slow as normal Furnaces, but it uses 20 times less fuel because steam is very efficient."]
-			dependencies: ["39FADF9C0442304F"]
-			id: "4AD93229344EA0BE"
 			tasks: [{
 				id: "747A0D40FA945748"
 				type: "item"
 				item: "modern_industrialization:bronze_furnace"
 			}]
+			description: ["It is as slow as normal Furnaces, but it uses 20 times less fuel because steam is very efficient."]
+			id: "4AD93229344EA0BE"
+			x: -8.0d
+			y: -2.5d
 			rewards: [{
 				id: "17AC3EF54F4E9B84"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The Furnace is... well... a Furnace."
+			dependencies: ["39FADF9C0442304F"]
 		}
 		{
-			icon: "modern_industrialization:coke_oven"
-			x: -9.5d
-			y: -1.5d
-			subtitle: "Coke-A Cola -Technici4n"
-			description: [
-				"The Coke Oven block here has the role of a Controller."
-				""
-				"Every multiblock is managed by a controller, but you usually cannot interact with the controller directly: all input and output goes through hatches."
-				""
-				"We need a fluid input because the coke oven is powered by steam, we need an item input for the coal and an output for the coke."
-				""
-				"If we forget one of the hatches, the coke oven will not be able to start!"
-				""
-				"Hold a Wrench to see the missing blocks and the errors!"
-				""
-				"You can also hold a Hatch to know where it can go."
-				""
-				"Once the Coke Oven says Shape Valid, fill the fluid input hatch with steam, put coal in the item input hatch and you're good to go!"
-				""
-				"Coke will be very useful for steel, but it is also a powerful fuel."
-			]
-			dependencies: ["4661838E492BDE53"]
-			id: "36ECD7C06649DE78"
 			tasks: [
 				{
 					id: "217D2448551C324A"
@@ -356,26 +334,37 @@
 					item: "modern_industrialization:bronze_fluid_output_hatch"
 				}
 			]
+			description: [
+				"The Coke Oven block here has the role of a Controller."
+				""
+				"Every multiblock is managed by a controller, but you usually cannot interact with the controller directly: all input and output goes through hatches."
+				""
+				"We need a fluid input because the coke oven is powered by steam, we need an item input for the coal and an output for the coke."
+				""
+				"If we forget one of the hatches, the coke oven will not be able to start!"
+				""
+				"Hold a Wrench to see the missing blocks and the errors!"
+				""
+				"You can also hold a Hatch to know where it can go."
+				""
+				"Once the Coke Oven says Shape Valid, fill the fluid input hatch with steam, put coal in the item input hatch and you're good to go!"
+				""
+				"Coke will be very useful for steel, but it is also a powerful fuel."
+			]
+			icon: "modern_industrialization:coke_oven"
+			id: "36ECD7C06649DE78"
+			x: -9.5d
+			y: -1.5d
 			rewards: [{
 				id: "7B545F9C9DFD9A38"
 				type: "item"
 				item: "minecraft:coal"
 				count: 32
 			}]
+			subtitle: "Coke-A Cola -Technici4n"
+			dependencies: ["4661838E492BDE53"]
 		}
 		{
-			x: -8.0d
-			y: -1.5d
-			subtitle: "Coke it Up!"
-			description: [
-				"Once you have had enough of the bronze machines, you can start working toward making steel."
-				""
-				"The ultimate goal is to be able to build the quarry, a multiblock that will dig ores for you!"
-				""
-				"The first step is to make coke, by heating coal without oxygen."
-			]
-			dependencies: ["36ECD7C06649DE78"]
-			id: "748D2241F66FF644"
 			tasks: [
 				{
 					id: "4F5F070D435F875B"
@@ -388,16 +377,30 @@
 					item: "modern_industrialization:coke_dust"
 				}
 			]
+			description: [
+				"Once you have had enough of the bronze machines, you can start working toward making steel."
+				""
+				"The ultimate goal is to be able to build the quarry, a multiblock that will dig ores for you!"
+				""
+				"The first step is to make coke, by heating coal without oxygen."
+			]
+			id: "748D2241F66FF644"
+			x: -8.0d
+			y: -1.5d
 			rewards: [{
 				id: "5D4B74FC7E1B82E1"
 				type: "item"
 				item: "modern_industrialization:coke_block"
 			}]
+			subtitle: "Coke it Up!"
+			dependencies: ["36ECD7C06649DE78"]
 		}
 		{
-			x: -8.0d
-			y: 0.5d
-			subtitle: "Your personal bucketer!"
+			tasks: [{
+				id: "510DB26BFE950469"
+				type: "item"
+				item: "modern_industrialization:bronze_water_pump"
+			}]
 			description: [
 				"You may have been wondering if perhaps there was a way to insert water into the boiler automatically? There is!"
 				""
@@ -409,23 +412,24 @@
 				""
 				"The Bronze Water Pump will produce 1/8th of a bucket of water for every adjacent water source every 5 seconds, for a max output of 1 bucket / 5 seconds."
 			]
-			dependencies: ["0BAB52BE15CE157F"]
 			id: "0DD703B94D202B68"
-			tasks: [{
-				id: "510DB26BFE950469"
-				type: "item"
-				item: "modern_industrialization:bronze_water_pump"
-			}]
+			x: -8.0d
+			y: 0.5d
 			rewards: [{
 				id: "2AEDBF6DC1F8F0AA"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Your personal bucketer!"
+			dependencies: ["0BAB52BE15CE157F"]
 		}
 		{
-			title: "Fluid Transportation"
-			x: -12.0d
-			y: 0.0d
+			tasks: [{
+				id: "2E9298C2FC478FF5"
+				type: "item"
+				item: "modern_industrialization:fluid_pipe"
+				count: 16L
+			}]
 			description: [
 				"Fluid pipes can only contain one type of fluid, and by default they won't connect to empty pipes or blocks."
 				""
@@ -439,26 +443,24 @@
 				""
 				"> Right-clicking a pipe with a wrench will change the connection type, shift-right-clicking will drop the pipe."
 			]
-			dependencies: ["4661838E492BDE53"]
 			id: "75608EDF99965533"
-			tasks: [{
-				id: "2E9298C2FC478FF5"
-				type: "item"
-				item: "modern_industrialization:fluid_pipe"
-				count: 16L
-			}]
+			x: -12.0d
+			y: 0.0d
+			title: "Fluid Transportation"
 			rewards: [{
 				id: "1E311CE091051941"
 				type: "item"
 				item: "minecraft:red_dye"
 				count: 8
 			}]
+			dependencies: ["4661838E492BDE53"]
 		}
 		{
-			title: "Your First Steel"
-			x: -4.0d
-			y: -1.5d
-			subtitle: "The finest steel has to go through the hottest fire."
+			tasks: [{
+				id: "3612549FFBF5E73C"
+				type: "item"
+				item: "modern_industrialization:steel_ingot"
+			}]
 			description: [
 				"You can macerate coke to obtain Coke Dust, which you can combine with iron to get Uncooked Steel Dust."
 				""
@@ -468,72 +470,58 @@
 				""
 				"Steel machines can process recipes up to 4 EU/t, and they will process recipes at twice the speed as long as the energy usage doesn't go above 4 EU/t. Basically, they are twice as fast as bronze machines and they may also unlock new recipes."
 			]
-			dependencies: ["586CB8FEAA0A50C6"]
 			id: "7C5C1CA5A7954896"
-			tasks: [{
-				id: "3612549FFBF5E73C"
-				type: "item"
-				item: "modern_industrialization:steel_ingot"
-			}]
+			x: -4.0d
+			y: -1.5d
+			title: "Your First Steel"
 			rewards: [{
 				id: "36A1D42CD94293F6"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "The finest steel has to go through the hottest fire."
+			dependencies: ["586CB8FEAA0A50C6"]
 		}
 		{
-			title: "Lignite coal"
-			x: -13.5d
-			y: -3.0d
-			subtitle: "It's brown coal. Great source of Sulfur."
-			dependencies: ["6F6196A606D3A8EF"]
-			id: "0D10B5E838DF9196"
 			tasks: [{
 				id: "5B8A314E5014ADA6"
 				type: "item"
 				item: "modern_industrialization:lignite_coal"
 				count: 64L
 			}]
+			id: "0D10B5E838DF9196"
+			x: -13.5d
+			y: -3.0d
+			title: "Lignite coal"
 			rewards: [{
 				id: "468AFB6AC11BDA99"
 				type: "item"
 				item: "modern_industrialization:lignite_coal_block"
 				count: 8
 			}]
+			subtitle: "It's brown coal. Great source of Sulfur."
+			dependencies: ["6F6196A606D3A8EF"]
 		}
 		{
-			title: "Faster machines?"
-			x: -3.5d
-			y: 0.5d
-			subtitle: "To upgrade a bronze machine, craft a Steel Upgrade and apply it in a Smithing Table."
-			dependencies: ["7C5C1CA5A7954896"]
-			id: "6F4AE13DA520109C"
 			tasks: [{
 				id: "763B45889C554D7E"
 				type: "item"
 				item: "modern_industrialization:steel_upgrade"
 				count: 2L
 			}]
+			id: "6F4AE13DA520109C"
+			x: -3.5d
+			y: 0.5d
+			title: "Faster machines?"
 			rewards: [{
 				id: "1055A70750FD98ED"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "To upgrade a bronze machine, craft a Steel Upgrade and apply it in a Smithing Table."
+			dependencies: ["7C5C1CA5A7954896"]
 		}
 		{
-			title: "Infinite resources?"
-			icon: "modern_industrialization:steam_quarry"
-			x: -4.0d
-			y: -3.5d
-			subtitle: "So what does it do?"
-			description: [
-				"The Steam Quarry is a steam multiblock machine that consumes bronze drills, uses them to dig deeper than the bedrock and gives you back some ores, as you can see in REI."
-				""
-				"It's recommended that you have multiple SBFs running before you attempt to build it because it requires a lot of steel."
-				""
-			]
-			dependencies: ["7C5C1CA5A7954896"]
-			id: "26E587E34810A8FE"
 			tasks: [
 				{
 					id: "0B829B6C4987D67B"
@@ -559,35 +547,50 @@
 					count: 4L
 				}
 			]
+			description: [
+				"The Steam Quarry is a steam multiblock machine that consumes bronze drills, uses them to dig deeper than the bedrock and gives you back some ores, as you can see in REI."
+				""
+				"It's recommended that you have multiple SBFs running before you attempt to build it because it requires a lot of steel."
+				""
+			]
+			id: "26E587E34810A8FE"
+			icon: "modern_industrialization:steam_quarry"
+			x: -4.0d
+			y: -3.5d
+			title: "Infinite resources?"
 			rewards: [{
 				id: "388CF8B7A5818995"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "So what does it do?"
+			dependencies: ["7C5C1CA5A7954896"]
 		}
 		{
-			title: "Bronze Drill"
-			x: -3.5d
-			y: -6.5d
-			subtitle: "Used in the quarry. Check REI for outputs."
-			dependencies: ["2050D2FF42E29F6D"]
-			id: "74A278B57EF76B3B"
 			tasks: [{
 				id: "624F6E6D7A45923D"
 				type: "item"
 				item: "modern_industrialization:bronze_drill"
 				count: 4L
 			}]
+			id: "74A278B57EF76B3B"
+			x: -3.5d
+			y: -6.5d
+			title: "Bronze Drill"
 			rewards: [{
 				id: "15C461D9898E5B96"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Used in the quarry. Check REI for outputs."
+			dependencies: ["2050D2FF42E29F6D"]
 		}
 		{
-			x: -2.5d
-			y: -1.5d
-			subtitle: "It... Makes wires?"
+			tasks: [{
+				id: "32FF28A50A8B3DD5"
+				type: "item"
+				item: "modern_industrialization:steel_wiremill"
+			}]
 			description: [
 				"Mix Coke Dust with Water in a mixer and you will get Raw Synthetic Oil, which you can burn in a Steam Blast Furnace to get Synthetic Oil."
 				""
@@ -597,41 +600,42 @@
 				""
 				"For the wires, you will need the Wiremill! Combine these wires with rubber sheets to get cables!"
 			]
-			dependencies: ["7C5C1CA5A7954896"]
 			id: "43F43FB0B9ED0818"
-			tasks: [{
-				id: "32FF28A50A8B3DD5"
-				type: "item"
-				item: "modern_industrialization:steel_wiremill"
-			}]
+			x: -2.5d
+			y: -1.5d
 			rewards: [{
 				id: "1E9D18D104CA30EC"
 				type: "item"
 				item: "modern_industrialization:steel_plate"
 				count: 4
 			}]
+			subtitle: "It... Makes wires?"
+			dependencies: ["7C5C1CA5A7954896"]
 		}
 		{
-			x: -4.5d
-			y: -6.5d
-			subtitle: "Used in the quarry. Check REI for outputs."
-			dependencies: ["2050D2FF42E29F6D"]
-			id: "2F5A88568154E986"
 			tasks: [{
 				id: "4CB128CC2F0687DD"
 				type: "item"
 				item: "modern_industrialization:copper_drill"
 			}]
+			id: "2F5A88568154E986"
+			x: -4.5d
+			y: -6.5d
 			rewards: [{
 				id: "78C277549C6DE7D9"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Used in the quarry. Check REI for outputs."
+			dependencies: ["2050D2FF42E29F6D"]
 		}
 		{
-			title: "Item Transportation"
-			x: -4.5d
-			y: 0.5d
+			tasks: [{
+				id: "52537690D3281DBF"
+				type: "item"
+				item: "modern_industrialization:item_pipe"
+				count: 16L
+			}]
 			description: [
 				"Item pipes will not connect to inventories by default, but again you can force a connection."
 				""
@@ -643,25 +647,24 @@
 				""
 				"They can be upgraded later on with motors."
 			]
-			dependencies: ["7C5C1CA5A7954896"]
 			id: "38F9192F665742BA"
-			tasks: [{
-				id: "52537690D3281DBF"
-				type: "item"
-				item: "modern_industrialization:item_pipe"
-				count: 16L
-			}]
+			x: -4.5d
+			y: 0.5d
+			title: "Item Transportation"
 			rewards: [{
 				id: "0B0E01C14DDDB67F"
 				type: "item"
 				item: "minecraft:blue_dye"
 				count: 8
 			}]
+			dependencies: ["7C5C1CA5A7954896"]
 		}
 		{
-			x: -12.0d
-			y: -3.0d
-			subtitle: "Is this GregTech?"
+			tasks: [{
+				id: "68063DD59C50E1A7"
+				type: "item"
+				item: "modern_industrialization:wrench"
+			}]
 			description: [
 				"Using a wrench, you can rotate any machine by right-clicking."
 				""
@@ -670,32 +673,18 @@
 				"And no, this isn't GregTech, so don't try to break your machines using wrenches, because they will not drop. Use a pickaxe for that!"
 				"Also, machines won't explode."
 			]
-			dependencies: ["4661838E492BDE53"]
 			id: "2DB9C3C383C91BC0"
-			tasks: [{
-				id: "68063DD59C50E1A7"
-				type: "item"
-				item: "modern_industrialization:wrench"
-			}]
+			x: -12.0d
+			y: -3.0d
 			rewards: [{
 				id: "5D84F5B463C03DB4"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Is this GregTech?"
+			dependencies: ["4661838E492BDE53"]
 		}
 		{
-			x: -4.0d
-			y: -5.0d
-			subtitle: "Hatchback!"
-			description: [
-				"Steel hatches have more capacity than bronze hatches, and a multiblock with at least one steel hatch will be upgraded to steel tier."
-				""
-				"This means that it will go twice as fast if its energy usage wouldn't exceed 4 EU/t."
-				""
-				"A steel boiler will produce twice as much steam as a bronze one, that means up to 16 EU/t, and a steel water pump will produce twice as much water as its bronze counterpart, so up to 2 buckets / 5 seconds."
-			]
-			dependencies: ["26E587E34810A8FE"]
-			id: "2050D2FF42E29F6D"
 			tasks: [
 				{
 					id: "7A4F57CDD12A6800"
@@ -713,6 +702,16 @@
 					item: "modern_industrialization:steel_item_output_hatch"
 				}
 			]
+			description: [
+				"Steel hatches have more capacity than bronze hatches, and a multiblock with at least one steel hatch will be upgraded to steel tier."
+				""
+				"This means that it will go twice as fast if its energy usage wouldn't exceed 4 EU/t."
+				""
+				"A steel boiler will produce twice as much steam as a bronze one, that means up to 16 EU/t, and a steel water pump will produce twice as much water as its bronze counterpart, so up to 2 buckets / 5 seconds."
+			]
+			id: "2050D2FF42E29F6D"
+			x: -4.0d
+			y: -5.0d
 			rewards: [
 				{
 					id: "54AF33022467EEBE"
@@ -725,85 +724,87 @@
 					table_id: 13756307348121783L
 				}
 			]
+			subtitle: "Hatchback!"
+			dependencies: ["26E587E34810A8FE"]
 		}
 		{
-			x: -3.0d
-			y: -3.5d
-			subtitle: "A new machine only available in steel, can perform simple crafts for you."
-			description: ["You can now automate double ingots and pipes, for example! Again, check REI."]
-			dependencies: ["7C5C1CA5A7954896"]
-			id: "324B15844FC6C305"
 			tasks: [{
 				id: "52306C6F2E77D371"
 				type: "item"
 				item: "modern_industrialization:steel_packer"
 			}]
+			description: ["You can now automate double ingots and pipes, for example! Again, check REI."]
+			id: "324B15844FC6C305"
+			x: -3.0d
+			y: -3.5d
 			rewards: [{
 				id: "64ABA029EB796AD1"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A new machine only available in steel, can perform simple crafts for you."
+			dependencies: ["7C5C1CA5A7954896"]
 		}
 		{
-			x: -5.0d
-			y: -3.5d
-			subtitle: "A new machine only available in steel... Guess what it does."
-			dependencies: ["7C5C1CA5A7954896"]
-			id: "2D320F78629CC719"
 			tasks: [{
 				id: "58691A4447512CEE"
 				type: "item"
 				item: "modern_industrialization:steel_unpacker"
 			}]
+			id: "2D320F78629CC719"
+			x: -5.0d
+			y: -3.5d
 			rewards: [{
 				id: "2ABA2304997809DD"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A new machine only available in steel... Guess what it does."
+			dependencies: ["7C5C1CA5A7954896"]
 		}
 		{
-			title: "Copper Spools craftable!"
+			tasks: [{
+				type: "item"
+				id: "65CF2A9E8F2B113C"
+				item: "modern_industrialization:steel_wiremill"
+				icon: "createaddition:copper_spool"
+				title: "Copper Spool Unlocked"
+			}]
 			icon: "createaddition:copper_spool"
+			id: "04DA0052406282E1"
 			x: -1.0d
 			y: -3.0d
+			title: "Copper Spools craftable!"
 			subtitle: "Copper Spools are now craftable! Check out the \"Mechanical Age\" tab!"
 			dependencies: ["43F43FB0B9ED0818"]
-			id: "04DA0052406282E1"
-			tasks: [{
-				id: "65CF2A9E8F2B113C"
-				type: "item"
-				title: "Copper Spool Unlocked"
-				icon: "createaddition:copper_spool"
-				item: "modern_industrialization:steel_wiremill"
-			}]
 		}
 		{
-			title: "Machine Speedup!"
-			x: -8.0d
-			y: -0.5d
-			subtitle: "Right-Clicking a Steam Machine with Gunpowder doubles its speed for 2 minutes per Gunpowder!"
-			dependencies: ["0BAB52BE15CE157F"]
-			id: "2695042EA3E73DDB"
 			tasks: [{
 				id: "75F710EAB970AF8F"
 				type: "item"
 				item: "minecraft:gunpowder"
 			}]
+			id: "2695042EA3E73DDB"
+			x: -8.0d
+			y: -0.5d
+			title: "Machine Speedup!"
 			rewards: [{
 				id: "321E4D4CDDD5B635"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Right-Clicking a Steam Machine with Gunpowder doubles its speed for 2 minutes per Gunpowder!"
+			dependencies: ["0BAB52BE15CE157F"]
 		}
 		{
+			size: 1.5d
 			x: -1.0d
+			id: "24A168D8221DCA7D"
 			y: -1.5d
 			shape: "gear"
 			subtitle: "After crafting your first Analog circuit, the gate to LV technology is opened."
 			dependencies: ["43F43FB0B9ED0818"]
-			size: 1.5d
-			id: "24A168D8221DCA7D"
 			tasks: [{
 				id: "47461CBAEBDC4EE1"
 				type: "item"
@@ -811,5 +812,4 @@
 			}]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/resourceful_ways.snbt
+++ b/config/ftbquests/quests/chapters/resourceful_ways.snbt
@@ -1,20 +1,15 @@
 {
-	id: "5C764279146E5E66"
-	group: "76C22988F9A7C9CE"
-	order_index: 4
-	filename: "resourceful_ways"
-	title: "Resourceful Ways"
-	icon: "croparia:elematilius"
-	default_quest_shape: "hexagon"
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "76C22988F9A7C9CE"
+	id: "5C764279146E5E66"
+	filename: "resourceful_ways"
+	default_quest_shape: "hexagon"
+	icon: "croparia:elematilius"
+	title: "Resourceful Ways"
+	order_index: 4
 	quests: [
 		{
-			title: "The Infusion Pedestal"
-			x: -1.0d
-			y: -1.5d
-			shape: "circle"
-			subtitle: "Required to make your first Elematilius."
-			id: "6D750A38944E9B68"
 			tasks: [
 				{
 					id: "49A0E9D22020400E"
@@ -22,9 +17,9 @@
 					item: "betterend:infusion_pedestal"
 				}
 				{
-					id: "46517C1CEB2EFD8D"
 					type: "item"
-					title: "8x Pedestal"
+					count: 8L
+					id: "46517C1CEB2EFD8D"
 					item: {
 						id: "itemfilters:or"
 						Count: 1b
@@ -89,35 +84,35 @@
 							]
 						}
 					}
-					count: 8L
+					title: "8x Pedestal"
 				}
 			]
+			x: -1.0d
+			id: "6D750A38944E9B68"
+			y: -1.5d
+			shape: "circle"
+			title: "The Infusion Pedestal"
 			rewards: [{
 				id: "67621D3B3F77D14A"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Required to make your first Elematilius."
 		}
 		{
-			title: "Seed for Though"
-			x: -13.5d
-			y: -0.5d
-			shape: "diamond"
-			dependencies: ["5BC4250E4C9F803C"]
-			id: "0A731CA172FB9188"
 			tasks: [{
 				id: "53A2218A89F26A4E"
 				type: "item"
 				item: "croparia:seed_crop_elemental"
 			}]
-		}
-		{
-			title: "Plant Seeds"
-			x: -5.5d
+			x: -13.5d
+			id: "0A731CA172FB9188"
 			y: -0.5d
 			shape: "diamond"
-			dependencies: ["7DFF18CFEB0B8DBE"]
-			id: "54D72C234EA76054"
+			title: "Seed for Though"
+			dependencies: ["5BC4250E4C9F803C"]
+		}
+		{
 			tasks: [
 				{
 					id: "4442C5D3356C04AF"
@@ -150,37 +145,37 @@
 					item: "croparia:seed_crop_fern"
 				}
 			]
+			x: -5.5d
+			id: "54D72C234EA76054"
+			y: -0.5d
+			shape: "diamond"
+			title: "Plant Seeds"
 			rewards: [{
 				id: "1D1EC42A100FDBC9"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7DFF18CFEB0B8DBE"]
 		}
 		{
-			title: "Croparia"
-			x: -5.0d
-			y: -1.5d
-			shape: "circle"
-			dependencies: ["366ACE7F8E5E5C83"]
-			id: "7DFF18CFEB0B8DBE"
 			tasks: [{
 				id: "3BE2200A7B852974"
 				type: "item"
 				item: "croparia:croparia"
 			}]
+			x: -5.0d
+			id: "7DFF18CFEB0B8DBE"
+			y: -1.5d
+			shape: "circle"
+			title: "Croparia"
 			rewards: [{
 				id: "4A61D638DF4F258A"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["366ACE7F8E5E5C83"]
 		}
 		{
-			title: "Fish Seed"
-			x: -4.5d
-			y: -0.5d
-			shape: "diamond"
-			dependencies: ["7DFF18CFEB0B8DBE"]
-			id: "1E7DC8E0493BE99E"
 			tasks: [
 				{
 					id: "139404EF97A2DB76"
@@ -203,19 +198,19 @@
 					item: "croparia:seed_crop_salmon"
 				}
 			]
+			x: -4.5d
+			id: "1E7DC8E0493BE99E"
+			y: -0.5d
+			shape: "diamond"
+			title: "Fish Seed"
 			rewards: [{
 				id: "4F701076BE0CD0BE"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7DFF18CFEB0B8DBE"]
 		}
 		{
-			title: "Other T1 Seeds"
-			x: -5.0d
-			y: 0.0d
-			shape: "diamond"
-			dependencies: ["7DFF18CFEB0B8DBE"]
-			id: "712EB19B26D405DD"
 			tasks: [
 				{
 					id: "3502B94CAA19179E"
@@ -243,19 +238,19 @@
 					item: "croparia:seed_crop_lead2"
 				}
 			]
+			x: -5.0d
+			id: "712EB19B26D405DD"
+			y: 0.0d
+			shape: "diamond"
+			title: "Other T1 Seeds"
 			rewards: [{
 				id: "33228F5C4BA961C2"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7DFF18CFEB0B8DBE"]
 		}
 		{
-			title: "Wood Seeds"
-			x: -5.5d
-			y: -2.5d
-			shape: "diamond"
-			dependencies: ["7DFF18CFEB0B8DBE"]
-			id: "409A92D40F539485"
 			tasks: [
 				{
 					id: "7DEB271808127E13"
@@ -288,19 +283,19 @@
 					item: "croparia:seed_crop_spruce"
 				}
 			]
+			x: -5.5d
+			id: "409A92D40F539485"
+			y: -2.5d
+			shape: "diamond"
+			title: "Wood Seeds"
 			rewards: [{
 				id: "4B79C23ABB4EB514"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7DFF18CFEB0B8DBE"]
 		}
 		{
-			title: "Dye Seeds"
-			x: -4.5d
-			y: -2.5d
-			shape: "diamond"
-			dependencies: ["7DFF18CFEB0B8DBE"]
-			id: "1609BF52108238B0"
 			tasks: [
 				{
 					id: "21A4EF8FFF886125"
@@ -383,19 +378,19 @@
 					item: "croparia:seed_crop_white"
 				}
 			]
+			x: -4.5d
+			id: "1609BF52108238B0"
+			y: -2.5d
+			shape: "diamond"
+			title: "Dye Seeds"
 			rewards: [{
 				id: "59F032DB9A686245"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7DFF18CFEB0B8DBE"]
 		}
 		{
-			title: "Meat Seeds"
-			x: -5.0d
-			y: -3.0d
-			shape: "diamond"
-			dependencies: ["7DFF18CFEB0B8DBE"]
-			id: "4526E151BAE88310"
 			tasks: [
 				{
 					id: "055F9E6A348CE3EB"
@@ -428,31 +423,31 @@
 					item: "croparia:seed_crop_rawmutton"
 				}
 			]
+			x: -5.0d
+			id: "4526E151BAE88310"
+			y: -3.0d
+			shape: "diamond"
+			title: "Meat Seeds"
 			rewards: [{
 				id: "5D49CB44B75FE95C"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7DFF18CFEB0B8DBE"]
 		}
 		{
-			x: -7.5d
-			y: -1.5d
-			shape: "circle"
-			dependencies: ["7DFF18CFEB0B8DBE"]
-			id: "576ABF43FCF886B7"
 			tasks: [{
 				id: "5093432E189F5F6F"
 				type: "item"
 				item: "croparia:croparia2"
 			}]
+			dependencies: ["7DFF18CFEB0B8DBE"]
+			id: "576ABF43FCF886B7"
+			shape: "circle"
+			y: -1.5d
+			x: -7.5d
 		}
 		{
-			title: "Mob-Seeds"
-			x: -7.0d
-			y: -2.5d
-			shape: "diamond"
-			dependencies: ["576ABF43FCF886B7"]
-			id: "31BAC57972148E1F"
 			tasks: [
 				{
 					id: "24D831A2D79414B9"
@@ -490,70 +485,71 @@
 					item: "croparia:seed_crop_eye"
 				}
 			]
+			x: -7.0d
+			id: "31BAC57972148E1F"
+			y: -2.5d
+			shape: "diamond"
+			title: "Mob-Seeds"
 			rewards: [{
 				id: "66F31AB427BBED53"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["576ABF43FCF886B7"]
 		}
 		{
-			title: "Iron Seed"
-			x: -8.0d
-			y: -2.5d
-			shape: "diamond"
-			dependencies: ["576ABF43FCF886B7"]
-			id: "4A6AC3D1ACBC3BFC"
 			tasks: [{
 				id: "3AC9CA74D6E96E6F"
 				type: "item"
 				item: "croparia:seed_crop_iron"
 			}]
+			x: -8.0d
+			id: "4A6AC3D1ACBC3BFC"
+			y: -2.5d
+			shape: "diamond"
+			title: "Iron Seed"
 			rewards: [{
 				id: "57AADAE21DF66F68"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["576ABF43FCF886B7"]
 		}
 		{
-			x: -7.0d
-			y: -0.5d
-			shape: "diamond"
-			dependencies: ["576ABF43FCF886B7"]
-			id: "573885D6EF32B7BC"
 			tasks: [{
 				id: "45CE21EA926EDA57"
 				type: "item"
 				item: "croparia:seed_crop_scute"
 			}]
+			x: -7.0d
+			id: "573885D6EF32B7BC"
+			y: -0.5d
+			shape: "diamond"
 			rewards: [{
 				id: "057C5596DD8218DC"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["576ABF43FCF886B7"]
 		}
 		{
-			x: -7.5d
-			y: -3.0d
-			shape: "diamond"
-			dependencies: ["576ABF43FCF886B7"]
-			id: "2777FEB022346947"
 			tasks: [{
 				id: "67F1723AA62338F1"
 				type: "item"
 				item: "croparia:seed_crop_gold"
 			}]
+			x: -7.5d
+			id: "2777FEB022346947"
+			y: -3.0d
+			shape: "diamond"
 			rewards: [{
 				id: "6DF0F61F24B54927"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["576ABF43FCF886B7"]
 		}
 		{
-			x: -8.0d
-			y: -0.5d
-			shape: "diamond"
-			dependencies: ["576ABF43FCF886B7"]
-			id: "40B13424FA523E11"
 			tasks: [
 				{
 					id: "133C69134938A678"
@@ -566,106 +562,105 @@
 					item: "croparia:seed_crop_crystal"
 				}
 			]
+			x: -8.0d
+			id: "40B13424FA523E11"
+			y: -0.5d
+			shape: "diamond"
 			rewards: [{
 				id: "14CEE6584B7AFFAB"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["576ABF43FCF886B7"]
 		}
 		{
-			x: -7.5d
-			y: 0.0d
-			shape: "diamond"
-			dependencies: ["576ABF43FCF886B7"]
-			id: "13EDB9956517B349"
 			tasks: [{
 				id: "291B67AB95D93F72"
 				type: "item"
 				item: "croparia:seed_crop_copper"
 			}]
+			x: -7.5d
+			id: "13EDB9956517B349"
+			y: 0.0d
+			shape: "diamond"
 			rewards: [{
 				id: "5D4F734E3B332845"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["576ABF43FCF886B7"]
 		}
 		{
-			x: -10.0d
-			y: -1.5d
-			shape: "circle"
-			dependencies: ["576ABF43FCF886B7"]
-			id: "76071C22A73A2026"
 			tasks: [{
 				id: "65F226B04C4E0440"
 				type: "item"
 				item: "croparia:croparia3"
 			}]
+			dependencies: ["576ABF43FCF886B7"]
+			id: "76071C22A73A2026"
+			shape: "circle"
+			y: -1.5d
+			x: -10.0d
 		}
 		{
-			x: -9.5d
-			y: -2.5d
-			shape: "diamond"
-			dependencies: ["76071C22A73A2026"]
-			id: "7A89560F303A8BE6"
 			tasks: [{
 				id: "195459EDA666625B"
 				type: "item"
 				item: "croparia:seed_crop_quartz"
 			}]
+			dependencies: ["76071C22A73A2026"]
+			id: "7A89560F303A8BE6"
+			shape: "diamond"
+			y: -2.5d
+			x: -9.5d
 		}
 		{
-			x: -10.0d
-			y: -3.0d
-			shape: "diamond"
-			dependencies: ["76071C22A73A2026"]
-			id: "6950FC974624C6AA"
 			tasks: [{
 				id: "22752792321F5533"
 				type: "item"
 				item: "croparia:seed_crop_nether"
 			}]
+			dependencies: ["76071C22A73A2026"]
+			id: "6950FC974624C6AA"
+			shape: "diamond"
+			y: -3.0d
+			x: -10.0d
 		}
 		{
-			x: -10.5d
-			y: -3.5d
-			shape: "diamond"
-			dependencies: ["76071C22A73A2026"]
-			id: "7361BD20A6B95D14"
 			tasks: [{
 				id: "688CF4D959B2C166"
 				type: "item"
 				item: "croparia:seed_crop_nautilus"
 			}]
+			x: -10.5d
+			id: "7361BD20A6B95D14"
+			y: -3.5d
+			shape: "diamond"
 			rewards: [{
 				id: "67943886E1BEEE97"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["76071C22A73A2026"]
 		}
 		{
-			x: -9.5d
-			y: -3.5d
-			shape: "diamond"
-			dependencies: ["76071C22A73A2026"]
-			id: "0A8F44B9B3C8FC0F"
 			tasks: [{
 				id: "0C4C662FE28C30A5"
 				type: "item"
 				item: "croparia:seed_crop_lapis"
 			}]
+			x: -9.5d
+			id: "0A8F44B9B3C8FC0F"
+			y: -3.5d
+			shape: "diamond"
 			rewards: [{
 				id: "384F19EA7943556F"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["76071C22A73A2026"]
 		}
 		{
-			title: "Ender Pearl + Magma Cream Seeds"
-			x: -9.5d
-			y: 0.5d
-			shape: "diamond"
-			dependencies: ["76071C22A73A2026"]
-			id: "02D45E3FB37ED0AD"
 			tasks: [
 				{
 					id: "2D62D0EC3AC2BA8D"
@@ -678,123 +673,123 @@
 					item: "croparia:seed_crop_magma"
 				}
 			]
+			x: -9.5d
+			id: "02D45E3FB37ED0AD"
+			y: 0.5d
+			shape: "diamond"
+			title: "Ender Pearl + Magma Cream Seeds"
 			rewards: [{
 				id: "7EA19682476195DF"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["76071C22A73A2026"]
 		}
 		{
-			x: -10.5d
-			y: 0.5d
-			shape: "diamond"
-			dependencies: ["76071C22A73A2026"]
-			id: "62020721A69D40F2"
 			tasks: [{
 				id: "702FF74EA6FCA251"
 				type: "item"
 				item: "croparia:seed_crop_goldenapple"
 			}]
+			x: -10.5d
+			id: "62020721A69D40F2"
+			y: 0.5d
+			shape: "diamond"
 			rewards: [{
 				id: "44EDC95D72204BE8"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["76071C22A73A2026"]
 		}
 		{
-			x: -10.0d
-			y: 0.0d
-			shape: "diamond"
-			dependencies: ["76071C22A73A2026"]
-			id: "30DF8297FEEC9F22"
 			tasks: [{
 				id: "073DB8EBFC3BC948"
 				type: "item"
 				item: "croparia:seed_crop_glowstone"
 			}]
+			x: -10.0d
+			id: "30DF8297FEEC9F22"
+			y: 0.0d
+			shape: "diamond"
 			rewards: [{
 				id: "0EABDECC3F8D36C9"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["76071C22A73A2026"]
 		}
 		{
-			x: -9.5d
-			y: -0.5d
-			shape: "diamond"
-			dependencies: ["76071C22A73A2026"]
-			id: "47045A0E8E3457C2"
 			tasks: [{
 				id: "26E5425CC40CE5EE"
 				type: "item"
 				item: "croparia:seed_crop_chorus"
 			}]
+			x: -9.5d
+			id: "47045A0E8E3457C2"
+			y: -0.5d
+			shape: "diamond"
 			rewards: [{
 				id: "5A509E45A9220898"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["76071C22A73A2026"]
 		}
 		{
-			x: -10.5d
-			y: -0.5d
-			shape: "diamond"
-			dependencies: ["76071C22A73A2026"]
-			id: "2581B7D8E6C6E510"
 			tasks: [{
 				id: "756BEE3608FFA0A4"
 				type: "item"
 				item: "croparia:seed_crop_blaze"
 			}]
+			x: -10.5d
+			id: "2581B7D8E6C6E510"
+			y: -0.5d
+			shape: "diamond"
 			rewards: [{
 				id: "28968D2F4CEB1B99"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["76071C22A73A2026"]
 		}
 		{
-			x: -10.5d
-			y: -2.5d
-			shape: "diamond"
-			dependencies: ["76071C22A73A2026"]
-			id: "3BCE1CC36B46047C"
 			tasks: [{
 				id: "4DA7A4F6BEA7948A"
 				type: "item"
 				item: "croparia:seed_crop_redstone"
 			}]
+			dependencies: ["76071C22A73A2026"]
+			id: "3BCE1CC36B46047C"
+			shape: "diamond"
+			y: -2.5d
+			x: -10.5d
 		}
 		{
-			x: -13.0d
-			y: -1.5d
-			shape: "circle"
-			dependencies: ["76071C22A73A2026"]
-			id: "5BC4250E4C9F803C"
 			tasks: [{
 				id: "19D0A5FD97D7E3E8"
 				type: "item"
 				item: "croparia:croparia4"
 			}]
+			dependencies: ["76071C22A73A2026"]
+			id: "5BC4250E4C9F803C"
+			shape: "circle"
+			y: -1.5d
+			x: -13.0d
 		}
 		{
-			x: -12.5d
-			y: -0.5d
-			shape: "diamond"
-			dependencies: ["5BC4250E4C9F803C"]
-			id: "0AF5FB1B5AA5AA11"
 			tasks: [{
 				id: "737A74FAB46C9E54"
 				type: "item"
 				item: "croparia:seed_crop_sea"
 			}]
+			dependencies: ["5BC4250E4C9F803C"]
+			id: "0AF5FB1B5AA5AA11"
+			shape: "diamond"
+			y: -0.5d
+			x: -12.5d
 		}
 		{
-			title: "Shulker + Ghast Seed"
-			x: -12.5d
-			y: -2.5d
-			shape: "diamond"
-			dependencies: ["5BC4250E4C9F803C"]
-			id: "64B04D1CBC923789"
 			tasks: [
 				{
 					id: "09233415005F6331"
@@ -807,140 +802,139 @@
 					item: "croparia:seed_crop_ghast"
 				}
 			]
+			x: -12.5d
+			id: "64B04D1CBC923789"
+			y: -2.5d
+			shape: "diamond"
+			title: "Shulker + Ghast Seed"
+			dependencies: ["5BC4250E4C9F803C"]
 		}
 		{
-			x: -13.0d
-			y: -3.0d
-			shape: "diamond"
-			dependencies: ["5BC4250E4C9F803C"]
-			id: "222739E77C745519"
 			tasks: [{
 				id: "1DC4FE7A037EC52E"
 				type: "item"
 				item: "croparia:seed_crop_diamond"
 			}]
+			dependencies: ["5BC4250E4C9F803C"]
+			id: "222739E77C745519"
+			shape: "diamond"
+			y: -3.0d
+			x: -13.0d
 		}
 		{
-			x: -13.5d
-			y: -2.5d
-			shape: "diamond"
-			dependencies: ["5BC4250E4C9F803C"]
-			id: "0AE23BAFE82168E6"
 			tasks: [{
 				id: "58F4B063BC12F9B9"
 				type: "item"
 				item: "croparia:seed_crop_xp"
 			}]
+			dependencies: ["5BC4250E4C9F803C"]
+			id: "0AE23BAFE82168E6"
+			shape: "diamond"
+			y: -2.5d
+			x: -13.5d
 		}
 		{
-			x: -13.0d
-			y: 0.0d
-			shape: "diamond"
-			dependencies: ["5BC4250E4C9F803C"]
-			id: "47D8A9BBAD2DE451"
 			tasks: [{
 				id: "5C50870611266B89"
 				type: "item"
 				item: "croparia:seed_crop_emerald"
 			}]
+			dependencies: ["5BC4250E4C9F803C"]
+			id: "47D8A9BBAD2DE451"
+			shape: "diamond"
+			y: 0.0d
+			x: -13.0d
 		}
 		{
-			x: -16.0d
-			y: -1.5d
-			shape: "circle"
-			dependencies: ["5BC4250E4C9F803C"]
-			id: "48BF71269DEA1AB1"
 			tasks: [{
 				id: "7F969AA823C4157B"
 				type: "item"
 				item: "croparia:croparia5"
 			}]
+			dependencies: ["5BC4250E4C9F803C"]
+			id: "48BF71269DEA1AB1"
+			shape: "circle"
+			y: -1.5d
+			x: -16.0d
 		}
 		{
-			x: -16.0d
-			y: -0.5d
-			shape: "diamond"
-			dependencies: ["48BF71269DEA1AB1"]
-			id: "7CFA92CC48D1E7E3"
 			tasks: [{
 				id: "3E93D20A19EEAD09"
 				type: "item"
 				item: "croparia:seed_crop_wither"
 			}]
+			dependencies: ["48BF71269DEA1AB1"]
+			id: "7CFA92CC48D1E7E3"
+			shape: "diamond"
+			y: -0.5d
+			x: -16.0d
 		}
 		{
-			x: -16.0d
-			y: -2.5d
-			shape: "diamond"
-			dependencies: ["48BF71269DEA1AB1"]
-			id: "7D6C1EFD0AA0AEFE"
 			tasks: [{
 				id: "027DA0F6532BB646"
 				type: "item"
 				item: "croparia:seed_crop_netherite"
 			}]
+			dependencies: ["48BF71269DEA1AB1"]
+			id: "7D6C1EFD0AA0AEFE"
+			shape: "diamond"
+			y: -2.5d
+			x: -16.0d
 		}
 		{
-			x: -18.5d
-			y: -1.5d
-			shape: "circle"
-			dependencies: ["48BF71269DEA1AB1"]
-			id: "2FA6B8A1C8713DE0"
 			tasks: [{
 				id: "5A17FCC895F52C8B"
 				type: "item"
 				item: "croparia:croparia6"
 			}]
+			dependencies: ["48BF71269DEA1AB1"]
+			id: "2FA6B8A1C8713DE0"
+			shape: "circle"
+			y: -1.5d
+			x: -18.5d
 		}
 		{
-			x: -18.5d
-			y: -0.5d
-			shape: "diamond"
-			dependencies: ["2FA6B8A1C8713DE0"]
-			id: "4A96A0456680837C"
 			tasks: [{
 				id: "7E1EA6614D3AD212"
 				type: "item"
 				item: "croparia:seed_crop_star"
 			}]
+			dependencies: ["2FA6B8A1C8713DE0"]
+			id: "4A96A0456680837C"
+			shape: "diamond"
+			y: -0.5d
+			x: -18.5d
 		}
 		{
-			x: -22.0d
-			y: -1.5d
-			shape: "diamond"
-			dependencies: ["3CC32A1B2662B6B9"]
-			id: "6AB1C7B6251FE9F5"
 			tasks: [{
 				id: "2DB99A45CE808456"
 				type: "item"
 				item: "croparia:seed_crop_dragon"
 			}]
+			x: -22.0d
+			id: "6AB1C7B6251FE9F5"
+			y: -1.5d
+			shape: "diamond"
 			rewards: [{
 				id: "46115479604171EF"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["3CC32A1B2662B6B9"]
 		}
 		{
-			x: -18.5d
-			y: -2.5d
-			shape: "diamond"
-			dependencies: ["2FA6B8A1C8713DE0"]
-			id: "11948ECF241B2923"
 			tasks: [{
 				id: "7E372EC07A6238D1"
 				type: "item"
 				item: "croparia:seed_crop_totem"
 			}]
+			dependencies: ["2FA6B8A1C8713DE0"]
+			id: "11948ECF241B2923"
+			shape: "diamond"
+			y: -2.5d
+			x: -18.5d
 		}
 		{
-			x: 0.0d
-			y: -4.5d
-			shape: "pentagon"
-			subtitle: "Used to harvest plants without breaking them."
-			description: ["When harvesting a plant with a Diamond Knife, it will make that plant go back only 1 stage instead of starting from scratch."]
-			dependencies: ["748485FEC1097A71"]
-			id: "17549F4A0B59DEA4"
 			tasks: [{
 				id: "551B10C952DD6686"
 				type: "item"
@@ -952,87 +946,79 @@
 					}
 				}
 			}]
+			description: ["When harvesting a plant with a Diamond Knife, it will make that plant go back only 1 stage instead of starting from scratch."]
+			x: 0.0d
+			id: "17549F4A0B59DEA4"
+			y: -4.5d
+			shape: "pentagon"
 			rewards: [{
 				id: "73E3A399DF6BCA64"
 				type: "item"
 				item: "botania:overgrowth_seed"
 			}]
+			subtitle: "Used to harvest plants without breaking them."
+			dependencies: ["748485FEC1097A71"]
 		}
 		{
-			x: -3.0d
-			y: -4.5d
-			shape: "pentagon"
-			subtitle: "Plant in a Jar!"
-			description: ["When given a plant and an appropiate soil, it will grow that plant inside and output the harvest into the Hopper below."]
-			dependencies: ["748485FEC1097A71"]
-			id: "6FFC449DE313A1BD"
 			tasks: [{
 				id: "3A91C6FD4E68A1DD"
 				type: "item"
 				item: "plantinajar:plant_jar"
 			}]
+			description: ["When given a plant and an appropiate soil, it will grow that plant inside and output the harvest into the Hopper below."]
+			x: -3.0d
+			id: "6FFC449DE313A1BD"
+			y: -4.5d
+			shape: "pentagon"
 			rewards: [{
 				id: "4384FB4F5DDD70EB"
 				type: "item"
 				item: "botania:overgrowth_seed"
 			}]
+			subtitle: "Plant in a Jar!"
+			dependencies: ["748485FEC1097A71"]
 		}
 		{
-			x: -1.5d
-			y: -4.5d
+			tasks: [{
+				id: "6B6CD08FAF249745"
+				type: "checkmark"
+				title: "Tools of Farming"
+			}]
 			description: [
 				"These are 2 quests given to receive a 100% chance of an Overgrowth Seed."
 				""
 				"If placed on grass block, it will turn it into an Enchanted Soil, on which Botania Flowers work twice as fast, so spend them wisely!"
 			]
 			id: "748485FEC1097A71"
-			tasks: [{
-				id: "6B6CD08FAF249745"
-				type: "checkmark"
-				title: "Tools of Farming"
-			}]
+			y: -4.5d
+			x: -1.5d
 		}
 		{
-			x: -21.0d
-			y: -1.5d
-			shape: "circle"
-			dependencies: ["2FA6B8A1C8713DE0"]
-			id: "3CC32A1B2662B6B9"
 			tasks: [{
 				id: "12836F421C015E97"
 				type: "item"
 				item: "croparia:croparia7"
 			}]
+			dependencies: ["2FA6B8A1C8713DE0"]
+			id: "3CC32A1B2662B6B9"
+			shape: "circle"
+			y: -1.5d
+			x: -21.0d
 		}
 		{
-			x: -3.0d
-			y: -1.5d
-			shape: "circle"
-			subtitle: "A base ingredient for the Croparia mod."
-			dependencies: ["6D750A38944E9B68"]
-			id: "366ACE7F8E5E5C83"
 			tasks: [{
 				id: "5247A5F6BCFAE903"
 				type: "item"
 				item: "croparia:elematilius"
 			}]
+			x: -3.0d
+			id: "366ACE7F8E5E5C83"
+			y: -1.5d
+			shape: "circle"
+			subtitle: "A base ingredient for the Croparia mod."
+			dependencies: ["6D750A38944E9B68"]
 		}
 		{
-			icon: "croparia:infusor"
-			x: -3.0d
-			y: 0.0d
-			shape: "circle"
-			description: [
-				"The Infusor can be used for alternative recipes for Croparias and crops."
-				""
-				"But first, you need an Elematilius Potion."
-				"To obtain it, right-click a Cauldron filled with water with Elematilius in hand."
-				"Then right-click the Elematilius Cauldron with glass bottles to obtain Elematilius Potions."
-				""
-				"These can be dropped on the Infusor to craft recipes."
-			]
-			dependencies: ["366ACE7F8E5E5C83"]
-			id: "50CC6F9ACF40232E"
 			tasks: [
 				{
 					id: "22438152F65DBBB8"
@@ -1045,26 +1031,23 @@
 					item: "croparia:potion_elematilius"
 				}
 			]
+			description: [
+				"The Infusor can be used for alternative recipes for Croparias and crops."
+				""
+				"But first, you need an Elematilius Potion."
+				"To obtain it, right-click a Cauldron filled with water with Elematilius in hand."
+				"Then right-click the Elematilius Cauldron with glass bottles to obtain Elematilius Potions."
+				""
+				"These can be dropped on the Infusor to craft recipes."
+			]
+			icon: "croparia:infusor"
+			x: -3.0d
+			id: "50CC6F9ACF40232E"
+			y: 0.0d
+			shape: "circle"
+			dependencies: ["366ACE7F8E5E5C83"]
 		}
 		{
-			title: "Recipes Craftable with Elematilius Infusor"
-			x: -1.0d
-			y: -0.5d
-			subtitle: "You won't find these recipes in REI."
-			description: [
-				"Stone -> Elemental Stone"
-				"Croparia -> Croparia of the next Tier"
-				"Wheat/Beetroot Seeds -> Elematilius Seed"
-				"Coal Seed -> Iron Seed"
-				"Gold Seed -> Redstone Seed"
-				"Redstone Seed -> Lapis Seed"
-				"Lapis Seed -> Diamond Seed"
-				"Diamond Seed -> Emerald Seed"
-				"Book -> RF Meter"
-				"Furnace -> Seed Recycler"
-			]
-			dependencies: ["50CC6F9ACF40232E"]
-			id: "48A9D61EE4AECF9B"
 			tasks: [{
 				id: "7788CFE16209F1E1"
 				type: "item"
@@ -1140,12 +1123,31 @@
 					}
 				}
 			}]
+			description: [
+				"Stone -> Elemental Stone"
+				"Croparia -> Croparia of the next Tier"
+				"Wheat/Beetroot Seeds -> Elematilius Seed"
+				"Coal Seed -> Iron Seed"
+				"Gold Seed -> Redstone Seed"
+				"Redstone Seed -> Lapis Seed"
+				"Lapis Seed -> Diamond Seed"
+				"Diamond Seed -> Emerald Seed"
+				"Book -> RF Meter"
+				"Furnace -> Seed Recycler"
+			]
+			id: "48A9D61EE4AECF9B"
+			x: -1.0d
+			y: -0.5d
+			title: "Recipes Craftable with Elematilius Infusor"
+			subtitle: "You won't find these recipes in REI."
+			dependencies: ["50CC6F9ACF40232E"]
 		}
 		{
-			title: "Ritual Tier 1"
-			x: -3.0d
-			y: 1.5d
-			shape: "circle"
+			tasks: [{
+				id: "54E5021470F302E4"
+				type: "item"
+				item: "croparia:ritual_stand"
+			}]
 			description: [
 				"{image:kubejs:textures/item/ritual_tier1.png width:160 height:160 align:1}"
 				"The ritual structure consists of:"
@@ -1156,19 +1158,19 @@
 				""
 				"Crafting with the Ritual requires placing blocks in empty spots around the Elemental Stone, depending on recipe."
 			]
-			dependencies: ["50CC6F9ACF40232E"]
+			x: -3.0d
 			id: "2CCE423E7974B8BB"
+			y: 1.5d
+			shape: "circle"
+			title: "Ritual Tier 1"
+			dependencies: ["50CC6F9ACF40232E"]
+		}
+		{
 			tasks: [{
-				id: "54E5021470F302E4"
+				id: "7F8663DF32E65949"
 				type: "item"
 				item: "croparia:ritual_stand"
 			}]
-		}
-		{
-			title: "Ritual Tier 2"
-			x: -3.0d
-			y: 3.0d
-			shape: "circle"
 			description: [
 				"{image:kubejs:textures/item/ritual_tier2.png width:160 height:160 align:1}"
 				"The ritual structure consists of:"
@@ -1183,46 +1185,17 @@
 				""
 				"Crafting with the Ritual requires placing blocks in empty spots around the Elemental Stone, depending on recipe."
 			]
+			x: -3.0d
+			id: "4DD5B91564DBFBD3"
+			y: 3.0d
+			shape: "circle"
+			title: "Ritual Tier 2"
 			dependencies: [
 				"50CC6F9ACF40232E"
 				"2CCE423E7974B8BB"
 			]
-			id: "4DD5B91564DBFBD3"
-			tasks: [{
-				id: "7F8663DF32E65949"
-				type: "item"
-				item: "croparia:ritual_stand"
-			}]
 		}
 		{
-			title: "Recipes Craftable with Ritual Tier 1"
-			x: -1.0d
-			y: 1.5d
-			subtitle: "You won't find these recipes in REI."
-			description: [
-				"Soul Dagger:"
-				"Fill the empty spots with 4 Elemental Stones, throw a Golden Sword onto the Ritual Stand."
-				""
-				"Midas Hand:"
-				"Fill the empty spots with 4 Gold Blocks, throw a Stick onto the Ritual Stand."
-				"It turns any right-clicked block (apart from Bedrock) into Gold Ingots, and any mob (including bosses) into Gold Blocks."
-				""
-				"Horn of Plenty:"
-				"Fill the empty spots with 4 Nether Wart Blocks, throw a Spruce Log onto the Ritual Stand."
-				"Right-clicking blocks with this item in hand will drop random Minecraft food on the ground."
-				""
-				"Infinite Apple:"
-				"Fill the empty spots with 4 Nether Wart Blocks, throw a Golen Apple onto the Ritual Stand."
-				"It can be eaten infinitely, however, it does not restore any hunger points. (bugged item)"
-				""
-				"Magic Rope:"
-				"Fill the empty spots with 4 Elemental Stones, throw a Lead onto the Ritual Stand."
-				"Shift-right click a block to set a position."
-				"Right-click any block to teleport to a saved position."
-				"Warning: It only stores coordinates, not a dimension, so using it in the wrong dimension can cause you to teleport into very far skies..."
-			]
-			dependencies: ["2CCE423E7974B8BB"]
-			id: "5AE23E2EE4787E35"
 			tasks: [{
 				id: "6FA35874C139F976"
 				type: "item"
@@ -1263,31 +1236,36 @@
 					}
 				}
 			}]
+			description: [
+				"Soul Dagger:"
+				"Fill the empty spots with 4 Elemental Stones, throw a Golden Sword onto the Ritual Stand."
+				""
+				"Midas Hand:"
+				"Fill the empty spots with 4 Gold Blocks, throw a Stick onto the Ritual Stand."
+				"It turns any right-clicked block (apart from Bedrock) into Gold Ingots, and any mob (including bosses) into Gold Blocks."
+				""
+				"Horn of Plenty:"
+				"Fill the empty spots with 4 Nether Wart Blocks, throw a Spruce Log onto the Ritual Stand."
+				"Right-clicking blocks with this item in hand will drop random Minecraft food on the ground."
+				""
+				"Infinite Apple:"
+				"Fill the empty spots with 4 Nether Wart Blocks, throw a Golen Apple onto the Ritual Stand."
+				"It can be eaten infinitely, however, it does not restore any hunger points. (bugged item)"
+				""
+				"Magic Rope:"
+				"Fill the empty spots with 4 Elemental Stones, throw a Lead onto the Ritual Stand."
+				"Shift-right click a block to set a position."
+				"Right-click any block to teleport to a saved position."
+				"Warning: It only stores coordinates, not a dimension, so using it in the wrong dimension can cause you to teleport into very far skies..."
+			]
+			id: "5AE23E2EE4787E35"
+			x: -1.0d
+			y: 1.5d
+			title: "Recipes Craftable with Ritual Tier 1"
+			subtitle: "You won't find these recipes in REI."
+			dependencies: ["2CCE423E7974B8BB"]
 		}
 		{
-			title: "Recipes Craftable with Ritual Tier 2"
-			x: -1.0d
-			y: 3.0d
-			subtitle: "You won't find these recipes in REI."
-			description: [
-				"Accelerator:"
-				"Fill the empty spots with 4 Elemental Stones, throw a Clock onto the Ritual Stand."
-				"Place up to 5 of them under the soil to very slightly increase growth rate."
-				""
-				"Elemental Time:"
-				"Fill the empty spots with 4 Accelerators, throw an Elematilius onto the Ritual Stand."
-				"Right-click any block to activate it. It will start skipping 2000 time ticks every half second. Right-click again to deactivate."
-				""
-				"Harvester:"
-				"Fill the empty spots with 4 Iron Blocks, throw a Renforced Hoe (sic) onto the Ritual Stand."
-				"When activated with Redstone, it will harvest crops in a 5x5 area."
-				""
-				"Soul Spawner:"
-				"Fill the empty spots with 4 Elemental Stones, throw a Cage onto the Ritual Stand."
-				"It will spawn mobs like a vanilla Spawner, when a Soul Jar with mob's Soul is insterted into it."
-			]
-			dependencies: ["4DD5B91564DBFBD3"]
-			id: "5995D98C701DE0F3"
 			tasks: [{
 				id: "42B15C0E3792B1D6"
 				type: "item"
@@ -1320,23 +1298,31 @@
 					}
 				}
 			}]
+			description: [
+				"Accelerator:"
+				"Fill the empty spots with 4 Elemental Stones, throw a Clock onto the Ritual Stand."
+				"Place up to 5 of them under the soil to very slightly increase growth rate."
+				""
+				"Elemental Time:"
+				"Fill the empty spots with 4 Accelerators, throw an Elematilius onto the Ritual Stand."
+				"Right-click any block to activate it. It will start skipping 2000 time ticks every half second. Right-click again to deactivate."
+				""
+				"Harvester:"
+				"Fill the empty spots with 4 Iron Blocks, throw a Renforced Hoe (sic) onto the Ritual Stand."
+				"When activated with Redstone, it will harvest crops in a 5x5 area."
+				""
+				"Soul Spawner:"
+				"Fill the empty spots with 4 Elemental Stones, throw a Cage onto the Ritual Stand."
+				"It will spawn mobs like a vanilla Spawner, when a Soul Jar with mob's Soul is insterted into it."
+			]
+			id: "5995D98C701DE0F3"
+			x: -1.0d
+			y: 3.0d
+			title: "Recipes Craftable with Ritual Tier 2"
+			subtitle: "You won't find these recipes in REI."
+			dependencies: ["4DD5B91564DBFBD3"]
 		}
 		{
-			x: -1.0d
-			y: 0.5d
-			subtitle: "You won't find these recipes in REI."
-			description: [
-				"Recipes crafted in Elematilius Infusor:"
-				""
-				"Prismarine Shard -> Elemental Water"
-				"Magma Block -> Elemental Fire"
-				"Podzol -> Elemental Earth"
-				"End Stone -> Elemental Air"
-				""
-				"To craft an Elemental Potion, just craft the Elemental with a bottle of Dragon's Breath."
-			]
-			dependencies: ["50CC6F9ACF40232E"]
-			id: "1A188C19A2D44165"
 			tasks: [{
 				id: "49AD8DCD1FAC9372"
 				type: "item"
@@ -1368,31 +1354,23 @@
 					}
 				}
 			}]
+			description: [
+				"Recipes crafted in Elematilius Infusor:"
+				""
+				"Prismarine Shard -> Elemental Water"
+				"Magma Block -> Elemental Fire"
+				"Podzol -> Elemental Earth"
+				"End Stone -> Elemental Air"
+				""
+				"To craft an Elemental Potion, just craft the Elemental with a bottle of Dragon's Breath."
+			]
+			id: "1A188C19A2D44165"
+			x: -1.0d
+			y: 0.5d
+			subtitle: "You won't find these recipes in REI."
+			dependencies: ["50CC6F9ACF40232E"]
 		}
 		{
-			x: 0.5d
-			y: 0.5d
-			subtitle: "Avatar: The Last Crystalbender"
-			description: [
-				"Water Shard:"
-				"Right-click to place Water."
-				"Attacking a mob will cause a freezing effect, causing 1 damage."
-				""
-				"Earth Shard:"
-				"Right Click a block to transform it according to this scheme:"
-				"Any other Block -> Stone -> Cobblestone -> Gravel -> Sand"
-				"Red Sandstone -> Red Sand"
-				"Sandstone -> Sand"
-				""
-				"Fire Shard:"
-				"Right-Click to place Fire."
-				"Attacking a mob will briefly set it on fire, however the fire duration is too short to do any damage."
-				""
-				"Air Shard:"
-				"Right-Clicking a block or a mob will make it disappear. Poof! Now it's gone."
-			]
-			dependencies: ["1A188C19A2D44165"]
-			id: "4FB9344EDC392CB0"
 			tasks: [{
 				id: "01310FFC2836BFAB"
 				type: "item"
@@ -1424,32 +1402,31 @@
 					}
 				}
 			}]
+			description: [
+				"Water Shard:"
+				"Right-click to place Water."
+				"Attacking a mob will cause a freezing effect, causing 1 damage."
+				""
+				"Earth Shard:"
+				"Right Click a block to transform it according to this scheme:"
+				"Any other Block -> Stone -> Cobblestone -> Gravel -> Sand"
+				"Red Sandstone -> Red Sand"
+				"Sandstone -> Sand"
+				""
+				"Fire Shard:"
+				"Right-Click to place Fire."
+				"Attacking a mob will briefly set it on fire, however the fire duration is too short to do any damage."
+				""
+				"Air Shard:"
+				"Right-Clicking a block or a mob will make it disappear. Poof! Now it's gone."
+			]
+			id: "4FB9344EDC392CB0"
+			x: 0.5d
+			y: 0.5d
+			subtitle: "Avatar: The Last Crystalbender"
+			dependencies: ["1A188C19A2D44165"]
 		}
 		{
-			title: "A Proprietary Power System"
-			x: 2.0d
-			y: 0.5d
-			description: [
-				"The Croparia Energy System is incompatible with other energy systems."
-				"This means that you need specific generators in order to power the Croparia Machines."
-				""
-				"Rain Panel:"
-				"Generates energy while it's raining."
-				""
-				"Depth Generator:"
-				"Generates more energy, the deeper this block is."
-				""
-				"Solar Panel:"
-				"Generates energy in daytime when it's sunny."
-				""
-				"Wind Generator:"
-				"Generates more energy, the higher this block is."
-				""
-				"Crop Generator:"
-				"Generates a bit of energy, when any crop in a 5x5 area around itself grows."
-			]
-			dependencies: ["4FB9344EDC392CB0"]
-			id: "5AEE472CF55E0E18"
 			tasks: [{
 				id: "27E0B79DF8CD9EEF"
 				type: "item"
@@ -1485,18 +1462,32 @@
 					}
 				}
 			}]
+			description: [
+				"The Croparia Energy System is incompatible with other energy systems."
+				"This means that you need specific generators in order to power the Croparia Machines."
+				""
+				"Rain Panel:"
+				"Generates energy while it's raining."
+				""
+				"Depth Generator:"
+				"Generates more energy, the deeper this block is."
+				""
+				"Solar Panel:"
+				"Generates energy in daytime when it's sunny."
+				""
+				"Wind Generator:"
+				"Generates more energy, the higher this block is."
+				""
+				"Crop Generator:"
+				"Generates a bit of energy, when any crop in a 5x5 area around itself grows."
+			]
+			id: "5AEE472CF55E0E18"
+			x: 2.0d
+			y: 0.5d
+			title: "A Proprietary Power System"
+			dependencies: ["4FB9344EDC392CB0"]
 		}
 		{
-			title: "Energy Transport"
-			x: 2.0d
-			y: 1.5d
-			description: [
-				"You can use Croparia Copper Wires to transport energy from generators to machines."
-				"You can input energy on blue sides, and output it on top or bottom."
-				"The sides are fixed and not configurable."
-			]
-			dependencies: ["5AEE472CF55E0E18"]
-			id: "4B0B5A453BDD61E2"
 			tasks: [
 				{
 					id: "32EFCFB0C9A773E7"
@@ -1509,22 +1500,31 @@
 					item: "croparia:battery"
 				}
 			]
+			description: [
+				"You can use Croparia Copper Wires to transport energy from generators to machines."
+				"You can input energy on blue sides, and output it on top or bottom."
+				"The sides are fixed and not configurable."
+			]
+			id: "4B0B5A453BDD61E2"
+			x: 2.0d
+			y: 1.5d
+			title: "Energy Transport"
+			dependencies: ["5AEE472CF55E0E18"]
 		}
 		{
-			icon: "kubejs:info_mark"
-			x: -3.0d
-			y: -3.0d
-			shape: "circle"
-			subtitle: "The Seed Recycling recipes have been added to Modern Industrialization's Centrifuge."
-			description: ["Contrary to Croparia's Seed Recycler, is upgradeable, less buggy and compatible with easily-generatable EU!"]
-			dependencies: ["366ACE7F8E5E5C83"]
-			id: "6EB9FF4D7E730738"
 			tasks: [{
 				id: "67748D8357277FE5"
 				type: "checkmark"
 				title: "Seed Recycling"
 			}]
+			description: ["Contrary to Croparia's Seed Recycler, is upgradeable, less buggy and compatible with easily-generatable EU!"]
+			id: "6EB9FF4D7E730738"
+			icon: "kubejs:info_mark"
+			x: -3.0d
+			y: -3.0d
+			shape: "circle"
+			subtitle: "The Seed Recycling recipes have been added to Modern Industrialization's Centrifuge."
+			dependencies: ["366ACE7F8E5E5C83"]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/simple_storage_network.snbt
+++ b/config/ftbquests/quests/chapters/simple_storage_network.snbt
@@ -1,116 +1,120 @@
 {
-	id: "65B6805CC09093AB"
-	group: "33A417364C0A17FE"
-	order_index: 1
-	filename: "simple_storage_network"
-	title: "Simple Storage Network"
-	icon: "toms_storage:ts.inventory_connector"
-	default_quest_shape: ""
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "33A417364C0A17FE"
+	id: "65B6805CC09093AB"
+	filename: "simple_storage_network"
+	default_quest_shape: ""
+	icon: "toms_storage:ts.inventory_connector"
+	title: "Simple Storage Network"
+	order_index: 1
 	quests: [
 		{
-			x: -1.0d
-			y: 1.0d
+			size: 1.5d
 			description: [
 				"Connects all of the touching inventories into one."
 				"Closer inventories are prioritised both on insert and extract."
 			]
-			size: 1.5d
 			id: "7C76A579439D4EA9"
-			tasks: [{
-				id: "33449F39A9F31601"
-				type: "item"
-				item: "toms_storage:ts.inventory_connector"
-			}]
+			x: -1.0d
+			y: 1.0d
 			rewards: [{
 				id: "16CE74F6CBED339F"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			tasks: [{
+				id: "33449F39A9F31601"
+				type: "item"
+				item: "toms_storage:ts.inventory_connector"
+			}]
 		}
 		{
-			x: -1.0d
-			y: -1.0d
-			subtitle: "Connects different Inventory Network blocks together."
-			dependencies: ["7C76A579439D4EA9"]
-			id: "6F3B60946C6C21DF"
 			tasks: [{
 				id: "49AECA99525CB636"
 				type: "item"
 				item: "toms_storage:ts.inventory_cable"
 			}]
+			id: "6F3B60946C6C21DF"
+			x: -1.0d
+			y: -1.0d
 			rewards: [{
 				id: "689ADBF0E704C5DC"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Connects different Inventory Network blocks together."
+			dependencies: ["7C76A579439D4EA9"]
 		}
 		{
-			x: -1.0d
-			y: -2.5d
-			description: [
-				"Access all of your items stored on connected Inventories using this convenient grid."
-				""
-				"Place it on Inventory Connector (block or cable form)."
-			]
-			dependencies: ["6F3B60946C6C21DF"]
-			id: "0CB961291F0A9B12"
 			tasks: [{
 				id: "39A61AD7910BA650"
 				type: "item"
 				item: "toms_storage:ts.storage_terminal"
 			}]
+			description: [
+				"Access all of your items stored on connected Inventories using this convenient grid."
+				""
+				"Place it on Inventory Connector (block or cable form)."
+			]
+			id: "0CB961291F0A9B12"
+			x: -1.0d
+			y: -2.5d
 			rewards: [{
 				id: "520B2F0D6E3F3971"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["6F3B60946C6C21DF"]
 		}
 		{
-			x: -1.0d
-			y: -4.0d
-			description: [
-				"A Storage Terminal with a Crafting Table built into it!"
-				""
-				"Warning: Mass-crafting items can bring the server to halt due to constant lookup for recipes upon each craft."
-			]
-			dependencies: ["0CB961291F0A9B12"]
-			id: "70B0C5570698C366"
 			tasks: [{
 				id: "77E18145C09BB9B7"
 				type: "item"
 				item: "toms_storage:ts.crafting_terminal"
 			}]
+			description: [
+				"A Storage Terminal with a Crafting Table built into it!"
+				""
+				"Warning: Mass-crafting items can bring the server to halt due to constant lookup for recipes upon each craft."
+			]
+			id: "70B0C5570698C366"
+			x: -1.0d
+			y: -4.0d
 			rewards: [{
 				id: "13FE6C3E6AA1905D"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["0CB961291F0A9B12"]
 		}
 		{
-			x: -1.0d
-			y: -5.5d
-			description: [
-				"Hold in hand to be able to reach your Terminal up to 16 blocks."
-				""
-				"You can't reach Terminals through walls."
-			]
-			dependencies: ["70B0C5570698C366"]
-			id: "26703D9F698CED92"
 			tasks: [{
 				id: "11F034A6921505C7"
 				type: "item"
 				item: "toms_storage:ts.wireless_terminal"
 			}]
+			description: [
+				"Hold in hand to be able to reach your Terminal up to 16 blocks."
+				""
+				"You can't reach Terminals through walls."
+			]
+			id: "26703D9F698CED92"
+			x: -1.0d
+			y: -5.5d
 			rewards: [{
 				id: "69A39DB03B884E75"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["70B0C5570698C366"]
 		}
 		{
-			x: -1.0d
-			y: -7.0d
+			tasks: [{
+				id: "7B961890075AA289"
+				type: "item"
+				item: "toms_storage:ts.adv_wireless_terminal"
+			}]
 			description: [
 				"Enables remote access to your Terminal, up to 64 blocks, regardless of obstructions."
 				""
@@ -118,88 +122,77 @@
 				""
 				"If a level 4 (maxed) Beacon is within 8 blocks of the Terminal, you can access your Terminal cross-dimensionally!"
 			]
-			dependencies: ["26703D9F698CED92"]
 			id: "13323D65D14836E4"
-			tasks: [{
-				id: "7B961890075AA289"
-				type: "item"
-				item: "toms_storage:ts.adv_wireless_terminal"
-			}]
+			x: -1.0d
+			y: -7.0d
 			rewards: [{
 				id: "546DF49C3C0C181E"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["26703D9F698CED92"]
 		}
 		{
-			x: 0.5d
-			y: -1.5d
-			description: ["Connects a single Inventory to the Inventory Network."]
-			dependencies: ["6F3B60946C6C21DF"]
-			id: "31D39465E7B92A07"
 			tasks: [{
 				id: "4EB379759491F0C2"
 				type: "item"
 				item: "toms_storage:ts.inventory_cable_connector"
 			}]
+			description: ["Connects a single Inventory to the Inventory Network."]
+			id: "31D39465E7B92A07"
+			x: 0.5d
+			y: -1.5d
 			rewards: [{
 				id: "2B5924B098EAEB7A"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["6F3B60946C6C21DF"]
 		}
 		{
-			x: 0.5d
-			y: -0.5d
+			tasks: [{
+				id: "1CE75114F63FE818"
+				type: "item"
+				item: "toms_storage:ts.inventory_hopper_basic"
+			}]
 			description: [
 				"Can import or export from the Inventory System."
 				"Can be filtered by Right-Clicking the hopper with an item."
 				""
 				"A bit slower than the vanilla Hopper."
 			]
-			dependencies: ["6F3B60946C6C21DF"]
 			id: "7AEB5D8D3250F219"
-			tasks: [{
-				id: "1CE75114F63FE818"
-				type: "item"
-				item: "toms_storage:ts.inventory_hopper_basic"
-			}]
+			x: 0.5d
+			y: -0.5d
 			rewards: [{
 				id: "56D0EB95246C63FB"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["6F3B60946C6C21DF"]
 		}
 		{
-			x: -2.5d
-			y: -0.5d
-			description: [
-				"Emits a redstone signal based on Inventory Network contents."
-				""
-				"Very similar to AE2 Device with the same name."
-			]
-			dependencies: ["6F3B60946C6C21DF"]
-			id: "3623FC7755A25338"
 			tasks: [{
 				id: "3A06775DD80F24CA"
 				type: "item"
 				item: "toms_storage:ts.level_emitter"
 			}]
+			description: [
+				"Emits a redstone signal based on Inventory Network contents."
+				""
+				"Very similar to AE2 Device with the same name."
+			]
+			id: "3623FC7755A25338"
+			x: -2.5d
+			y: -0.5d
 			rewards: [{
 				id: "1D49A18663A7728B"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["6F3B60946C6C21DF"]
 		}
 		{
-			x: 0.5d
-			y: 1.0d
-			description: [
-				"Can paint Framed Inventory Cables, disguising them as other blocks."
-				"Shift-Right Click on a block to paint with it."
-			]
-			dependencies: ["7C76A579439D4EA9"]
-			id: "14825318A41F3BDA"
 			tasks: [{
 				id: "2E5E890171F02E0E"
 				type: "item"
@@ -211,50 +204,57 @@
 					}
 				}
 			}]
+			description: [
+				"Can paint Framed Inventory Cables, disguising them as other blocks."
+				"Shift-Right Click on a block to paint with it."
+			]
+			id: "14825318A41F3BDA"
+			x: 0.5d
+			y: 1.0d
 			rewards: [{
 				id: "746767503190636A"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7C76A579439D4EA9"]
 		}
 		{
-			x: -2.5d
-			y: -1.5d
-			description: ["Can be used instead of inventory to connect distant Inventories together."]
-			dependencies: ["6F3B60946C6C21DF"]
-			id: "5FFAEA8608882D68"
 			tasks: [{
 				id: "48305ABF0B7DB387"
 				type: "item"
 				item: "toms_storage:ts.trim"
 			}]
+			description: ["Can be used instead of inventory to connect distant Inventories together."]
+			id: "5FFAEA8608882D68"
+			x: -2.5d
+			y: -1.5d
 			rewards: [{
 				id: "64C0363BBC782E4C"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["6F3B60946C6C21DF"]
 		}
 		{
-			x: -2.5d
-			y: 1.0d
-			description: [
-				"Extends the faces of the inventory this block points at."
-				""
-				"Useful, if you are tight on space or you just wanted to output from a single inventory using multiple Hoppers."
-			]
-			dependencies: ["7C76A579439D4EA9"]
-			id: "361ADFDACDA99035"
 			tasks: [{
 				id: "027B393966C2EBEB"
 				type: "item"
 				item: "toms_storage:ts.inventory_proxy"
 			}]
+			description: [
+				"Extends the faces of the inventory this block points at."
+				""
+				"Useful, if you are tight on space or you just wanted to output from a single inventory using multiple Hoppers."
+			]
+			id: "361ADFDACDA99035"
+			x: -2.5d
+			y: 1.0d
 			rewards: [{
 				id: "0E53C70C6ECC3BF6"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["7C76A579439D4EA9"]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/spatial_harvesters.snbt
+++ b/config/ftbquests/quests/chapters/spatial_harvesters.snbt
@@ -1,58 +1,59 @@
 {
-	id: "3FA09F995A9C2E78"
+	quest_links: [ ]
+	default_hide_dependency_lines: false
 	group: "5A79AA7D1974C9A9"
-	order_index: 0
+	id: "3FA09F995A9C2E78"
 	filename: "spatial_harvesters"
-	title: "Spatial Harvesters"
+	default_quest_shape: ""
 	icon: {
 		id: "spatialharvesters:ore_harvester_8"
 		Count: 1b
 		tag: { }
 	}
-	default_quest_shape: ""
-	default_hide_dependency_lines: false
+	title: "Spatial Harvesters"
+	order_index: 0
 	quests: [
 		{
-			x: -1.0d
-			y: -3.5d
-			subtitle: "Required to make Spatial Harvesters."
-			dependencies: ["432F1A4732E73037"]
 			size: 1.5d
 			id: "45A82DB03F64C6F3"
-			tasks: [{
-				id: "65407A0EEBAE9906"
-				type: "item"
-				item: "spatialharvesters:casing"
-			}]
+			x: -1.0d
+			y: -3.5d
 			rewards: [{
 				id: "5B2C76810F0CBC27"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Required to make Spatial Harvesters."
+			dependencies: ["432F1A4732E73037"]
+			tasks: [{
+				id: "65407A0EEBAE9906"
+				type: "item"
+				item: "spatialharvesters:casing"
+			}]
 		}
 		{
-			disable_toast: true
-			x: -1.0d
-			y: -5.0d
-			subtitle: "A Quantum Circuit is required to assemble Spatial Harvesters' Casings."
-			dependencies: ["363455215C23E84E"]
-			id: "432F1A4732E73037"
 			tasks: [{
 				id: "66B1060C4701D323"
 				type: "item"
 				item: "modern_industrialization:quantum_circuit"
 			}]
+			x: -1.0d
+			id: "432F1A4732E73037"
+			disable_toast: true
+			y: -5.0d
+			subtitle: "A Quantum Circuit is required to assemble Spatial Harvesters' Casings."
+			dependencies: ["363455215C23E84E"]
 		}
 		{
-			x: -2.0d
-			y: -2.0d
-			id: "4CEF6567080ACA79"
 			tasks: [{
 				id: "5C82AA2461ECFD37"
 				type: "item"
 				item: "spatialharvesters:ore_core"
 			}]
+			id: "4CEF6567080ACA79"
+			y: -2.0d
+			x: -2.0d
 			rewards: [{
 				id: "2A2FA497FB86B0C0"
 				type: "random"
@@ -61,14 +62,14 @@
 			}]
 		}
 		{
-			x: -1.0d
-			y: -2.0d
-			id: "5CEEEA572C7370C8"
 			tasks: [{
 				id: "22BC9F4808E1F444"
 				type: "item"
 				item: "spatialharvesters:bio_core"
 			}]
+			id: "5CEEEA572C7370C8"
+			y: -2.0d
+			x: -1.0d
 			rewards: [{
 				id: "5F5074065CA3329F"
 				type: "random"
@@ -77,14 +78,14 @@
 			}]
 		}
 		{
-			x: 0.0d
-			y: -2.0d
-			id: "3527AC6DD13A51B3"
 			tasks: [{
 				id: "77846F29AA8E858F"
 				type: "item"
 				item: "spatialharvesters:stone_core"
 			}]
+			id: "3527AC6DD13A51B3"
+			y: -2.0d
+			x: 0.0d
 			rewards: [{
 				id: "22ABFF4A574F326F"
 				type: "random"
@@ -93,14 +94,14 @@
 			}]
 		}
 		{
-			x: 1.0d
-			y: -2.0d
-			id: "0007683B85C5D429"
 			tasks: [{
 				id: "1EA45163E7771181"
 				type: "item"
 				item: "spatialharvesters:soil_core"
 			}]
+			id: "0007683B85C5D429"
+			y: -2.0d
+			x: 1.0d
 			rewards: [{
 				id: "7DEA891CE1F48C20"
 				type: "random"
@@ -109,15 +110,15 @@
 			}]
 		}
 		{
-			x: 2.5d
-			y: 3.5d
-			subtitle: "A Neutronium Nugget is required to craft this item."
-			id: "3E17651799AF2546"
 			tasks: [{
 				id: "72A113FAD8AB99EE"
 				type: "item"
 				item: "spatialharvesters:loot_core"
 			}]
+			subtitle: "A Neutronium Nugget is required to craft this item."
+			id: "3E17651799AF2546"
+			y: 3.5d
+			x: 2.5d
 			rewards: [{
 				id: "5059C09741004BC0"
 				type: "random"
@@ -126,14 +127,14 @@
 			}]
 		}
 		{
-			x: 2.5d
-			y: -2.0d
-			id: "69DD3E95BDB5E400"
 			tasks: [{
 				id: "7AE921BE2184E25A"
 				type: "item"
 				item: "spatialharvesters:mob_core"
 			}]
+			id: "69DD3E95BDB5E400"
+			y: -2.0d
+			x: 2.5d
 			rewards: [{
 				id: "4EC074449E66AE93"
 				type: "random"
@@ -142,14 +143,14 @@
 			}]
 		}
 		{
-			x: 3.5d
-			y: 2.0d
-			id: "279BF2C329E9D9DF"
 			tasks: [{
 				id: "3FD913361865C11B"
 				type: "item"
 				item: "spatialharvesters:dark_mob_core"
 			}]
+			id: "279BF2C329E9D9DF"
+			y: 2.0d
+			x: 3.5d
 			rewards: [{
 				id: "404B93501F55ADB1"
 				type: "random"
@@ -158,18 +159,6 @@
 			}]
 		}
 		{
-			x: -2.0d
-			y: -1.0d
-			subtitle: "Generates every ore in the game!"
-			description: [
-				"Generates every 400 ticks (or 20 seconds)."
-				""
-				"Uses 400 E per generated item."
-				""
-				"Average consumption: 1 E/t."
-			]
-			dependencies: ["4CEF6567080ACA79"]
-			id: "6402400F5F40CF37"
 			tasks: [{
 				id: "569004595B937E91"
 				type: "item"
@@ -179,29 +168,26 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 400 ticks (or 20 seconds)."
+				""
+				"Uses 400 E per generated item."
+				""
+				"Average consumption: 1 E/t."
+			]
+			id: "6402400F5F40CF37"
+			x: -2.0d
+			y: -1.0d
 			rewards: [{
 				id: "7D14AA205D3F62C3"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates every ore in the game!"
+			dependencies: ["4CEF6567080ACA79"]
 		}
 		{
-			x: -2.0d
-			y: 0.0d
-			subtitle: "Generates every ore in the game!"
-			description: [
-				"Generates every 350 ticks (or 17.5 seconds)."
-				""
-				"Uses 600 E per generated item."
-				""
-				"Average consumption: 1.71 E/t."
-			]
-			dependencies: [
-				"6402400F5F40CF37"
-				"2B2FFD6B5333EAF3"
-			]
-			id: "0E53685ECFC4C1CF"
 			tasks: [{
 				id: "216727C0B03800FC"
 				type: "item"
@@ -211,29 +197,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 350 ticks (or 17.5 seconds)."
+				""
+				"Uses 600 E per generated item."
+				""
+				"Average consumption: 1.71 E/t."
+			]
+			id: "0E53685ECFC4C1CF"
+			x: -2.0d
+			y: 0.0d
 			rewards: [{
 				id: "50EB606362FD3D19"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates every ore in the game!"
+			dependencies: [
+				"6402400F5F40CF37"
+				"2B2FFD6B5333EAF3"
+			]
 		}
 		{
-			x: -2.0d
-			y: 1.0d
-			subtitle: "Generates every ore in the game!"
-			description: [
-				"Generates every 300 ticks (or 15 seconds)."
-				""
-				"Uses 1000 E per generated item."
-				""
-				"Average consumption: 3.33 E/t."
-			]
-			dependencies: [
-				"0E53685ECFC4C1CF"
-				"29C1E30A9260BC71"
-			]
-			id: "3E04366C15960FDC"
 			tasks: [{
 				id: "256279E38D0A4B96"
 				type: "item"
@@ -243,29 +229,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 300 ticks (or 15 seconds)."
+				""
+				"Uses 1000 E per generated item."
+				""
+				"Average consumption: 3.33 E/t."
+			]
+			id: "3E04366C15960FDC"
+			x: -2.0d
+			y: 1.0d
 			rewards: [{
 				id: "56034C21A47211B3"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates every ore in the game!"
+			dependencies: [
+				"0E53685ECFC4C1CF"
+				"29C1E30A9260BC71"
+			]
 		}
 		{
-			x: -2.0d
-			y: 2.0d
-			subtitle: "Generates every ore in the game!"
-			description: [
-				"Generates every 250 ticks (or 12.5 seconds)."
-				""
-				"Uses 1500 E per generated item."
-				""
-				"Average consumption: 6 E/t."
-			]
-			dependencies: [
-				"3E04366C15960FDC"
-				"58226D1F08683EB5"
-			]
-			id: "7336B45C0EB22709"
 			tasks: [{
 				id: "0085CB977C5B7CEB"
 				type: "item"
@@ -275,29 +261,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 250 ticks (or 12.5 seconds)."
+				""
+				"Uses 1500 E per generated item."
+				""
+				"Average consumption: 6 E/t."
+			]
+			id: "7336B45C0EB22709"
+			x: -2.0d
+			y: 2.0d
 			rewards: [{
 				id: "7C9B4DD874FD5356"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates every ore in the game!"
+			dependencies: [
+				"3E04366C15960FDC"
+				"58226D1F08683EB5"
+			]
 		}
 		{
-			x: -2.0d
-			y: 3.0d
-			subtitle: "Generates every ore in the game!"
-			description: [
-				"Generates every 200 ticks (or 10 seconds)."
-				""
-				"Uses 4000 E per generated item."
-				""
-				"Average consumption: 20 E/t."
-			]
-			dependencies: [
-				"7336B45C0EB22709"
-				"446A5E8AAB0DE2AE"
-			]
-			id: "2F744D5C38C727F0"
 			tasks: [{
 				id: "35FAD285CD4428D8"
 				type: "item"
@@ -307,29 +293,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 200 ticks (or 10 seconds)."
+				""
+				"Uses 4000 E per generated item."
+				""
+				"Average consumption: 20 E/t."
+			]
+			id: "2F744D5C38C727F0"
+			x: -2.0d
+			y: 3.0d
 			rewards: [{
 				id: "07A0F319259B96F3"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates every ore in the game!"
+			dependencies: [
+				"7336B45C0EB22709"
+				"446A5E8AAB0DE2AE"
+			]
 		}
 		{
-			x: -2.0d
-			y: 4.0d
-			subtitle: "Generates every ore in the game!"
-			description: [
-				"Generates every 150 ticks (or 7.5 seconds)."
-				""
-				"Uses 7000 E per generated item."
-				""
-				"Average consumption: 46.67 E/t."
-			]
-			dependencies: [
-				"2F744D5C38C727F0"
-				"3443B551C3A65130"
-			]
-			id: "392518EDE405BF33"
 			tasks: [{
 				id: "1BAD38D580E892AF"
 				type: "item"
@@ -339,29 +325,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 150 ticks (or 7.5 seconds)."
+				""
+				"Uses 7000 E per generated item."
+				""
+				"Average consumption: 46.67 E/t."
+			]
+			id: "392518EDE405BF33"
+			x: -2.0d
+			y: 4.0d
 			rewards: [{
 				id: "27016FF351E17354"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates every ore in the game!"
+			dependencies: [
+				"2F744D5C38C727F0"
+				"3443B551C3A65130"
+			]
 		}
 		{
-			x: -2.0d
-			y: 5.0d
-			subtitle: "Generates every ore in the game!"
-			description: [
-				"Generates every 100 ticks (or 5 seconds)."
-				""
-				"Uses 7500 E per generated item."
-				""
-				"Average consumption: 75 E/t."
-			]
-			dependencies: [
-				"392518EDE405BF33"
-				"75B77AC8911A5A57"
-			]
-			id: "553E973F8A8E6889"
 			tasks: [{
 				id: "5B57BF5D7E3B440B"
 				type: "item"
@@ -371,29 +357,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 100 ticks (or 5 seconds)."
+				""
+				"Uses 7500 E per generated item."
+				""
+				"Average consumption: 75 E/t."
+			]
+			id: "553E973F8A8E6889"
+			x: -2.0d
+			y: 5.0d
 			rewards: [{
 				id: "36BB5E359D8E2663"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates every ore in the game!"
+			dependencies: [
+				"392518EDE405BF33"
+				"75B77AC8911A5A57"
+			]
 		}
 		{
-			x: -2.0d
-			y: 6.0d
-			subtitle: "Generates every ore in the game!"
-			description: [
-				"Generates every 5 ticks (or 0.25 seconds)."
-				""
-				"Uses 8000 E per generated item."
-				""
-				"Average consumption: 1600 E/t."
-			]
-			dependencies: [
-				"553E973F8A8E6889"
-				"1D64053A738C877A"
-			]
-			id: "66C4872AD36B57DE"
 			tasks: [{
 				id: "30E063440C4C4C58"
 				type: "item"
@@ -403,17 +389,38 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 5 ticks (or 0.25 seconds)."
+				""
+				"Uses 8000 E per generated item."
+				""
+				"Average consumption: 1600 E/t."
+			]
+			id: "66C4872AD36B57DE"
+			x: -2.0d
+			y: 6.0d
 			rewards: [{
 				id: "07DCB7E12D935058"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates every ore in the game!"
+			dependencies: [
+				"553E973F8A8E6889"
+				"1D64053A738C877A"
+			]
 		}
 		{
-			x: -1.0d
-			y: -1.0d
-			subtitle: "Generates various organic items."
+			tasks: [{
+				id: "276120D3428C84DF"
+				type: "item"
+				item: {
+					id: "spatialharvesters:bio_harvester_1"
+					Count: 1b
+					tag: { }
+				}
+			}]
 			description: [
 				"Generates:"
 				""
@@ -437,39 +444,19 @@
 				""
 				"Average consumption: 1 E/t."
 			]
-			dependencies: ["5CEEEA572C7370C8"]
 			id: "7441BC53B18AF8F0"
-			tasks: [{
-				id: "276120D3428C84DF"
-				type: "item"
-				item: {
-					id: "spatialharvesters:bio_harvester_1"
-					Count: 1b
-					tag: { }
-				}
-			}]
+			x: -1.0d
+			y: -1.0d
 			rewards: [{
 				id: "28699EED5C5492CA"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates various organic items."
+			dependencies: ["5CEEEA572C7370C8"]
 		}
 		{
-			x: -1.0d
-			y: 0.0d
-			subtitle: "Generates various organic items."
-			description: [
-				"Generates every 350 ticks (or 17.5 seconds)."
-				""
-				"Uses 600 E per generated item."
-				"Average consumption: 1.71 E/t."
-			]
-			dependencies: [
-				"7441BC53B18AF8F0"
-				"2B2FFD6B5333EAF3"
-			]
-			id: "567F0904EC32FC46"
 			tasks: [{
 				id: "3A09C3EB0C1DB263"
 				type: "item"
@@ -479,29 +466,28 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 350 ticks (or 17.5 seconds)."
+				""
+				"Uses 600 E per generated item."
+				"Average consumption: 1.71 E/t."
+			]
+			id: "567F0904EC32FC46"
+			x: -1.0d
+			y: 0.0d
 			rewards: [{
 				id: "2CC4D2D8A872A89D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates various organic items."
+			dependencies: [
+				"7441BC53B18AF8F0"
+				"2B2FFD6B5333EAF3"
+			]
 		}
 		{
-			x: -1.0d
-			y: 1.0d
-			subtitle: "Generates various organic items."
-			description: [
-				"Generates every 300 ticks (or 15 seconds)."
-				""
-				"Uses 1000 E per generated item."
-				""
-				"Average consumption: 3.33 E/t."
-			]
-			dependencies: [
-				"567F0904EC32FC46"
-				"29C1E30A9260BC71"
-			]
-			id: "549CCCB73B700D04"
 			tasks: [{
 				id: "4C93E24CD96B2CC3"
 				type: "item"
@@ -511,29 +497,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 300 ticks (or 15 seconds)."
+				""
+				"Uses 1000 E per generated item."
+				""
+				"Average consumption: 3.33 E/t."
+			]
+			id: "549CCCB73B700D04"
+			x: -1.0d
+			y: 1.0d
 			rewards: [{
 				id: "4ECD479DE68A4824"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates various organic items."
+			dependencies: [
+				"567F0904EC32FC46"
+				"29C1E30A9260BC71"
+			]
 		}
 		{
-			x: -1.0d
-			y: 2.0d
-			subtitle: "Generates various organic items."
-			description: [
-				"Generates every 250 ticks (or 12.5 seconds)."
-				""
-				"Uses 1500 E per generated item."
-				""
-				"Average consumption: 6 E/t."
-			]
-			dependencies: [
-				"549CCCB73B700D04"
-				"58226D1F08683EB5"
-			]
-			id: "364280C8FE027ED4"
 			tasks: [{
 				id: "770C7E1A907D6440"
 				type: "item"
@@ -543,29 +529,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 250 ticks (or 12.5 seconds)."
+				""
+				"Uses 1500 E per generated item."
+				""
+				"Average consumption: 6 E/t."
+			]
+			id: "364280C8FE027ED4"
+			x: -1.0d
+			y: 2.0d
 			rewards: [{
 				id: "70436C9824717586"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates various organic items."
+			dependencies: [
+				"549CCCB73B700D04"
+				"58226D1F08683EB5"
+			]
 		}
 		{
-			x: -1.0d
-			y: 3.0d
-			subtitle: "Generates various organic items."
-			description: [
-				"Generates every 200 ticks (or 10 seconds)."
-				""
-				"Uses 4000 E per generated item."
-				""
-				"Average consumption: 20 E/t."
-			]
-			dependencies: [
-				"364280C8FE027ED4"
-				"446A5E8AAB0DE2AE"
-			]
-			id: "5C6F3AE8D028BA2A"
 			tasks: [{
 				id: "0A726C64FCEE88E9"
 				type: "item"
@@ -575,29 +561,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 200 ticks (or 10 seconds)."
+				""
+				"Uses 4000 E per generated item."
+				""
+				"Average consumption: 20 E/t."
+			]
+			id: "5C6F3AE8D028BA2A"
+			x: -1.0d
+			y: 3.0d
 			rewards: [{
 				id: "67461E61C7347421"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates various organic items."
+			dependencies: [
+				"364280C8FE027ED4"
+				"446A5E8AAB0DE2AE"
+			]
 		}
 		{
-			x: -1.0d
-			y: 4.0d
-			subtitle: "Generates various organic items."
-			description: [
-				"Generates every 150 ticks (or 7.5 seconds)."
-				""
-				"Uses 7000 E per generated item."
-				""
-				"Average consumption: 46.67 E/t."
-			]
-			dependencies: [
-				"5C6F3AE8D028BA2A"
-				"3443B551C3A65130"
-			]
-			id: "3B57275DF8614D64"
 			tasks: [{
 				id: "766DE3E6EF4E02D5"
 				type: "item"
@@ -607,29 +593,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 150 ticks (or 7.5 seconds)."
+				""
+				"Uses 7000 E per generated item."
+				""
+				"Average consumption: 46.67 E/t."
+			]
+			id: "3B57275DF8614D64"
+			x: -1.0d
+			y: 4.0d
 			rewards: [{
 				id: "519F8F0E7D04FF43"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates various organic items."
+			dependencies: [
+				"5C6F3AE8D028BA2A"
+				"3443B551C3A65130"
+			]
 		}
 		{
-			x: -1.0d
-			y: 5.0d
-			subtitle: "Generates various organic items."
-			description: [
-				"Generates every 100 ticks (or 5 seconds)."
-				""
-				"Uses 7500 E per generated item."
-				""
-				"Average consumption: 75 E/t."
-			]
-			dependencies: [
-				"3B57275DF8614D64"
-				"75B77AC8911A5A57"
-			]
-			id: "5C2995E356239D8B"
 			tasks: [{
 				id: "7BED190E6106AC72"
 				type: "item"
@@ -639,29 +625,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 100 ticks (or 5 seconds)."
+				""
+				"Uses 7500 E per generated item."
+				""
+				"Average consumption: 75 E/t."
+			]
+			id: "5C2995E356239D8B"
+			x: -1.0d
+			y: 5.0d
 			rewards: [{
 				id: "433A16E7E5969532"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates various organic items."
+			dependencies: [
+				"3B57275DF8614D64"
+				"75B77AC8911A5A57"
+			]
 		}
 		{
-			x: -1.0d
-			y: 6.0d
-			subtitle: "Generates various organic items."
-			description: [
-				"Generates every 5 ticks (or 0.25 seconds)."
-				""
-				"Uses 8000 E per generated item."
-				""
-				"Average consumption: 1600 E/t."
-			]
-			dependencies: [
-				"5C2995E356239D8B"
-				"1D64053A738C877A"
-			]
-			id: "0626A214491254DD"
 			tasks: [{
 				id: "22FB0AA63D1F6AF9"
 				type: "item"
@@ -671,26 +657,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 5 ticks (or 0.25 seconds)."
+				""
+				"Uses 8000 E per generated item."
+				""
+				"Average consumption: 1600 E/t."
+			]
+			id: "0626A214491254DD"
+			x: -1.0d
+			y: 6.0d
 			rewards: [{
 				id: "363970EB39E4B220"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates various organic items."
+			dependencies: [
+				"5C2995E356239D8B"
+				"1D64053A738C877A"
+			]
 		}
 		{
-			x: 0.0d
-			y: -1.0d
-			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
-			description: [
-				"Generates every 400 ticks (or 20 seconds)."
-				""
-				"Uses 400 E per generated item."
-				""
-				"Average consumption: 1 E/t."
-			]
-			dependencies: ["3527AC6DD13A51B3"]
-			id: "12866716DDB31F3D"
 			tasks: [{
 				id: "453F63569AFACB9B"
 				type: "item"
@@ -700,29 +689,26 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 400 ticks (or 20 seconds)."
+				""
+				"Uses 400 E per generated item."
+				""
+				"Average consumption: 1 E/t."
+			]
+			id: "12866716DDB31F3D"
+			x: 0.0d
+			y: -1.0d
 			rewards: [{
 				id: "7D51A5FA49C66700"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
+			dependencies: ["3527AC6DD13A51B3"]
 		}
 		{
-			x: 0.0d
-			y: 0.0d
-			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
-			description: [
-				"Generates every 350 ticks (or 17.5 seconds)."
-				""
-				"Uses 600 E per generated item."
-				""
-				"Average consumption: 1.71 E/t."
-			]
-			dependencies: [
-				"12866716DDB31F3D"
-				"2B2FFD6B5333EAF3"
-			]
-			id: "229E25830538A686"
 			tasks: [{
 				id: "53DC6F71F156BFFA"
 				type: "item"
@@ -732,29 +718,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 350 ticks (or 17.5 seconds)."
+				""
+				"Uses 600 E per generated item."
+				""
+				"Average consumption: 1.71 E/t."
+			]
+			id: "229E25830538A686"
+			x: 0.0d
+			y: 0.0d
 			rewards: [{
 				id: "754E4DA4EB80CE66"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
+			dependencies: [
+				"12866716DDB31F3D"
+				"2B2FFD6B5333EAF3"
+			]
 		}
 		{
-			x: 0.0d
-			y: 1.0d
-			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
-			description: [
-				"Generates every 300 ticks (or 15 seconds)."
-				""
-				"Uses 1000 E per generated item."
-				""
-				"Average consumption: 3.33 E/t."
-			]
-			dependencies: [
-				"229E25830538A686"
-				"29C1E30A9260BC71"
-			]
-			id: "682E67ED3061BC66"
 			tasks: [{
 				id: "33102AECB0272DDA"
 				type: "item"
@@ -764,29 +750,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 300 ticks (or 15 seconds)."
+				""
+				"Uses 1000 E per generated item."
+				""
+				"Average consumption: 3.33 E/t."
+			]
+			id: "682E67ED3061BC66"
+			x: 0.0d
+			y: 1.0d
 			rewards: [{
 				id: "77ABA5515DBD9604"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
+			dependencies: [
+				"229E25830538A686"
+				"29C1E30A9260BC71"
+			]
 		}
 		{
-			x: 0.0d
-			y: 2.0d
-			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
-			description: [
-				"Generates every 250 ticks (or 12.5 seconds)."
-				""
-				"Uses 1500 E per generated item."
-				""
-				"Average consumption: 6 E/t."
-			]
-			dependencies: [
-				"682E67ED3061BC66"
-				"58226D1F08683EB5"
-			]
-			id: "0974E1AC3971B5AD"
 			tasks: [{
 				id: "273654540DA2B9E8"
 				type: "item"
@@ -796,29 +782,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 250 ticks (or 12.5 seconds)."
+				""
+				"Uses 1500 E per generated item."
+				""
+				"Average consumption: 6 E/t."
+			]
+			id: "0974E1AC3971B5AD"
+			x: 0.0d
+			y: 2.0d
 			rewards: [{
 				id: "1C05712836D31D1D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
+			dependencies: [
+				"682E67ED3061BC66"
+				"58226D1F08683EB5"
+			]
 		}
 		{
-			x: 0.0d
-			y: 3.0d
-			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
-			description: [
-				"Generates every 200 ticks (or 10 seconds)."
-				""
-				"Uses 4000 E per generated item."
-				""
-				"Average consumption: 20 E/t."
-			]
-			dependencies: [
-				"0974E1AC3971B5AD"
-				"446A5E8AAB0DE2AE"
-			]
-			id: "4F7D37E42D87709D"
 			tasks: [{
 				id: "26B46C01A358D6DA"
 				type: "item"
@@ -828,29 +814,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 200 ticks (or 10 seconds)."
+				""
+				"Uses 4000 E per generated item."
+				""
+				"Average consumption: 20 E/t."
+			]
+			id: "4F7D37E42D87709D"
+			x: 0.0d
+			y: 3.0d
 			rewards: [{
 				id: "4921730EDED51C48"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
+			dependencies: [
+				"0974E1AC3971B5AD"
+				"446A5E8AAB0DE2AE"
+			]
 		}
 		{
-			x: 0.0d
-			y: 4.0d
-			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
-			description: [
-				"Generates every 150 ticks (or 7.5 seconds)."
-				""
-				"Uses 7000 E per generated item."
-				""
-				"Average consumption: 46.67 E/t."
-			]
-			dependencies: [
-				"4F7D37E42D87709D"
-				"3443B551C3A65130"
-			]
-			id: "1FF684D69AF9A8E8"
 			tasks: [{
 				id: "3FB0C689AA1FF2F9"
 				type: "item"
@@ -860,29 +846,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 150 ticks (or 7.5 seconds)."
+				""
+				"Uses 7000 E per generated item."
+				""
+				"Average consumption: 46.67 E/t."
+			]
+			id: "1FF684D69AF9A8E8"
+			x: 0.0d
+			y: 4.0d
 			rewards: [{
 				id: "20C517C95D241A2F"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
+			dependencies: [
+				"4F7D37E42D87709D"
+				"3443B551C3A65130"
+			]
 		}
 		{
-			x: 0.0d
-			y: 5.0d
-			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
-			description: [
-				"Generates every 100 ticks (or 5 seconds)."
-				""
-				"Uses 7500 E per generated item."
-				""
-				"Average consumption: 75 E/t."
-			]
-			dependencies: [
-				"1FF684D69AF9A8E8"
-				"75B77AC8911A5A57"
-			]
-			id: "50A96EDA711681EF"
 			tasks: [{
 				id: "1543343758B2A707"
 				type: "item"
@@ -892,29 +878,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 100 ticks (or 5 seconds)."
+				""
+				"Uses 7500 E per generated item."
+				""
+				"Average consumption: 75 E/t."
+			]
+			id: "50A96EDA711681EF"
+			x: 0.0d
+			y: 5.0d
 			rewards: [{
 				id: "3C561DC431C9D2A5"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
+			dependencies: [
+				"1FF684D69AF9A8E8"
+				"75B77AC8911A5A57"
+			]
 		}
 		{
-			x: 0.0d
-			y: 6.0d
-			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
-			description: [
-				"Generates every 5 ticks (or 0.25 seconds)."
-				""
-				"Uses 8000 E per generated item."
-				""
-				"Average consumption: 1600 E/t."
-			]
-			dependencies: [
-				"50A96EDA711681EF"
-				"1D64053A738C877A"
-			]
-			id: "63D7E4101B7E304A"
 			tasks: [{
 				id: "5DA7B7C92795958F"
 				type: "item"
@@ -924,26 +910,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 5 ticks (or 0.25 seconds)."
+				""
+				"Uses 8000 E per generated item."
+				""
+				"Average consumption: 1600 E/t."
+			]
+			id: "63D7E4101B7E304A"
+			x: 0.0d
+			y: 6.0d
 			rewards: [{
 				id: "19FDFDCD1377EED1"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Cobblestone, Sandstone, End Stone and Netherrack."
+			dependencies: [
+				"50A96EDA711681EF"
+				"1D64053A738C877A"
+			]
 		}
 		{
-			x: 1.0d
-			y: -1.0d
-			subtitle: "Generates Dirt, Sand and Gravel."
-			description: [
-				"Generates every 400 ticks (or 20 seconds)."
-				""
-				"Uses 400 E per generated item."
-				""
-				"Average consumption: 1 E/t."
-			]
-			dependencies: ["0007683B85C5D429"]
-			id: "40C204D921B2D3A5"
 			tasks: [{
 				id: "51F834FCF16A77CB"
 				type: "item"
@@ -953,29 +942,26 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 400 ticks (or 20 seconds)."
+				""
+				"Uses 400 E per generated item."
+				""
+				"Average consumption: 1 E/t."
+			]
+			id: "40C204D921B2D3A5"
+			x: 1.0d
+			y: -1.0d
 			rewards: [{
 				id: "3C5A5C9E43885DF0"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Dirt, Sand and Gravel."
+			dependencies: ["0007683B85C5D429"]
 		}
 		{
-			x: 1.0d
-			y: 0.0d
-			subtitle: "Generates Dirt, Sand and Gravel."
-			description: [
-				"Generates every 350 ticks (or 17.5 seconds)."
-				""
-				"Uses 600 E per generated item."
-				""
-				"Average consumption: 1.71 E/t."
-			]
-			dependencies: [
-				"40C204D921B2D3A5"
-				"2B2FFD6B5333EAF3"
-			]
-			id: "7E24BD2D97F8D1DB"
 			tasks: [{
 				id: "0D6EA11B6EE54472"
 				type: "item"
@@ -985,29 +971,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 350 ticks (or 17.5 seconds)."
+				""
+				"Uses 600 E per generated item."
+				""
+				"Average consumption: 1.71 E/t."
+			]
+			id: "7E24BD2D97F8D1DB"
+			x: 1.0d
+			y: 0.0d
 			rewards: [{
 				id: "17EA9FAA6F23E224"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Dirt, Sand and Gravel."
+			dependencies: [
+				"40C204D921B2D3A5"
+				"2B2FFD6B5333EAF3"
+			]
 		}
 		{
-			x: 1.0d
-			y: 1.0d
-			subtitle: "Generates Dirt, Sand and Gravel."
-			description: [
-				"Generates every 300 ticks (or 15 seconds)."
-				""
-				"Uses 1000 E per generated item."
-				""
-				"Average consumption: 3.33 E/t."
-			]
-			dependencies: [
-				"7E24BD2D97F8D1DB"
-				"29C1E30A9260BC71"
-			]
-			id: "1BD7BC07DC0D0485"
 			tasks: [{
 				id: "0B827BA51228656B"
 				type: "item"
@@ -1017,29 +1003,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 300 ticks (or 15 seconds)."
+				""
+				"Uses 1000 E per generated item."
+				""
+				"Average consumption: 3.33 E/t."
+			]
+			id: "1BD7BC07DC0D0485"
+			x: 1.0d
+			y: 1.0d
 			rewards: [{
 				id: "05C7E8E396AAFE83"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Dirt, Sand and Gravel."
+			dependencies: [
+				"7E24BD2D97F8D1DB"
+				"29C1E30A9260BC71"
+			]
 		}
 		{
-			x: 1.0d
-			y: 2.0d
-			subtitle: "Generates Dirt, Sand and Gravel."
-			description: [
-				"Generates every 250 ticks (or 12.5 seconds)."
-				""
-				"Uses 1500 E per generated item."
-				""
-				"Average consumption: 6 E/t."
-			]
-			dependencies: [
-				"1BD7BC07DC0D0485"
-				"58226D1F08683EB5"
-			]
-			id: "7648FD025997ABD4"
 			tasks: [{
 				id: "2E9D646EA43AD3E6"
 				type: "item"
@@ -1049,29 +1035,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 250 ticks (or 12.5 seconds)."
+				""
+				"Uses 1500 E per generated item."
+				""
+				"Average consumption: 6 E/t."
+			]
+			id: "7648FD025997ABD4"
+			x: 1.0d
+			y: 2.0d
 			rewards: [{
 				id: "3338FCB11ED6E2F3"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Dirt, Sand and Gravel."
+			dependencies: [
+				"1BD7BC07DC0D0485"
+				"58226D1F08683EB5"
+			]
 		}
 		{
-			x: 1.0d
-			y: 3.0d
-			subtitle: "Generates Dirt, Sand and Gravel."
-			description: [
-				"Generates every 200 ticks (or 10 seconds)."
-				""
-				"Uses 4000 E per generated item."
-				""
-				"Average consumption: 20 E/t."
-			]
-			dependencies: [
-				"7648FD025997ABD4"
-				"446A5E8AAB0DE2AE"
-			]
-			id: "2DF4C83B865B3AA0"
 			tasks: [{
 				id: "0171BADD2E9CF12D"
 				type: "item"
@@ -1081,29 +1067,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 200 ticks (or 10 seconds)."
+				""
+				"Uses 4000 E per generated item."
+				""
+				"Average consumption: 20 E/t."
+			]
+			id: "2DF4C83B865B3AA0"
+			x: 1.0d
+			y: 3.0d
 			rewards: [{
 				id: "58CBB1D2951D4F4D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Dirt, Sand and Gravel."
+			dependencies: [
+				"7648FD025997ABD4"
+				"446A5E8AAB0DE2AE"
+			]
 		}
 		{
-			x: 1.0d
-			y: 4.0d
-			subtitle: "Generates Dirt, Sand and Gravel."
-			description: [
-				"Generates every 150 ticks (or 7.5 seconds)."
-				""
-				"Uses 7000 E per generated item."
-				""
-				"Average consumption: 46.67 E/t."
-			]
-			dependencies: [
-				"2DF4C83B865B3AA0"
-				"3443B551C3A65130"
-			]
-			id: "05834C835E7B4FC0"
 			tasks: [{
 				id: "39B2DE351F0EB811"
 				type: "item"
@@ -1113,29 +1099,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 150 ticks (or 7.5 seconds)."
+				""
+				"Uses 7000 E per generated item."
+				""
+				"Average consumption: 46.67 E/t."
+			]
+			id: "05834C835E7B4FC0"
+			x: 1.0d
+			y: 4.0d
 			rewards: [{
 				id: "1D12E32EB52DEC5E"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Dirt, Sand and Gravel."
+			dependencies: [
+				"2DF4C83B865B3AA0"
+				"3443B551C3A65130"
+			]
 		}
 		{
-			x: 1.0d
-			y: 5.0d
-			subtitle: "Generates Dirt, Sand and Gravel."
-			description: [
-				"Generates every 100 ticks (or 5 seconds)."
-				""
-				"Uses 7500 E per generated item."
-				""
-				"Average consumption: 75 E/t."
-			]
-			dependencies: [
-				"05834C835E7B4FC0"
-				"75B77AC8911A5A57"
-			]
-			id: "27DCC8521DD68F65"
 			tasks: [{
 				id: "6D647D9AE8DD1AB2"
 				type: "item"
@@ -1145,29 +1131,29 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 100 ticks (or 5 seconds)."
+				""
+				"Uses 7500 E per generated item."
+				""
+				"Average consumption: 75 E/t."
+			]
+			id: "27DCC8521DD68F65"
+			x: 1.0d
+			y: 5.0d
 			rewards: [{
 				id: "726DC5344ED18A05"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Dirt, Sand and Gravel."
+			dependencies: [
+				"05834C835E7B4FC0"
+				"75B77AC8911A5A57"
+			]
 		}
 		{
-			x: 1.0d
-			y: 6.0d
-			subtitle: "Generates Dirt, Sand and Gravel."
-			description: [
-				"Generates every 5 ticks (or 0.25 seconds)."
-				""
-				"Uses 8000 E per generated item."
-				""
-				"Average consumption: 1600 E/t."
-			]
-			dependencies: [
-				"27DCC8521DD68F65"
-				"1D64053A738C877A"
-			]
-			id: "414AF14A64CA58FF"
 			tasks: [{
 				id: "24E23ABF0152F198"
 				type: "item"
@@ -1177,17 +1163,38 @@
 					tag: { }
 				}
 			}]
+			description: [
+				"Generates every 5 ticks (or 0.25 seconds)."
+				""
+				"Uses 8000 E per generated item."
+				""
+				"Average consumption: 1600 E/t."
+			]
+			id: "414AF14A64CA58FF"
+			x: 1.0d
+			y: 6.0d
 			rewards: [{
 				id: "6C6ECA15B77D4676"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates Dirt, Sand and Gravel."
+			dependencies: [
+				"27DCC8521DD68F65"
+				"1D64053A738C877A"
+			]
 		}
 		{
-			x: 2.5d
-			y: 4.5d
-			subtitle: "Generates loot from vanilla dungeons."
+			tasks: [{
+				id: "39C274746F2D206A"
+				type: "item"
+				item: {
+					id: "spatialharvesters:loot_harvester"
+					Count: 1b
+					tag: { }
+				}
+			}]
 			description: [
 				"Generates loot from:"
 				"> Classic dungeons."
@@ -1210,56 +1217,19 @@
 				""
 				"Average consumption: 160 E/t."
 			]
-			dependencies: ["3E17651799AF2546"]
 			id: "3A7FA48714800BCF"
-			tasks: [{
-				id: "39C274746F2D206A"
-				type: "item"
-				item: {
-					id: "spatialharvesters:loot_harvester"
-					Count: 1b
-					tag: { }
-				}
-			}]
+			x: 2.5d
+			y: 4.5d
 			rewards: [{
 				id: "128AEF4EAD1DB851"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates loot from vanilla dungeons."
+			dependencies: ["3E17651799AF2546"]
 		}
 		{
-			icon: {
-				id: "spatialharvesters:specific_mob_harvester"
-				Count: 1b
-				tag: { }
-			}
-			x: 2.5d
-			y: -1.0d
-			subtitle: "Generates mob loot of a specific mob."
-			description: [
-				"Attack a Mob with a Mob Key, *while sneaking* to bind a mob to the key."
-				""
-				"Choose a weapon with the Weapon Key by breaking any block while sneaking, holding a Weapon Key and having the desired weapon in off-hand."
-				""
-				"Then, you can bind those to the Specific Mob Harvester to start generating mob loot and Mob Shards."
-				""
-				"The Harvester will simulate player kills on the mob using a chosen weapon."
-				""
-				"WARNING - Do not place this Harvester after it was broken once, entering the world will crash the game!"
-				""
-				"Generates loot every 50 ticks (or 2.5 seconds)."
-				""
-				"Consumes 8000 E per generation."
-				""
-				"Average consumption: 160 E/t."
-			]
-			hide_dependency_lines: true
-			dependencies: [
-				"69DD3E95BDB5E400"
-				"1D64053A738C877A"
-			]
-			id: "6B24C01CCDEB34AE"
 			tasks: [
 				{
 					id: "33CBEF3C8C2CF36A"
@@ -1281,21 +1251,45 @@
 					item: "spatialharvesters:weapon_key"
 				}
 			]
+			description: [
+				"Attack a Mob with a Mob Key, *while sneaking* to bind a mob to the key."
+				""
+				"Choose a weapon with the Weapon Key by breaking any block while sneaking, holding a Weapon Key and having the desired weapon in off-hand."
+				""
+				"Then, you can bind those to the Specific Mob Harvester to start generating mob loot and Mob Shards."
+				""
+				"The Harvester will simulate player kills on the mob using a chosen weapon."
+				""
+				"WARNING - Do not place this Harvester after it was broken once, entering the world will crash the game!"
+				""
+				"Generates loot every 50 ticks (or 2.5 seconds)."
+				""
+				"Consumes 8000 E per generation."
+				""
+				"Average consumption: 160 E/t."
+			]
+			id: "6B24C01CCDEB34AE"
+			icon: {
+				id: "spatialharvesters:specific_mob_harvester"
+				Count: 1b
+				tag: { }
+			}
+			x: 2.5d
+			y: -1.0d
 			rewards: [{
 				id: "57712B75D9A347BD"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generates mob loot of a specific mob."
+			dependencies: [
+				"69DD3E95BDB5E400"
+				"1D64053A738C877A"
+			]
+			hide_dependency_lines: true
 		}
 		{
-			x: 2.5d
-			y: 2.0d
-			dependencies: [
-				"279BF2C329E9D9DF"
-				"18456F744DD7127E"
-			]
-			id: "648F6CB66DF70EE8"
 			tasks: [{
 				id: "69A626EE4B32EC11"
 				type: "item"
@@ -1305,6 +1299,13 @@
 					tag: { }
 				}
 			}]
+			dependencies: [
+				"279BF2C329E9D9DF"
+				"18456F744DD7127E"
+			]
+			id: "648F6CB66DF70EE8"
+			y: 2.0d
+			x: 2.5d
 			rewards: [{
 				id: "06620C3101304C17"
 				type: "random"
@@ -1313,10 +1314,21 @@
 			}]
 		}
 		{
+			tasks: [{
+				id: "0645106F77599F05"
+				type: "item"
+				item: "spatialharvesters:shard_1"
+			}]
+			id: "02E2B5FEAC3EE174"
 			x: -4.0d
 			y: 0.0d
+			rewards: [{
+				id: "508D500B0C9A8346"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 13756307348121783L
+			}]
 			subtitle: "Generated by any Tier 1 Spatial Harvester."
-			hide_dependency_lines: true
 			dependencies: [
 				"7441BC53B18AF8F0"
 				"6402400F5F40CF37"
@@ -1324,24 +1336,24 @@
 				"12866716DDB31F3D"
 			]
 			dependency_requirement: "one_completed"
-			id: "02E2B5FEAC3EE174"
+			hide_dependency_lines: true
+		}
+		{
 			tasks: [{
-				id: "0645106F77599F05"
+				id: "5C25492E636CBE33"
 				type: "item"
-				item: "spatialharvesters:shard_1"
+				item: "spatialharvesters:shard_2"
 			}]
+			id: "505AEF6A159C9254"
+			x: -4.0d
+			y: 1.0d
 			rewards: [{
-				id: "508D500B0C9A8346"
+				id: "03EED9C05286AC2A"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			x: -4.0d
-			y: 1.0d
 			subtitle: "Generated by any Tier 2 Spatial Harvester."
-			hide_dependency_lines: true
 			dependencies: [
 				"229E25830538A686"
 				"0E53685ECFC4C1CF"
@@ -1349,24 +1361,24 @@
 				"567F0904EC32FC46"
 			]
 			dependency_requirement: "one_completed"
-			id: "505AEF6A159C9254"
+			hide_dependency_lines: true
+		}
+		{
 			tasks: [{
-				id: "5C25492E636CBE33"
+				id: "7534A8B3B2DA013B"
 				type: "item"
-				item: "spatialharvesters:shard_2"
+				item: "spatialharvesters:shard_3"
 			}]
+			id: "6F1D69E6792E587A"
+			x: -4.0d
+			y: 2.0d
 			rewards: [{
-				id: "03EED9C05286AC2A"
+				id: "44E527EE0FDB6BD4"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			x: -4.0d
-			y: 2.0d
 			subtitle: "Generated by any Tier 3 Spatial Harvester."
-			hide_dependency_lines: true
 			dependencies: [
 				"3E04366C15960FDC"
 				"682E67ED3061BC66"
@@ -1374,24 +1386,24 @@
 				"549CCCB73B700D04"
 			]
 			dependency_requirement: "one_completed"
-			id: "6F1D69E6792E587A"
+			hide_dependency_lines: true
+		}
+		{
 			tasks: [{
-				id: "7534A8B3B2DA013B"
+				id: "4AE81F341A6672DA"
 				type: "item"
-				item: "spatialharvesters:shard_3"
+				item: "spatialharvesters:shard_4"
 			}]
+			id: "3C3A8D80081464C8"
+			x: -4.0d
+			y: 3.0d
 			rewards: [{
-				id: "44E527EE0FDB6BD4"
+				id: "1DE0CB3D694C33A4"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			x: -4.0d
-			y: 3.0d
 			subtitle: "Generated by any Tier 4 Spatial Harvester."
-			hide_dependency_lines: true
 			dependencies: [
 				"7336B45C0EB22709"
 				"0974E1AC3971B5AD"
@@ -1399,24 +1411,24 @@
 				"364280C8FE027ED4"
 			]
 			dependency_requirement: "one_completed"
-			id: "3C3A8D80081464C8"
+			hide_dependency_lines: true
+		}
+		{
 			tasks: [{
-				id: "4AE81F341A6672DA"
+				id: "7C2683F2E9B668A4"
 				type: "item"
-				item: "spatialharvesters:shard_4"
+				item: "spatialharvesters:shard_5"
 			}]
+			id: "3353203ED87C181E"
+			x: -4.0d
+			y: 4.0d
 			rewards: [{
-				id: "1DE0CB3D694C33A4"
+				id: "470C7F96F4D4AE97"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			x: -4.0d
-			y: 4.0d
 			subtitle: "Generated by any Tier 5 Spatial Harvester."
-			hide_dependency_lines: true
 			dependencies: [
 				"4F7D37E42D87709D"
 				"2DF4C83B865B3AA0"
@@ -1424,24 +1436,24 @@
 				"2F744D5C38C727F0"
 			]
 			dependency_requirement: "one_completed"
-			id: "3353203ED87C181E"
+			hide_dependency_lines: true
+		}
+		{
 			tasks: [{
-				id: "7C2683F2E9B668A4"
+				id: "43D6BAEE1BC72B04"
 				type: "item"
-				item: "spatialharvesters:shard_5"
+				item: "spatialharvesters:shard_6"
 			}]
+			id: "42708FDB4E844CFC"
+			x: -4.0d
+			y: 5.0d
 			rewards: [{
-				id: "470C7F96F4D4AE97"
+				id: "4460547F0E83E379"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			x: -4.0d
-			y: 5.0d
 			subtitle: "Generated by any Tier 6 Spatial Harvester."
-			hide_dependency_lines: true
 			dependencies: [
 				"1FF684D69AF9A8E8"
 				"05834C835E7B4FC0"
@@ -1449,24 +1461,24 @@
 				"3B57275DF8614D64"
 			]
 			dependency_requirement: "one_completed"
-			id: "42708FDB4E844CFC"
+			hide_dependency_lines: true
+		}
+		{
 			tasks: [{
-				id: "43D6BAEE1BC72B04"
+				id: "1301337635E4EF3F"
 				type: "item"
-				item: "spatialharvesters:shard_6"
+				item: "spatialharvesters:shard_7"
 			}]
+			id: "1E0002CCB05CC67B"
+			x: -4.0d
+			y: 6.0d
 			rewards: [{
-				id: "4460547F0E83E379"
+				id: "5E4264D3F9C4FF8A"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			x: -4.0d
-			y: 6.0d
 			subtitle: "Generated by any Tier 7 Spatial Harvester."
-			hide_dependency_lines: true
 			dependencies: [
 				"5C2995E356239D8B"
 				"553E973F8A8E6889"
@@ -1474,226 +1486,191 @@
 				"27DCC8521DD68F65"
 			]
 			dependency_requirement: "one_completed"
-			id: "1E0002CCB05CC67B"
-			tasks: [{
-				id: "1301337635E4EF3F"
-				type: "item"
-				item: "spatialharvesters:shard_7"
-			}]
-			rewards: [{
-				id: "5E4264D3F9C4FF8A"
-				type: "random"
-				exclude_from_claim_all: true
-				table_id: 13756307348121783L
-			}]
+			hide_dependency_lines: true
 		}
 		{
+			size: 1.5d
+			description: ["Place this on top of the Spatial Harvester."]
+			id: "40F365EB887E31C8"
 			x: 0.5d
 			y: -3.5d
-			subtitle: "Rips the Space-Time itself. Required for Spatial Harvesters to function."
-			description: ["Place this on top of the Spatial Harvester."]
-			dependencies: ["45A82DB03F64C6F3"]
-			size: 1.5d
-			id: "40F365EB887E31C8"
-			tasks: [{
-				id: "2CF4E714B41F317B"
-				type: "item"
-				item: "spatialharvesters:space_ripper"
-			}]
 			rewards: [{
 				id: "078C7C7FF3DC2FE7"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Rips the Space-Time itself. Required for Spatial Harvesters to function."
+			dependencies: ["45A82DB03F64C6F3"]
+			tasks: [{
+				id: "2CF4E714B41F317B"
+				type: "item"
+				item: "spatialharvesters:space_ripper"
+			}]
 		}
 		{
-			x: -3.0d
-			y: 0.0d
-			subtitle: "Crafted from 9 Tier 1 Shards."
-			dependencies: ["02E2B5FEAC3EE174"]
-			id: "2B2FFD6B5333EAF3"
 			tasks: [{
 				id: "54891FE6F01FEE7C"
 				type: "item"
 				item: "spatialharvesters:crystal_1"
 			}]
+			id: "2B2FFD6B5333EAF3"
+			x: -3.0d
+			y: 0.0d
 			rewards: [{
 				id: "6A3902F2090A2778"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Crafted from 9 Tier 1 Shards."
+			dependencies: ["02E2B5FEAC3EE174"]
 		}
 		{
-			x: -3.0d
-			y: 1.0d
-			subtitle: "Crafted from 9 Tier 2 Shards."
-			dependencies: ["505AEF6A159C9254"]
-			id: "29C1E30A9260BC71"
 			tasks: [{
 				id: "223B7A5BCD5239A7"
 				type: "item"
 				item: "spatialharvesters:crystal_2"
 			}]
+			id: "29C1E30A9260BC71"
+			x: -3.0d
+			y: 1.0d
 			rewards: [{
 				id: "7887BF0114CF86EE"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Crafted from 9 Tier 2 Shards."
+			dependencies: ["505AEF6A159C9254"]
 		}
 		{
-			x: -3.0d
-			y: 2.0d
-			subtitle: "Crafted from 9 Tier 3 Shards."
-			dependencies: ["6F1D69E6792E587A"]
-			id: "58226D1F08683EB5"
 			tasks: [{
 				id: "0F86892334DEE98E"
 				type: "item"
 				item: "spatialharvesters:crystal_3"
 			}]
+			id: "58226D1F08683EB5"
+			x: -3.0d
+			y: 2.0d
 			rewards: [{
 				id: "3BA43711FD7D418C"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Crafted from 9 Tier 3 Shards."
+			dependencies: ["6F1D69E6792E587A"]
 		}
 		{
-			x: -3.0d
-			y: 3.0d
-			subtitle: "Crafted from 9 Tier 4 Shards."
-			dependencies: ["3C3A8D80081464C8"]
-			id: "446A5E8AAB0DE2AE"
 			tasks: [{
 				id: "1287CD7B0B43C15F"
 				type: "item"
 				item: "spatialharvesters:crystal_4"
 			}]
+			id: "446A5E8AAB0DE2AE"
+			x: -3.0d
+			y: 3.0d
 			rewards: [{
 				id: "6CE6E678B7C7B5FD"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Crafted from 9 Tier 4 Shards."
+			dependencies: ["3C3A8D80081464C8"]
 		}
 		{
-			x: -3.0d
-			y: 4.0d
-			subtitle: "Crafted from 9 Tier 5 Shards."
-			dependencies: ["3353203ED87C181E"]
-			id: "3443B551C3A65130"
 			tasks: [{
 				id: "42FB95B2E42685AF"
 				type: "item"
 				item: "spatialharvesters:crystal_5"
 			}]
+			id: "3443B551C3A65130"
+			x: -3.0d
+			y: 4.0d
 			rewards: [{
 				id: "218FEEC0F1E4B414"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Crafted from 9 Tier 5 Shards."
+			dependencies: ["3353203ED87C181E"]
 		}
 		{
-			x: -3.0d
-			y: 5.0d
-			subtitle: "Crafted from 9 Tier 6 Shards."
-			dependencies: ["42708FDB4E844CFC"]
-			id: "75B77AC8911A5A57"
 			tasks: [{
 				id: "64028E5A88B3AEF7"
 				type: "item"
 				item: "spatialharvesters:crystal_6"
 			}]
+			id: "75B77AC8911A5A57"
+			x: -3.0d
+			y: 5.0d
 			rewards: [{
 				id: "26AAE5F2E606D7DF"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Crafted from 9 Tier 6 Shards."
+			dependencies: ["42708FDB4E844CFC"]
 		}
 		{
-			x: -3.0d
-			y: 6.0d
-			subtitle: "Crafted from 9 Tier 7 Shards."
-			dependencies: ["1E0002CCB05CC67B"]
-			id: "1D64053A738C877A"
 			tasks: [{
 				id: "0A9441F8A9215C4E"
 				type: "item"
 				item: "spatialharvesters:crystal_7"
 			}]
+			id: "1D64053A738C877A"
+			x: -3.0d
+			y: 6.0d
 			rewards: [{
 				id: "144F81EC4336667D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Crafted from 9 Tier 7 Shards."
+			dependencies: ["1E0002CCB05CC67B"]
 		}
 		{
-			x: 2.5d
-			y: 1.0d
-			subtitle: "Crafted from 9 Mob Shards."
-			dependencies: ["4C8C3F0C30EAD052"]
-			id: "18456F744DD7127E"
 			tasks: [{
 				id: "04082B74BDD7187B"
 				type: "item"
 				item: "spatialharvesters:mob_crystal"
 			}]
+			id: "18456F744DD7127E"
+			x: 2.5d
+			y: 1.0d
 			rewards: [{
 				id: "5DA3BABB23010C08"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Crafted from 9 Mob Shards."
+			dependencies: ["4C8C3F0C30EAD052"]
 		}
 		{
-			x: 2.5d
-			y: 0.0d
-			subtitle: "Generated by Mob Harvesters."
-			dependencies: ["6B24C01CCDEB34AE"]
-			id: "4C8C3F0C30EAD052"
 			tasks: [{
 				id: "7A4FDA3DE004CB72"
 				type: "item"
 				item: "spatialharvesters:mob_shard"
 			}]
+			id: "4C8C3F0C30EAD052"
+			x: 2.5d
+			y: 0.0d
 			rewards: [{
 				id: "427AB858EE52344D"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Generated by Mob Harvesters."
+			dependencies: ["6B24C01CCDEB34AE"]
 		}
 		{
-			icon: {
-				id: "spatialharvesters:dimensional_applicator"
-				Count: 1b
-				tag: { }
-			}
-			x: 2.5d
-			y: 6.0d
-			subtitle: "An Interdimensional Beacon!"
-			description: [
-				"Will supply you continually with potion effects."
-				""
-				"To bind the Dimensional Applicator to yourself, Right-Click it with a Player Key in hand."
-				""
-				"Then, you can specify effects you want to apply by either:"
-				""
-				"1. Placing Effect Activators on any side of the Applicator."
-				""
-				"2. Right-Clicking a Harvester with the Effect Key while under the effect of desired potions."
-				""
-				"It will then continually apply chosen effects on level 2."
-			]
-			hide_dependency_lines: true
-			dependencies: ["1E0002CCB05CC67B"]
-			id: "4092ED97F4417228"
 			tasks: [
 				{
 					id: "1297C29E5CCBB54F"
@@ -1715,13 +1692,36 @@
 					item: "spatialharvesters:effect_key"
 				}
 			]
+			description: [
+				"Will supply you continually with potion effects."
+				""
+				"To bind the Dimensional Applicator to yourself, Right-Click it with a Player Key in hand."
+				""
+				"Then, you can specify effects you want to apply by either:"
+				""
+				"1. Placing Effect Activators on any side of the Applicator."
+				""
+				"2. Right-Clicking a Harvester with the Effect Key while under the effect of desired potions."
+				""
+				"It will then continually apply chosen effects on level 2."
+			]
+			id: "4092ED97F4417228"
+			icon: {
+				id: "spatialharvesters:dimensional_applicator"
+				Count: 1b
+				tag: { }
+			}
+			x: 2.5d
+			y: 6.0d
 			rewards: [{
 				id: "0A860EE6DDE15B02"
 				type: "random"
 				exclude_from_claim_all: true
 				table_id: 13756307348121783L
 			}]
+			subtitle: "An Interdimensional Beacon!"
+			dependencies: ["1E0002CCB05CC67B"]
+			hide_dependency_lines: true
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/spectrum.snbt
+++ b/config/ftbquests/quests/chapters/spectrum.snbt
@@ -1,18 +1,16 @@
 {
-	id: "06E76B49ED832B81"
-	group: "1039AC171AB01709"
-	order_index: 3
-	filename: "spectrum"
-	title: "Spectrum"
-	icon: "spectrum:end_portal_cracker"
-	default_quest_shape: ""
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "1039AC171AB01709"
+	id: "06E76B49ED832B81"
+	filename: "spectrum"
+	default_quest_shape: ""
+	icon: "spectrum:end_portal_cracker"
+	title: "Spectrum"
+	order_index: 3
 	quests: [
 		{
-			title: "Welcome to the Spectrum mod"
-			icon: "spectrum:manual"
-			x: -1.0d
-			y: 1.5d
+			size: 1.25d
 			description: [
 				"Spectrum is a story driven and exploration-based magic mod."
 				""
@@ -23,8 +21,11 @@
 				""
 				"The first step is to get some Gemstone on hand using an Extractinator."
 			]
-			size: 1.25d
+			icon: "spectrum:manual"
 			id: "6F9B2ECCE750C280"
+			x: -1.0d
+			y: 1.5d
+			title: "Welcome to the Spectrum mod"
 			tasks: [{
 				id: "3FFA395CAB5C258F"
 				type: "item"
@@ -32,46 +33,45 @@
 			}]
 		}
 		{
-			icon: "spectrum:mermaids_gem"
-			x: 9.5d
-			y: 6.0d
-			description: ["A Vacuum Hopper is recommended to automatically collect Mermaids Gems."]
-			dependencies: ["62497389C3267837"]
-			hide: true
-			id: "5584A52CAA574CFC"
 			tasks: [{
 				id: "7D947A422124FBFF"
 				type: "advancement"
 				advancement: "spectrum:collect_mermaids_gem"
 				criterion: ""
 			}]
+			description: ["A Vacuum Hopper is recommended to automatically collect Mermaids Gems."]
+			icon: "spectrum:mermaids_gem"
+			id: "5584A52CAA574CFC"
+			x: 9.5d
+			y: 6.0d
 			rewards: [{
 				id: "2859B7AA60045469"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["62497389C3267837"]
+			hide: true
 		}
 		{
-			x: 2.0d
-			y: 1.5d
-			dependencies: ["2CC5282720701CB2"]
-			hide: true
-			id: "042E7914986F8A32"
 			tasks: [{
 				id: "050348C6180B542B"
 				type: "advancement"
 				advancement: "spectrum:collect_all_basic_shards"
 				criterion: ""
 			}]
+			id: "042E7914986F8A32"
+			x: 2.0d
+			y: 1.5d
 			rewards: [{
 				id: "4EEA476803C3672F"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["2CC5282720701CB2"]
+			hide: true
 		}
 		{
-			x: 3.5d
-			y: 1.5d
+			hide_text_until_complete: true
 			description: [
 				"Pigment Pedestals can auto-craft using Crafting Tablets as a pattern."
 				""
@@ -81,53 +81,52 @@
 				""
 				"Do you see a problem?"
 			]
-			dependencies: ["042E7914986F8A32"]
-			hide: true
-			hide_text_until_complete: true
 			id: "74F0C68679B78B5D"
+			x: 3.5d
+			y: 1.5d
+			rewards: [{
+				id: "1D92BB2FDA46790F"
+				type: "loot"
+				table_id: 13756307348121783L
+			}]
+			dependencies: ["042E7914986F8A32"]
 			tasks: [{
 				id: "495C5302C801134A"
 				type: "advancement"
 				advancement: "spectrum:craft_colored_pedestal"
 				criterion: ""
 			}]
-			rewards: [{
-				id: "1D92BB2FDA46790F"
-				type: "loot"
-				table_id: 13756307348121783L
-			}]
+			hide: true
 		}
 		{
-			x: 5.0d
-			y: 1.5d
-			dependencies: ["74F0C68679B78B5D"]
-			hide: true
-			id: "3A53CED5C9ABC06B"
 			tasks: [{
 				id: "5A0D90E9F122144F"
 				type: "advancement"
 				advancement: "spectrum:build_basic_pedestal_structure"
 				criterion: ""
 			}]
+			id: "3A53CED5C9ABC06B"
+			x: 5.0d
+			y: 1.5d
 			rewards: [{
 				id: "1D32B309EFF17941"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["74F0C68679B78B5D"]
+			hide: true
 		}
 		{
-			x: -1.0d
-			y: 3.0d
-			description: ["This new crafting table will help you harness the power of gemstones."]
-			dependencies: ["6F9B2ECCE750C280"]
-			hide: true
-			id: "777CED8399E65C29"
 			tasks: [{
 				id: "4D2C0E433C9185B6"
 				type: "advancement"
 				advancement: "spectrum:place_pedestal"
 				criterion: ""
 			}]
+			description: ["This new crafting table will help you harness the power of gemstones."]
+			id: "777CED8399E65C29"
+			x: -1.0d
+			y: 3.0d
 			rewards: [
 				{
 					id: "12C6CB96FD6FD2CD"
@@ -140,193 +139,207 @@
 					table_id: 13756307348121783L
 				}
 			]
+			dependencies: ["6F9B2ECCE750C280"]
+			hide: true
 		}
 		{
-			x: -1.0d
-			y: 4.5d
-			description: ["Turns out dropping an anvil on something is pretty useful!"]
-			dependencies: ["777CED8399E65C29"]
-			hide: true
-			id: "1481A572B8751B94"
 			tasks: [{
 				id: "4DCB4066706CAA1D"
 				type: "advancement"
 				advancement: "spectrum:collect_gemstone_powder"
 				criterion: ""
 			}]
+			description: ["Turns out dropping an anvil on something is pretty useful!"]
+			id: "1481A572B8751B94"
+			x: -1.0d
+			y: 4.5d
 			rewards: [{
 				id: "36ACE50D44A6D519"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["777CED8399E65C29"]
+			hide: true
 		}
 		{
-			x: 12.5d
-			y: -1.0d
-			dependencies: [
-				"2F56655D7C4C3882"
-				"24C70DAB3F66ECB2"
-			]
-			hide: true
-			id: "678BCF3361AE5512"
 			tasks: [{
 				id: "5C5AD91BEF4B518D"
 				type: "advancement"
 				advancement: "spectrum:midgame/craft_bottle_of_failing"
 				criterion: ""
 			}]
+			id: "678BCF3361AE5512"
+			x: 12.5d
+			y: -1.0d
 			rewards: [{
 				id: "2DD4B56B20CF129B"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: [
+				"2F56655D7C4C3882"
+				"24C70DAB3F66ECB2"
+			]
+			hide: true
 		}
 		{
+			hide_text_until_complete: true
+			description: ["They can be farmed by placing them in a 1-block deep body of water, with Clay underneath."]
+			id: "24C70DAB3F66ECB2"
 			x: 8.0d
 			y: -1.0d
+			rewards: [{
+				id: "36A116E4625D11E6"
+				type: "loot"
+				table_id: 13756307348121783L
+			}]
 			subtitle: "Obtainable using Botania's Petal Apothecary."
-			description: ["They can be farmed by placing them in a 1-block deep body of water, with Clay underneath."]
 			dependencies: ["6F3F4B2ADAAED3C1"]
-			hide: true
-			hide_text_until_complete: true
-			id: "24C70DAB3F66ECB2"
 			tasks: [{
 				id: "36D473C7A3DA8BED"
 				type: "advancement"
 				advancement: "spectrum:collect_quitoxic_reeds"
 				criterion: ""
 			}]
-			rewards: [{
-				id: "36A116E4625D11E6"
-				type: "loot"
-				table_id: 13756307348121783L
-			}]
+			hide: true
 		}
 		{
-			x: 0.5d
-			y: 4.5d
-			description: ["Use your Pigment Pedestal to craft an item using gemstone powder. It seems to react to redstone?"]
-			dependencies: ["1481A572B8751B94"]
-			hide: true
-			id: "36258B9E1280A188"
 			tasks: [{
 				id: "3248FA069DECAD16"
 				type: "advancement"
 				advancement: "spectrum:craft_using_pedestal"
 				criterion: ""
 			}]
+			description: ["Use your Pigment Pedestal to craft an item using gemstone powder. It seems to react to redstone?"]
+			id: "36258B9E1280A188"
+			x: 0.5d
+			y: 4.5d
 			rewards: [{
 				id: "5A9E1AF931F9CCA4"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["1481A572B8751B94"]
+			hide: true
 		}
 		{
-			x: 1.5d
-			y: 5.5d
-			description: ["Obtainable with the Extractinator!"]
-			dependencies: ["36258B9E1280A188"]
-			hide: true
-			id: "5E0135DE9E0D30CE"
 			tasks: [{
 				id: "6CA9C223DFA792D2"
 				type: "advancement"
 				advancement: "spectrum:collect_sparklestone"
 				criterion: ""
 			}]
+			description: ["Obtainable with the Extractinator!"]
+			id: "5E0135DE9E0D30CE"
+			x: 1.5d
+			y: 5.5d
 			rewards: [{
 				id: "4F9E610F1DD722F7"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["36258B9E1280A188"]
+			hide: true
 		}
 		{
-			x: 2.5d
-			y: 6.5d
-			description: [
-				"To unlock this recipe you must now venture to the depths of The Nether and aquire a smoldering ingredient."
-				""
-				"Time to tinker with your new magical abilities. Create life! Or more like... microorganisms. Weak and slow. It's something. What do they eat?"
-			]
-			dependencies: ["5E0135DE9E0D30CE"]
-			hide: true
-			id: "1E161856A9975BCE"
 			tasks: [{
 				id: "5312C1B5091577AF"
 				type: "advancement"
 				advancement: "spectrum:craft_bottle_of_fading"
 				criterion: ""
 			}]
+			description: [
+				"To unlock this recipe you must now venture to the depths of The Nether and aquire a smoldering ingredient."
+				""
+				"Time to tinker with your new magical abilities. Create life! Or more like... microorganisms. Weak and slow. It's something. What do they eat?"
+			]
+			id: "1E161856A9975BCE"
+			x: 2.5d
+			y: 6.5d
 			rewards: [{
 				id: "3B7BC022A5A971F3"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["5E0135DE9E0D30CE"]
+			hide: true
 		}
 		{
-			x: 3.5d
-			y: 7.5d
-			description: [
-				"Spill out your microorganisms and place organic blocks around it so it can feast!"
-				""
-				"In the leftovers you find a new material!"
-			]
-			dependencies: ["1E161856A9975BCE"]
-			hide: true
-			id: "371F3371DC37B760"
 			tasks: [{
 				id: "33D74A4188B867BE"
 				type: "advancement"
 				advancement: "spectrum:collect_vegetal"
 				criterion: ""
 			}]
+			description: [
+				"Spill out your microorganisms and place organic blocks around it so it can feast!"
+				""
+				"In the leftovers you find a new material!"
+			]
+			id: "371F3371DC37B760"
+			x: 3.5d
+			y: 7.5d
 			rewards: [{
 				id: "1CA80A7983D7CCC0"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["1E161856A9975BCE"]
+			hide: true
 		}
 		{
-			x: 5.0d
-			y: 7.5d
-			description: ["Here come the colors! Craft a colored sapling and bring color into the world!"]
-			dependencies: ["371F3371DC37B760"]
-			hide: true
-			id: "265E77D910C56546"
 			tasks: [{
 				id: "68A98F4268DBD672"
 				type: "advancement"
 				advancement: "spectrum:craft_colored_sapling"
 				criterion: ""
 			}]
+			description: ["Here come the colors! Craft a colored sapling and bring color into the world!"]
+			id: "265E77D910C56546"
+			x: 5.0d
+			y: 7.5d
 			rewards: [{
 				id: "40EE17DAA7859E8B"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["371F3371DC37B760"]
+			hide: true
 		}
 		{
-			x: 6.5d
-			y: 7.5d
-			description: ["Break the leaves of a colored tree to get the pure pigment you so desired. The leaves release their precious harvest only when broken by you personally."]
-			dependencies: ["265E77D910C56546"]
-			hide: true
-			id: "723E1C665A781C52"
 			tasks: [{
 				id: "279233226F0D7AB6"
 				type: "advancement"
 				advancement: "spectrum:collect_pigment"
 				criterion: ""
 			}]
+			description: ["Break the leaves of a colored tree to get the pure pigment you so desired. The leaves release their precious harvest only when broken by you personally."]
+			id: "723E1C665A781C52"
+			x: 6.5d
+			y: 7.5d
 			rewards: [{
 				id: "1CF3AA62BAB7B6BE"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["265E77D910C56546"]
+			hide: true
 		}
 		{
+			tasks: [{
+				id: "4D844E1A8EE700CD"
+				type: "advancement"
+				advancement: "spectrum:collect_all_basic_pigments_besides_brown"
+				criterion: ""
+			}]
+			id: "4C06D25DACB5536C"
 			x: 6.5d
 			y: 4.5d
+			rewards: [{
+				id: "48B135B3B2182FDB"
+				type: "loot"
+				table_id: 13756307348121783L
+			}]
 			dependencies: [
 				"723E1C665A781C52"
 				"2B9252657949C67E"
@@ -341,665 +354,651 @@
 				"5008ED129CAE4EED"
 				"2B486D1AE4A59F73"
 			]
-			hide: true
 			dependency_requirement: "one_completed"
-			id: "4C06D25DACB5536C"
-			tasks: [{
-				id: "4D844E1A8EE700CD"
-				type: "advancement"
-				advancement: "spectrum:collect_all_basic_pigments_besides_brown"
-				criterion: ""
-			}]
-			rewards: [{
-				id: "48B135B3B2182FDB"
-				type: "loot"
-				table_id: 13756307348121783L
-			}]
+			hide: true
 		}
 		{
-			x: 8.0d
-			y: 3.5d
-			hide_dependency_lines: true
-			dependencies: ["723E1C665A781C52"]
-			hide: true
-			id: "1FCEEFE4A3804DEF"
 			tasks: [{
 				id: "1CE9634136FBB731"
 				type: "item"
 				item: "spectrum:orange_pigment"
 			}]
+			id: "1FCEEFE4A3804DEF"
+			x: 8.0d
+			y: 3.5d
 			rewards: [{
 				id: "124FC5D47240F437"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["723E1C665A781C52"]
+			hide_dependency_lines: true
+			hide: true
 		}
 		{
-			x: 8.0d
-			y: 6.5d
-			hide_dependency_lines: true
-			dependencies: ["723E1C665A781C52"]
-			hide: true
-			id: "0777D896D81DEA4A"
 			tasks: [{
 				id: "0F1F9332DAD957D0"
 				type: "item"
 				item: "spectrum:magenta_pigment"
 			}]
+			id: "0777D896D81DEA4A"
+			x: 8.0d
+			y: 6.5d
 			rewards: [{
 				id: "3D4B1E010CDA62C8"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["723E1C665A781C52"]
+			hide_dependency_lines: true
+			hide: true
 		}
 		{
-			x: 5.0d
-			y: 5.5d
-			hide_dependency_lines: true
-			dependencies: ["723E1C665A781C52"]
-			hide: true
-			id: "782330BECD66EFD5"
 			tasks: [{
 				id: "29882807DF613632"
 				type: "item"
 				item: "spectrum:light_blue_pigment"
 			}]
+			id: "782330BECD66EFD5"
+			x: 5.0d
+			y: 5.5d
 			rewards: [{
 				id: "529BD938798A7297"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["723E1C665A781C52"]
+			hide_dependency_lines: true
+			hide: true
 		}
 		{
-			x: 8.0d
-			y: 2.5d
-			hide_dependency_lines: true
-			dependencies: ["723E1C665A781C52"]
-			hide: true
-			id: "1F17B62A67347D61"
 			tasks: [{
 				id: "3810D2BB4E6142CD"
 				type: "item"
 				item: "spectrum:yellow_pigment"
 			}]
+			id: "1F17B62A67347D61"
+			x: 8.0d
+			y: 2.5d
 			rewards: [{
 				id: "5C69CFD4FD310359"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["723E1C665A781C52"]
+			hide_dependency_lines: true
+			hide: true
 		}
 		{
-			x: 5.0d
-			y: 2.5d
-			hide_dependency_lines: true
-			dependencies: ["723E1C665A781C52"]
-			hide: true
-			id: "64CFFA9B0256E062"
 			tasks: [{
 				id: "2B9ADBDF75721934"
 				type: "item"
 				item: "spectrum:lime_pigment"
 			}]
+			id: "64CFFA9B0256E062"
+			x: 5.0d
+			y: 2.5d
 			rewards: [{
 				id: "6F1CCF589652C316"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["723E1C665A781C52"]
+			hide_dependency_lines: true
+			hide: true
 		}
 		{
-			x: 8.0d
-			y: 5.5d
-			hide_dependency_lines: true
-			dependencies: ["723E1C665A781C52"]
-			hide: true
-			id: "2B9252657949C67E"
 			tasks: [{
 				id: "7BEE98CD23CC9844"
 				type: "item"
 				item: "spectrum:pink_pigment"
 			}]
+			id: "2B9252657949C67E"
+			x: 8.0d
+			y: 5.5d
 			rewards: [{
 				id: "66A2CE85E4CA68C6"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["723E1C665A781C52"]
+			hide_dependency_lines: true
+			hide: true
 		}
 		{
-			x: 5.0d
-			y: 6.5d
-			hide_dependency_lines: true
-			dependencies: ["723E1C665A781C52"]
-			hide: true
-			id: "013FC32A48DE8E39"
 			tasks: [{
 				id: "3CE56A94BB668E9C"
 				type: "item"
 				item: "spectrum:cyan_pigment"
 			}]
+			id: "013FC32A48DE8E39"
+			x: 5.0d
+			y: 6.5d
 			rewards: [{
 				id: "67A9FDD934B7869B"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["723E1C665A781C52"]
+			hide_dependency_lines: true
+			hide: true
 		}
 		{
-			x: 8.0d
-			y: 7.5d
-			hide_dependency_lines: true
-			dependencies: ["723E1C665A781C52"]
-			hide: true
-			id: "4451D4AA7CB1BFF2"
 			tasks: [{
 				id: "6CB63845CBBC2DF2"
 				type: "item"
 				item: "spectrum:purple_pigment"
 			}]
+			id: "4451D4AA7CB1BFF2"
+			x: 8.0d
+			y: 7.5d
 			rewards: [{
 				id: "792070E157CF1065"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["723E1C665A781C52"]
+			hide_dependency_lines: true
+			hide: true
 		}
 		{
-			x: 5.0d
-			y: 4.5d
-			hide_dependency_lines: true
-			dependencies: ["723E1C665A781C52"]
-			hide: true
-			id: "54A1328F07B4BF16"
 			tasks: [{
 				id: "702FE6C32B80A53E"
 				type: "item"
 				item: "spectrum:blue_pigment"
 			}]
+			id: "54A1328F07B4BF16"
+			x: 5.0d
+			y: 4.5d
 			rewards: [{
 				id: "35756DC7E76EE4E2"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["723E1C665A781C52"]
+			hide_dependency_lines: true
+			hide: true
 		}
 		{
-			x: 5.0d
-			y: 3.5d
-			hide_dependency_lines: true
-			dependencies: ["723E1C665A781C52"]
-			hide: true
-			id: "5008ED129CAE4EED"
 			tasks: [{
 				id: "4D330581B9875B00"
 				type: "item"
 				item: "spectrum:green_pigment"
 			}]
+			id: "5008ED129CAE4EED"
+			x: 5.0d
+			y: 3.5d
 			rewards: [{
 				id: "3CE84D947815AF7D"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["723E1C665A781C52"]
+			hide_dependency_lines: true
+			hide: true
 		}
 		{
-			x: 8.0d
-			y: 4.5d
-			hide_dependency_lines: true
-			dependencies: ["723E1C665A781C52"]
-			hide: true
-			id: "2B486D1AE4A59F73"
 			tasks: [{
 				id: "00F3A6DC94F0AC91"
 				type: "item"
 				item: "spectrum:red_pigment"
 			}]
+			id: "2B486D1AE4A59F73"
+			x: 8.0d
+			y: 4.5d
 			rewards: [{
 				id: "5453E67AEACD0B09"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["723E1C665A781C52"]
+			hide_dependency_lines: true
+			hide: true
 		}
 		{
-			x: 6.5d
-			y: 1.5d
-			dependencies: [
-				"4C06D25DACB5536C"
-				"3A53CED5C9ABC06B"
-			]
-			hide: true
-			id: "49D9ECC98F3A5E05"
 			tasks: [{
 				id: "2FD8A5F5867DD21E"
 				type: "advancement"
 				advancement: "spectrum:build_fusion_shrine"
 				criterion: ""
 			}]
+			id: "49D9ECC98F3A5E05"
+			x: 6.5d
+			y: 1.5d
 			rewards: [{
 				id: "0AE6F7E82DE777F4"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: [
+				"4C06D25DACB5536C"
+				"3A53CED5C9ABC06B"
+			]
+			hide: true
 		}
 		{
-			x: 8.0d
-			y: 1.5d
-			dependencies: ["49D9ECC98F3A5E05"]
-			hide: true
-			id: "6F3F4B2ADAAED3C1"
 			tasks: [{
 				id: "7D0EB9275BA39983"
 				type: "advancement"
 				advancement: "spectrum:create_onyx_shard"
 				criterion: ""
 			}]
+			id: "6F3F4B2ADAAED3C1"
+			x: 8.0d
+			y: 1.5d
 			rewards: [{
 				id: "6029A74459C27B43"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["49D9ECC98F3A5E05"]
+			hide: true
 		}
 		{
-			x: 9.5d
-			y: 1.5d
-			dependencies: ["6F3F4B2ADAAED3C1"]
-			hide: true
-			id: "6D98F53C0C9748C4"
 			tasks: [{
 				id: "3BD1F28CE6C6D457"
 				type: "advancement"
 				advancement: "spectrum:craft_onyx_pedestal"
 				criterion: ""
 			}]
+			id: "6D98F53C0C9748C4"
+			x: 9.5d
+			y: 1.5d
 			rewards: [{
 				id: "10F0A4EE7E7E6803"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["6F3F4B2ADAAED3C1"]
+			hide: true
 		}
 		{
-			x: 11.0d
-			y: 1.5d
-			dependencies: ["6D98F53C0C9748C4"]
-			hide: true
-			id: "681C638B38019A73"
 			tasks: [{
 				id: "11534701EC58670B"
 				type: "advancement"
 				advancement: "spectrum:midgame/build_advanced_pedestal_structure"
 				criterion: ""
 			}]
+			id: "681C638B38019A73"
+			x: 11.0d
+			y: 1.5d
 			rewards: [{
 				id: "4740DB8D7DFEE405"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["6D98F53C0C9748C4"]
+			hide: true
 		}
 		{
-			x: 12.5d
-			y: 1.5d
-			dependencies: ["681C638B38019A73"]
-			hide: true
-			id: "2F56655D7C4C3882"
 			tasks: [{
 				id: "0F13414A52097D55"
 				type: "advancement"
 				advancement: "spectrum:midgame/collect_scarlet"
 				criterion: ""
 			}]
+			id: "2F56655D7C4C3882"
+			x: 12.5d
+			y: 1.5d
 			rewards: [{
 				id: "28F8FB582AFFC021"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["681C638B38019A73"]
+			hide: true
 		}
 		{
-			x: 14.0d
-			y: 1.5d
-			description: [
-				"Your first Experiments were successful. But there has to be More..."
-				""
-				"This blob seems likely to be unsatisified with anything but the hardest of materials."
-			]
-			dependencies: ["678BCF3361AE5512"]
-			hide: true
-			id: "1810EB195B0CC509"
 			tasks: [{
 				id: "7889167DE36DEF22"
 				type: "advancement"
 				advancement: "spectrum:midgame/collect_neolith"
 				criterion: ""
 			}]
+			description: [
+				"Your first Experiments were successful. But there has to be More..."
+				""
+				"This blob seems likely to be unsatisified with anything but the hardest of materials."
+			]
+			id: "1810EB195B0CC509"
+			x: 14.0d
+			y: 1.5d
 			rewards: [{
 				id: "5653ABF9D4C32A2D"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["678BCF3361AE5512"]
+			hide: true
 		}
 		{
-			x: 11.0d
-			y: 6.0d
+			hide_text_until_complete: true
 			description: [
 				"You can submerge your Mermaids Brushes and Quitoxic Reeds in this fluid."
 				""
 				"They will grow faster!"
 			]
+			id: "0F6E96D9C9F5EF35"
+			x: 11.0d
+			y: 6.0d
+			rewards: [{
+				id: "24EEBA48321D09F0"
+				type: "loot"
+				table_id: 13756307348121783L
+			}]
 			dependencies: [
 				"681C638B38019A73"
 				"5584A52CAA574CFC"
 			]
-			hide: true
 			dependency_requirement: "one_completed"
-			hide_text_until_complete: true
-			id: "0F6E96D9C9F5EF35"
 			tasks: [{
 				id: "6D58C64A9CC63876"
 				type: "advancement"
 				advancement: "spectrum:midgame/enter_liquid_crystal"
 				criterion: ""
 			}]
-			rewards: [{
-				id: "24EEBA48321D09F0"
-				type: "loot"
-				table_id: 13756307348121783L
-			}]
+			hide: true
 		}
 		{
-			x: 12.5d
-			y: 6.0d
-			dependencies: ["0F6E96D9C9F5EF35"]
-			hide: false
-			id: "5EA323A52C146DEA"
 			tasks: [{
 				id: "42F25E8A341BEB26"
 				type: "advancement"
 				advancement: "spectrum:midgame/build_enchanting_structure"
 				criterion: ""
 			}]
+			id: "5EA323A52C146DEA"
+			x: 12.5d
+			y: 6.0d
 			rewards: [{
 				id: "05C1C6C9F5CECF91"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["0F6E96D9C9F5EF35"]
+			hide: false
 		}
 		{
-			x: 14.0d
-			y: 3.0d
-			dependencies: ["1810EB195B0CC509"]
-			hide: true
-			id: "2AB88707D86F0506"
 			tasks: [{
 				id: "0E372556B55A9935"
 				type: "advancement"
 				advancement: "spectrum:midgame/collect_azurite"
 				criterion: ""
 			}]
+			id: "2AB88707D86F0506"
+			x: 14.0d
+			y: 3.0d
 			rewards: [{
 				id: "396317CFD5EB00BF"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["1810EB195B0CC509"]
+			hide: true
 		}
 		{
-			x: 12.5d
-			y: 3.0d
-			description: ["Is your Failing spreading too far? Reverse its consumption with Decay Away!"]
-			dependencies: ["2AB88707D86F0506"]
-			hide: true
-			id: "0FC449098A9EAD1D"
 			tasks: [{
 				id: "0A9087BFACBDF44A"
 				type: "advancement"
 				advancement: "spectrum:midgame/craft_bottle_of_decay_away"
 				criterion: ""
 			}]
+			description: ["Is your Failing spreading too far? Reverse its consumption with Decay Away!"]
+			id: "0FC449098A9EAD1D"
+			x: 12.5d
+			y: 3.0d
 			rewards: [{
 				id: "40DACBBDC54E040E"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
-		}
-		{
-			x: 14.0d
-			y: 4.5d
-			description: ["Refine raw Azurite in the Fusion Shrine. You didn't think it would only be used once did you?"]
 			dependencies: ["2AB88707D86F0506"]
 			hide: true
-			id: "28CB44142633D257"
+		}
+		{
 			tasks: [{
 				id: "7A826E0E7E0F7C87"
 				type: "advancement"
 				advancement: "spectrum:midgame/create_refined_azurite"
 				criterion: ""
 			}]
+			description: ["Refine raw Azurite in the Fusion Shrine. You didn't think it would only be used once did you?"]
+			id: "28CB44142633D257"
+			x: 14.0d
+			y: 4.5d
 			rewards: [{
 				id: "1143364F1A2B988F"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["2AB88707D86F0506"]
+			hide: true
 		}
 		{
-			x: 10.5d
-			y: -2.0d
-			shape: "square"
-			description: ["Spectrum Mid Game"]
-			id: "5D1A91608FE45D0A"
 			tasks: [{
 				id: "4BA0EB2C5D96C882"
 				type: "advancement"
 				advancement: "spectrum:midgame/spectrum_midgame"
 				criterion: ""
 			}]
+			description: ["Spectrum Mid Game"]
+			id: "5D1A91608FE45D0A"
+			shape: "square"
+			y: -2.0d
+			x: 10.5d
 		}
 		{
-			x: 9.5d
-			y: -2.0d
-			shape: "square"
-			description: ["Spectrum Early Game"]
-			id: "790E66B088B92037"
 			tasks: [{
 				id: "5EA6ED20EC868381"
 				type: "advancement"
 				advancement: "spectrum:spectrum"
 				criterion: ""
 			}]
+			description: ["Spectrum Early Game"]
+			id: "790E66B088B92037"
+			shape: "square"
+			y: -2.0d
+			x: 9.5d
 		}
 		{
-			x: 14.0d
-			y: 0.0d
-			description: [
-				"This item seems to be related to storms..."
-				"Perhaps there is a item, that makes it more likely for lightning bolt to strike..."
-			]
-			dependencies: ["1810EB195B0CC509"]
-			id: "38BEF83AFD8EA081"
 			tasks: [{
 				id: "37714CE4A2C0677A"
 				type: "advancement"
 				advancement: "spectrum:midgame/collect_lightning_stone"
 				criterion: ""
 			}]
+			description: [
+				"This item seems to be related to storms..."
+				"Perhaps there is a item, that makes it more likely for lightning bolt to strike..."
+			]
+			id: "38BEF83AFD8EA081"
+			x: 14.0d
+			y: 0.0d
 			rewards: [{
 				id: "73376946C465455F"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["1810EB195B0CC509"]
 		}
 		{
+			hide_text_until_complete: true
+			description: ["This substance seems to be so unstable, that it crumbles in your inventory!"]
+			id: "0CF717072CD02B28"
 			x: 15.5d
 			y: 1.5d
-			description: ["This substance seems to be so unstable, that it crumbles in your inventory!"]
+			rewards: [{
+				id: "2C16AC1564787375"
+				type: "random"
+				table_id: 13756307348121783L
+			}]
 			dependencies: ["1810EB195B0CC509"]
-			hide: true
-			hide_text_until_complete: true
-			id: "0CF717072CD02B28"
 			tasks: [{
 				id: "35C7CB50261B9E25"
 				type: "advancement"
 				advancement: "spectrum:midgame/create_midnight_aberration"
 				criterion: ""
 			}]
-			rewards: [{
-				id: "2C16AC1564787375"
-				type: "random"
-				table_id: 13756307348121783L
-			}]
+			hide: true
 		}
 		{
-			x: 15.5d
-			y: 3.0d
-			description: ["Ouch! That hurt! Perhaps we should use the Midnight Solution on an entity..."]
-			dependencies: ["0CF717072CD02B28"]
-			hide: true
-			id: "120A70EB61245315"
 			tasks: [{
 				id: "0C9DCFB386B1AF2A"
 				type: "advancement"
 				advancement: "spectrum:midgame/collect_midnight_chip"
 				criterion: ""
 			}]
+			description: ["Ouch! That hurt! Perhaps we should use the Midnight Solution on an entity..."]
+			id: "120A70EB61245315"
+			x: 15.5d
+			y: 3.0d
 			rewards: [{
 				id: "5BC0FB0F8EBCF752"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["0CF717072CD02B28"]
+			hide: true
 		}
 		{
-			icon: "spectrum:black_pigment"
-			x: 11.0d
-			y: 0.0d
-			dependencies: ["681C638B38019A73"]
-			hide: true
-			id: "7B50D9F39BF07C16"
 			tasks: [{
 				id: "4E7D74069D2ABD87"
 				type: "advancement"
 				advancement: "spectrum:collect_all_basic_pigments"
 				criterion: ""
 			}]
+			icon: "spectrum:black_pigment"
+			id: "7B50D9F39BF07C16"
+			x: 11.0d
+			y: 0.0d
+			dependencies: ["681C638B38019A73"]
+			hide: true
 		}
 		{
-			x: 9.5d
-			y: 0.0d
-			dependencies: ["7B50D9F39BF07C16"]
-			hide: true
-			id: "00CE2107C6C46BE1"
 			tasks: [{
 				id: "505BC27038A8EF05"
 				type: "advancement"
 				advancement: "spectrum:collect_shooting_star"
 				criterion: ""
 			}]
+			dependencies: ["7B50D9F39BF07C16"]
+			id: "00CE2107C6C46BE1"
+			y: 0.0d
+			x: 9.5d
+			hide: true
 		}
 		{
-			x: 11.0d
-			y: 7.5d
-			description: ["Craft and place down a Color Picker."]
-			hide_dependency_lines: true
-			dependencies: ["5D1A91608FE45D0A"]
-			hide: true
-			id: "0A895BEB210EA39C"
 			tasks: [{
 				id: "0EF7BBEA7D70F057"
 				type: "advancement"
 				advancement: "spectrum:midgame/place_color_picker"
 				criterion: ""
 			}]
+			description: ["Craft and place down a Color Picker."]
+			id: "0A895BEB210EA39C"
+			x: 11.0d
+			y: 7.5d
+			dependencies: ["5D1A91608FE45D0A"]
+			hide_dependency_lines: true
+			hide: true
 		}
 		{
-			x: 12.5d
-			y: 7.5d
-			dependencies: ["0A895BEB210EA39C"]
-			hide: true
-			id: "5ADB895DCB77C6A8"
 			tasks: [{
 				id: "3083977D9E453EE2"
 				type: "advancement"
 				advancement: "spectrum:midgame/fill_ink_container"
 				criterion: ""
 			}]
+			dependencies: ["0A895BEB210EA39C"]
+			id: "5ADB895DCB77C6A8"
+			y: 7.5d
+			x: 12.5d
+			hide: true
 		}
 		{
-			x: 14.0d
-			y: 7.5d
-			dependencies: ["5ADB895DCB77C6A8"]
-			hide: true
-			id: "349FEF1506100E4D"
 			tasks: [{
 				id: "05A46F5786E43C89"
 				type: "advancement"
 				advancement: "spectrum:midgame/kill_entity_with_ink_projectile"
 				criterion: ""
 			}]
+			dependencies: ["5ADB895DCB77C6A8"]
+			id: "349FEF1506100E4D"
+			y: 7.5d
+			x: 14.0d
+			hide: true
 		}
 		{
-			x: 15.5d
-			y: 4.5d
-			dependencies: ["120A70EB61245315"]
-			hide: true
-			id: "110822566F9E2DBB"
 			tasks: [{
 				id: "4E83BEE7E58FB233"
 				type: "advancement"
 				advancement: "spectrum:midgame/craft_bottle_of_ruin"
 				criterion: ""
 			}]
+			dependencies: ["120A70EB61245315"]
+			id: "110822566F9E2DBB"
+			y: 4.5d
+			x: 15.5d
+			hide: true
 		}
 		{
-			x: 15.5d
-			y: 0.0d
-			dependencies: ["38BEF83AFD8EA081"]
-			hide: true
-			id: "78ED7745488BC27E"
 			tasks: [{
 				id: "68CD0B7A81BC2CB3"
 				type: "advancement"
 				advancement: "spectrum:midgame/collect_gemstone_shard_using_crystal_apothecary"
 				criterion: ""
 			}]
+			id: "78ED7745488BC27E"
+			x: 15.5d
+			y: 0.0d
 			rewards: [{
 				id: "5406245BE8A175B4"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["38BEF83AFD8EA081"]
+			hide: true
 		}
 		{
-			x: 17.0d
-			y: 3.0d
-			dependencies: ["120A70EB61245315"]
-			hide: true
-			id: "1E1E5ECB2C1C95B9"
 			tasks: [{
 				id: "64BC2C12B83AF299"
 				type: "advancement"
 				advancement: "spectrum:midgame/build_spirit_instiller_structure"
 				criterion: ""
 			}]
+			dependencies: ["120A70EB61245315"]
+			id: "1E1E5ECB2C1C95B9"
+			y: 3.0d
+			x: 17.0d
+			hide: true
 		}
 		{
-			x: 15.5d
-			y: 6.0d
-			dependencies: ["110822566F9E2DBB"]
-			hide: true
-			id: "16AFA6ABBF50A54C"
 			tasks: [{
 				id: "6C1D187007F8798F"
 				type: "advancement"
 				advancement: "spectrum:midgame/break_decayed_bedrock"
 				criterion: ""
 			}]
+			dependencies: ["110822566F9E2DBB"]
+			id: "16AFA6ABBF50A54C"
+			y: 6.0d
+			x: 15.5d
+			hide: true
 		}
 		{
-			x: 15.5d
-			y: 7.5d
-			dependencies: ["16AFA6ABBF50A54C"]
-			hide: true
-			id: "7CE00D3A16827F50"
 			tasks: [{
 				id: "7A6F1ABEF288A69F"
 				type: "advancement"
 				advancement: "spectrum:midgame/wear_complete_set_of_bedrock_armor"
 				criterion: ""
 			}]
+			dependencies: ["16AFA6ABBF50A54C"]
+			id: "7CE00D3A16827F50"
+			y: 7.5d
+			x: 15.5d
+			hide: true
 		}
 		{
-			x: 17.0d
-			y: 1.5d
-			subtitle: "Search the Ancient Ruins for this ancient plant!"
+			hide_text_until_complete: true
 			description: [
 				"Now that you succesfuly germinated a Jade Vine Bulb, you can get some hints on how to grow this plant."
 				""
@@ -1018,183 +1017,179 @@
 				"Then, it can be right-clicked with a glass bottle to get a new substance."
 				"If you don't harvest it for 2 consecutive nights, it will revert to stage 6!"
 			]
-			dependencies: ["1E1E5ECB2C1C95B9"]
-			hide: true
-			hide_text_until_complete: true
 			id: "3DE03D1D2B4BC9D0"
+			x: 17.0d
+			y: 1.5d
+			subtitle: "Search the Ancient Ruins for this ancient plant!"
+			dependencies: ["1E1E5ECB2C1C95B9"]
 			tasks: [{
 				id: "662B39B5C47F5D6B"
 				type: "advancement"
 				advancement: "spectrum:midgame/plant_jade_vines"
 				criterion: ""
 			}]
+			hide: true
 		}
 		{
-			x: 18.5d
-			y: 3.0d
-			dependencies: ["1E1E5ECB2C1C95B9"]
-			hide: true
-			id: "3E84D82AC7429CF4"
 			tasks: [{
 				id: "016F031021A0B903"
 				type: "advancement"
 				advancement: "spectrum:midgame/manifest_memory"
 				criterion: ""
 			}]
+			dependencies: ["1E1E5ECB2C1C95B9"]
+			id: "3E84D82AC7429CF4"
+			y: 3.0d
+			x: 18.5d
+			hide: true
 		}
 		{
-			x: 21.5d
-			y: 3.0d
-			dependencies: ["27A271B2A51373A6"]
-			hide: true
-			id: "0858F0938EC383B5"
 			tasks: [{
 				id: "4553B6B160CCB2A8"
 				type: "advancement"
 				advancement: "spectrum:midgame/craft_blacklisted_memory_success"
 				criterion: ""
 			}]
+			dependencies: ["27A271B2A51373A6"]
+			id: "0858F0938EC383B5"
+			y: 3.0d
+			x: 21.5d
+			hide: true
 		}
 		{
-			x: 20.0d
-			y: 3.0d
-			dependencies: ["3E84D82AC7429CF4"]
-			hide: false
-			id: "27A271B2A51373A6"
 			tasks: [{
 				id: "6A5DE0060CB4295D"
 				type: "advancement"
 				advancement: "spectrum:midgame/craft_blacklisted_memory_fail"
 				criterion: ""
 			}]
+			dependencies: ["3E84D82AC7429CF4"]
+			id: "27A271B2A51373A6"
+			y: 3.0d
+			x: 20.0d
+			hide: false
 		}
 		{
-			x: 18.5d
-			y: 1.5d
-			dependencies: ["3DE03D1D2B4BC9D0"]
-			hide: true
-			id: "117B54FCAF3A40B9"
 			tasks: [{
 				id: "6AD46CD52B099DC4"
 				type: "advancement"
 				advancement: "spectrum:midgame/harvest_moonstruck_nectar"
 				criterion: ""
 			}]
+			dependencies: ["3DE03D1D2B4BC9D0"]
+			id: "117B54FCAF3A40B9"
+			y: 1.5d
+			x: 18.5d
+			hide: true
 		}
 		{
-			x: 20.0d
-			y: 1.5d
-			dependencies: ["117B54FCAF3A40B9"]
-			hide: true
-			id: "1699D14B24CE2883"
 			tasks: [{
 				id: "5C67C82C30066C6D"
 				type: "advancement"
 				advancement: "spectrum:midgame/create_budding_onyx"
 				criterion: ""
 			}]
+			dependencies: ["117B54FCAF3A40B9"]
+			id: "1699D14B24CE2883"
+			y: 1.5d
+			x: 20.0d
+			hide: true
 		}
 		{
-			title: "Not Yet Available in Survival"
-			x: 17.0d
-			y: 6.0d
-			description: ["Not Yet Available in Survival"]
-			dependencies: ["16AFA6ABBF50A54C"]
-			hide: true
-			id: "5F98F94ABEC9673E"
 			tasks: [{
 				id: "45F1F7513D75C6CD"
 				type: "advancement"
 				advancement: "spectrum:midgame/enter_dimension"
 				criterion: ""
 			}]
+			description: ["Not Yet Available in Survival"]
+			id: "5F98F94ABEC9673E"
+			x: 17.0d
+			y: 6.0d
+			title: "Not Yet Available in Survival"
+			dependencies: ["16AFA6ABBF50A54C"]
+			hide: true
 		}
 		{
-			title: "Moonstone"
-			x: 18.5d
-			y: 6.0d
-			dependencies: ["5F98F94ABEC9673E"]
-			hide: true
-			id: "6210877F3EE8EE4C"
 			tasks: [{
 				id: "4E87AAAACAB88424"
 				type: "advancement"
 				advancement: "spectrum:midgame/collect_moonstone_shard"
 				criterion: ""
 			}]
+			id: "6210877F3EE8EE4C"
+			x: 18.5d
+			y: 6.0d
+			title: "Moonstone"
 			rewards: [{
 				id: "57FCAEAE3AD8012F"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["5F98F94ABEC9673E"]
+			hide: true
 		}
 		{
-			title: "Not Yet Available in Survival"
-			x: 20.0d
-			y: 6.0d
-			description: ["Use a Moonstone to Upgrade your Pigment Pedestal."]
-			dependencies: ["6210877F3EE8EE4C"]
-			hide: true
-			id: "0023E8716BF866A2"
 			tasks: [{
 				id: "267D7B7EE7A7C67A"
 				type: "advancement"
 				advancement: "spectrum:midgame/craft_moonstone_pedestal"
 				criterion: ""
 			}]
+			description: ["Use a Moonstone to Upgrade your Pigment Pedestal."]
+			id: "0023E8716BF866A2"
+			x: 20.0d
+			y: 6.0d
+			title: "Not Yet Available in Survival"
 			rewards: [{
 				id: "1B19D3AD728F1250"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["6210877F3EE8EE4C"]
+			hide: true
 		}
 		{
-			x: 12.5d
-			y: 4.5d
-			dependencies: ["28CB44142633D257"]
-			hide: true
-			id: "3EF90588748BCDE8"
 			tasks: [{
 				id: "7F62A84995E6AC3A"
 				type: "advancement"
 				advancement: "spectrum:midgame/get_azure_dike_charge"
 				criterion: ""
 			}]
+			id: "3EF90588748BCDE8"
+			x: 12.5d
+			y: 4.5d
 			rewards: [{
 				id: "219059EE1D7938E4"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["28CB44142633D257"]
+			hide: true
 		}
 		{
-			x: 14.0d
-			y: 6.0d
-			description: [
-				"It seems you got lost..."
-				"Try crafting every Dike Trinket, that you can craft!"
-			]
-			dependencies: ["28CB44142633D257"]
-			hide: false
-			id: "054231A4D84A5569"
 			tasks: [{
 				id: "02067EB7D2A55E90"
 				type: "advancement"
 				advancement: "spectrum:midgame/fill_pigment_palette"
 				criterion: ""
 			}]
+			description: [
+				"It seems you got lost..."
+				"Try crafting every Dike Trinket, that you can craft!"
+			]
+			id: "054231A4D84A5569"
+			x: 14.0d
+			y: 6.0d
 			rewards: [{
 				id: "2BD34F667AC30BBA"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["28CB44142633D257"]
+			hide: false
 		}
 		{
-			title: "Budding Crystals"
-			x: 6.5d
-			y: 0.0d
-			subtitle: "Craftable only on new moon nights, just like Onyx."
-			dependencies: ["49D9ECC98F3A5E05"]
-			id: "3C392862FC5CA225"
 			tasks: [
 				{
 					id: "75936E139587B1B5"
@@ -1212,19 +1207,19 @@
 					item: "spectrum:budding_citrine"
 				}
 			]
+			id: "3C392862FC5CA225"
+			x: 6.5d
+			y: 0.0d
+			title: "Budding Crystals"
 			rewards: [{
 				id: "60F4D2895D3954A5"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Craftable only on new moon nights, just like Onyx."
+			dependencies: ["49D9ECC98F3A5E05"]
 		}
 		{
-			title: "Shards"
-			x: 0.5d
-			y: 1.5d
-			subtitle: "Collect all the Shards!"
-			dependencies: ["6F9B2ECCE750C280"]
-			id: "2CC5282720701CB2"
 			tasks: [
 				{
 					id: "741E15F4FB15D690"
@@ -1242,26 +1237,31 @@
 					item: "spectrum:citrine_shard"
 				}
 			]
+			id: "2CC5282720701CB2"
+			x: 0.5d
+			y: 1.5d
+			title: "Shards"
 			rewards: [{
 				id: "6116A006C23BCC0B"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Collect all the Shards!"
+			dependencies: ["6F9B2ECCE750C280"]
 		}
 		{
-			x: 9.5d
-			y: 3.0d
-			subtitle: "Obtainable using Botania's Petal Apothecary."
-			description: ["Plant it underwater. After some time, you will get a new item!"]
-			dependencies: ["6F3F4B2ADAAED3C1"]
-			hide: true
-			id: "62497389C3267837"
 			tasks: [{
 				id: "441428F5822DD91A"
 				type: "item"
 				item: "spectrum:mermaids_brush"
 			}]
+			description: ["Plant it underwater. After some time, you will get a new item!"]
+			id: "62497389C3267837"
+			x: 9.5d
+			y: 3.0d
+			subtitle: "Obtainable using Botania's Petal Apothecary."
+			dependencies: ["6F3F4B2ADAAED3C1"]
+			hide: true
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/spectrum_unlock_progress.snbt
+++ b/config/ftbquests/quests/chapters/spectrum_unlock_progress.snbt
@@ -1,317 +1,317 @@
 {
-	id: "46E31DEF8626C677"
+	always_invisible: true
+	default_hide_dependency_lines: false
+	default_quest_shape: ""
 	group: "1FCC565F739A4207"
-	order_index: 1
+	id: "46E31DEF8626C677"
 	filename: "spectrum_unlock_progress"
-	title: "Spectrum Unlocks"
 	icon: "extended_drawers:lock"
+	title: "Spectrum Unlocks"
 	subtitle: [
 		"A list of unlocks for Spectrum's mostly side content."
 		"These are advancements located in \"spectrum/progression\" invisible tree."
 	]
-	always_invisible: true
-	default_quest_shape: ""
-	default_hide_dependency_lines: false
+	order_index: 1
 	quests: [
 		{
 			x: -2.0d
 			y: -1.5d
 			id: "5603849F2BCF0982"
 			tasks: [{
-				id: "236F0AE48ECDDA32"
 				type: "advancement"
-				title: "Unlock Weather Detector"
-				icon: "spectrum:weather_detector"
 				advancement: "spectrum:progression/detectors/unlock_weather_detector"
 				criterion: ""
+				id: "236F0AE48ECDDA32"
+				icon: "spectrum:weather_detector"
+				title: "Unlock Weather Detector"
 			}]
 		}
 		{
-			icon: "blockus:rainbow_lamp_lit"
-			x: -7.0d
-			y: -3.5d
-			id: "723ACD270A56B1FB"
 			tasks: [{
-				id: "0DB76EAA2824DCA1"
 				type: "advancement"
-				title: "Unlock Any Colored Lamp"
-				icon: "blockus:rainbow_lamp_lit"
 				advancement: "spectrum:progression/colored_lamps/unlock_any_colored_lamp"
 				criterion: ""
+				id: "0DB76EAA2824DCA1"
+				icon: "blockus:rainbow_lamp_lit"
+				title: "Unlock Any Colored Lamp"
 			}]
+			id: "723ACD270A56B1FB"
+			y: -3.5d
+			x: -7.0d
+			icon: "blockus:rainbow_lamp_lit"
 		}
 		{
-			icon: "spectrum:black_lamp"
-			x: -6.0d
-			y: -3.5d
-			id: "72DFA71D876EFC92"
 			tasks: [{
-				id: "0404A5530147AD4B"
 				type: "advancement"
-				title: "Unlock Black Lamp"
-				icon: "spectrum:black_lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_black_lamp"
 				criterion: ""
+				id: "0404A5530147AD4B"
+				icon: "spectrum:black_lamp"
+				title: "Unlock Black Lamp"
 			}]
+			id: "72DFA71D876EFC92"
+			y: -3.5d
+			x: -6.0d
+			icon: "spectrum:black_lamp"
 		}
 		{
-			icon: "spectrum:blue_lamp"
-			x: -5.0d
-			y: -3.5d
-			id: "14C1A497833A77F9"
 			tasks: [{
-				id: "1F6E849C0D209796"
 				type: "advancement"
-				title: "Unlock Blue Lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_blue_lamp"
 				criterion: ""
+				id: "1F6E849C0D209796"
+				title: "Unlock Blue Lamp"
 			}]
+			id: "14C1A497833A77F9"
+			y: -3.5d
+			x: -5.0d
+			icon: "spectrum:blue_lamp"
 		}
 		{
-			icon: "spectrum:brown_lamp"
-			x: -4.0d
-			y: -3.5d
-			id: "259A308ACD6ED3DE"
 			tasks: [{
-				id: "2B2C90C8A793ED30"
 				type: "advancement"
-				title: "Unlock Brown Lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_brown_lamp"
 				criterion: ""
+				id: "2B2C90C8A793ED30"
+				title: "Unlock Brown Lamp"
 			}]
+			id: "259A308ACD6ED3DE"
+			y: -3.5d
+			x: -4.0d
+			icon: "spectrum:brown_lamp"
 		}
 		{
-			icon: "spectrum:cyan_lamp"
-			x: -3.0d
-			y: -3.5d
-			id: "074ED5C5A6D5D5DE"
 			tasks: [{
-				id: "29AC34ABC63E6F81"
 				type: "advancement"
-				title: "Unlock Cyan Lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_cyan_lamp"
 				criterion: ""
+				id: "29AC34ABC63E6F81"
+				title: "Unlock Cyan Lamp"
 			}]
+			id: "074ED5C5A6D5D5DE"
+			y: -3.5d
+			x: -3.0d
+			icon: "spectrum:cyan_lamp"
 		}
 		{
-			icon: "spectrum:gray_lamp"
-			x: -2.0d
-			y: -3.5d
-			id: "332655A44F40CCDC"
 			tasks: [{
-				id: "0BBA81EA9D5F2036"
 				type: "advancement"
-				title: "Unlock Gray Lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_gray_lamp"
 				criterion: ""
+				id: "0BBA81EA9D5F2036"
+				title: "Unlock Gray Lamp"
 			}]
+			id: "332655A44F40CCDC"
+			y: -3.5d
+			x: -2.0d
+			icon: "spectrum:gray_lamp"
 		}
 		{
-			icon: "spectrum:green_lamp"
-			x: -1.0d
-			y: -3.5d
-			id: "4209ED40E4B0A561"
 			tasks: [{
-				id: "3512A96C237348DD"
 				type: "advancement"
-				title: "Unlock Green Lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_green_lamp"
 				criterion: ""
+				id: "3512A96C237348DD"
+				title: "Unlock Green Lamp"
 			}]
+			id: "4209ED40E4B0A561"
+			y: -3.5d
+			x: -1.0d
+			icon: "spectrum:green_lamp"
 		}
 		{
-			icon: "spectrum:light_blue_lamp"
-			x: 0.0d
-			y: -3.5d
-			id: "7BAD8D883F52E835"
 			tasks: [{
-				id: "1437499864716F52"
 				type: "advancement"
-				title: "Unlock Light Blue Lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_light_blue_lamp"
 				criterion: ""
+				id: "1437499864716F52"
+				title: "Unlock Light Blue Lamp"
 			}]
+			id: "7BAD8D883F52E835"
+			y: -3.5d
+			x: 0.0d
+			icon: "spectrum:light_blue_lamp"
 		}
 		{
-			icon: "spectrum:light_gray_lamp"
-			x: 1.0d
-			y: -3.5d
-			id: "26C74BD9A9577A50"
 			tasks: [{
-				id: "72218A997AB8DEC7"
 				type: "advancement"
-				title: "Unlock Light Gray Lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_light_gray_lamp"
 				criterion: ""
+				id: "72218A997AB8DEC7"
+				title: "Unlock Light Gray Lamp"
 			}]
+			id: "26C74BD9A9577A50"
+			y: -3.5d
+			x: 1.0d
+			icon: "spectrum:light_gray_lamp"
 		}
 		{
-			icon: "spectrum:lime_lamp"
-			x: 2.0d
-			y: -3.5d
-			id: "4A52584FA39A89C0"
 			tasks: [{
-				id: "3D4E4348C5D2A30E"
 				type: "advancement"
-				title: "Unlock Lime Lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_lime_lamp"
 				criterion: ""
+				id: "3D4E4348C5D2A30E"
+				title: "Unlock Lime Lamp"
 			}]
+			id: "4A52584FA39A89C0"
+			y: -3.5d
+			x: 2.0d
+			icon: "spectrum:lime_lamp"
 		}
 		{
-			icon: "spectrum:magenta_lamp"
-			x: 3.0d
-			y: -3.5d
-			id: "33EA98C627457B47"
 			tasks: [{
-				id: "614719B652200387"
 				type: "advancement"
-				title: "Unlock Magenta Lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_magenta_lamp"
 				criterion: ""
+				id: "614719B652200387"
+				title: "Unlock Magenta Lamp"
 			}]
+			id: "33EA98C627457B47"
+			y: -3.5d
+			x: 3.0d
+			icon: "spectrum:magenta_lamp"
 		}
 		{
-			icon: "spectrum:orange_lamp"
-			x: 4.0d
-			y: -3.5d
-			id: "4D30F3AE2382CB21"
 			tasks: [{
-				id: "1ADEB5701BF9F5E6"
 				type: "advancement"
-				title: "Unlock Orange Lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_orange_lamp"
 				criterion: ""
+				id: "1ADEB5701BF9F5E6"
+				title: "Unlock Orange Lamp"
 			}]
+			id: "4D30F3AE2382CB21"
+			y: -3.5d
+			x: 4.0d
+			icon: "spectrum:orange_lamp"
 		}
 		{
-			icon: "spectrum:pink_lamp"
-			x: 5.0d
-			y: -3.5d
-			id: "7ABFC140641ABCB5"
 			tasks: [{
-				id: "51413A98CF2B24AB"
 				type: "advancement"
-				title: "Unlock Pink Lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_pink_lamp"
 				criterion: ""
+				id: "51413A98CF2B24AB"
+				title: "Unlock Pink Lamp"
 			}]
+			id: "7ABFC140641ABCB5"
+			y: -3.5d
+			x: 5.0d
+			icon: "spectrum:pink_lamp"
 		}
 		{
-			icon: "spectrum:purple_lamp"
-			x: 6.0d
-			y: -3.5d
-			id: "2D2BE19E19A87203"
 			tasks: [{
-				id: "3B84F85E9822186E"
 				type: "advancement"
-				title: "Unlock Purple Lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_purple_lamp"
 				criterion: ""
+				id: "3B84F85E9822186E"
+				title: "Unlock Purple Lamp"
 			}]
+			id: "2D2BE19E19A87203"
+			y: -3.5d
+			x: 6.0d
+			icon: "spectrum:purple_lamp"
 		}
 		{
-			icon: "spectrum:red_lamp"
-			x: 7.0d
-			y: -3.5d
-			id: "05983E77E1B511AA"
 			tasks: [{
-				id: "1B9157CAFB06FE29"
 				type: "advancement"
-				title: "Unlock Red Lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_red_lamp"
 				criterion: ""
+				id: "1B9157CAFB06FE29"
+				title: "Unlock Red Lamp"
 			}]
+			id: "05983E77E1B511AA"
+			y: -3.5d
+			x: 7.0d
+			icon: "spectrum:red_lamp"
 		}
 		{
-			icon: "spectrum:white_lamp"
-			x: 8.0d
-			y: -3.5d
-			id: "1D25127DD30F1BD9"
 			tasks: [{
-				id: "204D4ECFFDF25FCA"
 				type: "advancement"
-				title: "Unlock White Lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_white_lamp"
 				criterion: ""
+				id: "204D4ECFFDF25FCA"
+				title: "Unlock White Lamp"
 			}]
+			id: "1D25127DD30F1BD9"
+			y: -3.5d
+			x: 8.0d
+			icon: "spectrum:white_lamp"
 		}
 		{
-			icon: "spectrum:yellow_lamp"
-			x: -7.0d
-			y: -2.5d
-			id: "778FAFE4DA07E117"
 			tasks: [{
-				id: "331F2F32BF26721F"
 				type: "advancement"
-				title: "Unlock Yellow Lamp"
 				advancement: "spectrum:progression/colored_lamps/unlock_yellow_lamp"
 				criterion: ""
+				id: "331F2F32BF26721F"
+				title: "Unlock Yellow Lamp"
 			}]
+			id: "778FAFE4DA07E117"
+			y: -2.5d
+			x: -7.0d
+			icon: "spectrum:yellow_lamp"
 		}
 		{
-			icon: "spectrum:black_sapling"
-			x: -6.0d
-			y: -2.5d
-			id: "25F7F1FA1D1171AE"
 			tasks: [{
-				id: "09B94E5E20AF4434"
 				type: "advancement"
-				title: "Unlock Black Sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_black_sapling"
 				criterion: ""
+				id: "09B94E5E20AF4434"
+				title: "Unlock Black Sapling"
 			}]
+			id: "25F7F1FA1D1171AE"
+			y: -2.5d
+			x: -6.0d
+			icon: "spectrum:black_sapling"
 		}
 		{
-			icon: "spectrum:blue_sapling"
-			x: -5.0d
-			y: -2.5d
-			id: "62C2801DBCFFAB71"
 			tasks: [{
-				id: "70EA9E6EA7E75DA5"
 				type: "advancement"
-				title: "Unlock Blue Sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_blue_sapling"
 				criterion: ""
+				id: "70EA9E6EA7E75DA5"
+				title: "Unlock Blue Sapling"
 			}]
+			id: "62C2801DBCFFAB71"
+			y: -2.5d
+			x: -5.0d
+			icon: "spectrum:blue_sapling"
 		}
 		{
-			icon: "spectrum:brown_sapling"
-			x: -4.0d
-			y: -2.5d
-			id: "48553A90F633B6E8"
 			tasks: [{
-				id: "5BD9D809ED8C2F79"
 				type: "advancement"
-				title: "Unlock Brown Sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_brown_sapling"
 				criterion: ""
+				id: "5BD9D809ED8C2F79"
+				title: "Unlock Brown Sapling"
 			}]
+			id: "48553A90F633B6E8"
+			y: -2.5d
+			x: -4.0d
+			icon: "spectrum:brown_sapling"
 		}
 		{
-			icon: "spectrum:cyan_sapling"
-			x: -3.0d
-			y: -2.5d
-			id: "19BD837EAAF94506"
 			tasks: [{
-				id: "2BF072054C78B9D5"
 				type: "advancement"
-				title: "Unlock Cyan Sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_cyan_sapling"
 				criterion: ""
+				id: "2BF072054C78B9D5"
+				title: "Unlock Cyan Sapling"
 			}]
+			id: "19BD837EAAF94506"
+			y: -2.5d
+			x: -3.0d
+			icon: "spectrum:cyan_sapling"
 		}
 		{
 			x: -2.0d
 			y: -2.5d
 			id: "14A805BCA7806818"
 			tasks: [{
-				id: "117FA0B5E7F89B7C"
 				type: "advancement"
-				title: "Unlock Gray Sapling"
-				icon: "spectrum:gray_sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_gray_sapling"
 				criterion: ""
+				id: "117FA0B5E7F89B7C"
+				icon: "spectrum:gray_sapling"
+				title: "Unlock Gray Sapling"
 			}]
 		}
 		{
@@ -319,12 +319,12 @@
 			y: -2.5d
 			id: "44C6BFDF3EB4DD7D"
 			tasks: [{
-				id: "6C9E3586CF7D6632"
 				type: "advancement"
-				title: "Unlock Green Sapling"
-				icon: "spectrum:green_sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_green_sapling"
 				criterion: ""
+				id: "6C9E3586CF7D6632"
+				icon: "spectrum:green_sapling"
+				title: "Unlock Green Sapling"
 			}]
 		}
 		{
@@ -332,12 +332,12 @@
 			y: -2.5d
 			id: "5E11EC2D91648F7D"
 			tasks: [{
-				id: "0B3BB65301FD7F4E"
 				type: "advancement"
-				title: "Unlock Light Blue Sapling"
-				icon: "spectrum:light_blue_sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_light_blue_sapling"
 				criterion: ""
+				id: "0B3BB65301FD7F4E"
+				icon: "spectrum:light_blue_sapling"
+				title: "Unlock Light Blue Sapling"
 			}]
 		}
 		{
@@ -345,12 +345,12 @@
 			y: -2.5d
 			id: "6B54BDF275EA6C87"
 			tasks: [{
-				id: "3CB44D915E91FEBF"
 				type: "advancement"
-				title: "Unlock Light Gray Sapling"
-				icon: "spectrum:light_gray_sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_light_gray_sapling"
 				criterion: ""
+				id: "3CB44D915E91FEBF"
+				icon: "spectrum:light_gray_sapling"
+				title: "Unlock Light Gray Sapling"
 			}]
 		}
 		{
@@ -358,12 +358,12 @@
 			y: -2.5d
 			id: "13AC9345601D4682"
 			tasks: [{
-				id: "196E0918842814A5"
 				type: "advancement"
-				title: "Unlock Lime Sapling"
-				icon: "spectrum:lime_sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_lime_sapling"
 				criterion: ""
+				id: "196E0918842814A5"
+				icon: "spectrum:lime_sapling"
+				title: "Unlock Lime Sapling"
 			}]
 		}
 		{
@@ -371,12 +371,12 @@
 			y: -2.5d
 			id: "0765F465A520329F"
 			tasks: [{
-				id: "1F3F6FED43036A7F"
 				type: "advancement"
-				title: "Unlock Magenta Sapling"
-				icon: "spectrum:magenta_sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_magenta_sapling"
 				criterion: ""
+				id: "1F3F6FED43036A7F"
+				icon: "spectrum:magenta_sapling"
+				title: "Unlock Magenta Sapling"
 			}]
 		}
 		{
@@ -384,12 +384,12 @@
 			y: -2.5d
 			id: "68D5ED9919AD6BE0"
 			tasks: [{
-				id: "63EFE28BF932D872"
 				type: "advancement"
-				title: "Unlock Orange Sapling"
-				icon: "spectrum:orange_sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_orange_sapling"
 				criterion: ""
+				id: "63EFE28BF932D872"
+				icon: "spectrum:orange_sapling"
+				title: "Unlock Orange Sapling"
 			}]
 		}
 		{
@@ -397,12 +397,12 @@
 			y: -2.5d
 			id: "7AD2EE44AF21D857"
 			tasks: [{
-				id: "5521CA7154856F6B"
 				type: "advancement"
-				title: "Unlock Pink Sapling"
-				icon: "spectrum:pink_sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_pink_sapling"
 				criterion: ""
+				id: "5521CA7154856F6B"
+				icon: "spectrum:pink_sapling"
+				title: "Unlock Pink Sapling"
 			}]
 		}
 		{
@@ -410,12 +410,12 @@
 			y: -2.5d
 			id: "42912D485546E28F"
 			tasks: [{
-				id: "41F79088140A08B6"
 				type: "advancement"
-				title: "Unlock Purple Sapling"
-				icon: "spectrum:purple_sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_purple_sapling"
 				criterion: ""
+				id: "41F79088140A08B6"
+				icon: "spectrum:purple_sapling"
+				title: "Unlock Purple Sapling"
 			}]
 		}
 		{
@@ -423,12 +423,12 @@
 			y: -2.5d
 			id: "5B5D06BAB4133473"
 			tasks: [{
-				id: "07BEC84901F60B0C"
 				type: "advancement"
-				title: "Unlock Red Sapling"
-				icon: "spectrum:red_sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_red_sapling"
 				criterion: ""
+				id: "07BEC84901F60B0C"
+				icon: "spectrum:red_sapling"
+				title: "Unlock Red Sapling"
 			}]
 		}
 		{
@@ -436,12 +436,12 @@
 			y: -2.5d
 			id: "4352B0E2126C0D65"
 			tasks: [{
-				id: "4C3CC64574D122C4"
 				type: "advancement"
-				title: "Unlock White Sapling"
-				icon: "spectrum:white_sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_white_sapling"
 				criterion: ""
+				id: "4C3CC64574D122C4"
+				icon: "spectrum:white_sapling"
+				title: "Unlock White Sapling"
 			}]
 		}
 		{
@@ -449,39 +449,39 @@
 			y: -1.5d
 			id: "7A71DCD716C04065"
 			tasks: [{
-				id: "3DD09A0287DFAC49"
 				type: "advancement"
-				title: "Unlock Yellow Sapling"
-				icon: "spectrum:yellow_sapling"
 				advancement: "spectrum:progression/colored_saplings/unlock_yellow_sapling"
 				criterion: ""
+				id: "3DD09A0287DFAC49"
+				icon: "spectrum:yellow_sapling"
+				title: "Unlock Yellow Sapling"
 			}]
 		}
 		{
-			icon: "spectrum:entity_detector"
-			x: -6.0d
-			y: -1.5d
-			id: "006A136682466EF9"
 			tasks: [{
-				id: "28723DBFB6D52D8B"
 				type: "advancement"
-				title: "Unlock Creature Detector"
-				icon: "spectrum:entity_detector"
 				advancement: "spectrum:progression/detectors/unlock_entity_detector"
 				criterion: ""
+				id: "28723DBFB6D52D8B"
+				icon: "spectrum:entity_detector"
+				title: "Unlock Creature Detector"
 			}]
+			id: "006A136682466EF9"
+			y: -1.5d
+			x: -6.0d
+			icon: "spectrum:entity_detector"
 		}
 		{
 			x: -5.0d
 			y: -1.5d
 			id: "6E03AD76AB457B71"
 			tasks: [{
-				id: "6EA0447ED3C49DB7"
 				type: "advancement"
-				title: "Unlock Item Detector"
-				icon: "spectrum:item_detector"
 				advancement: "spectrum:progression/detectors/unlock_item_detector"
 				criterion: ""
+				id: "6EA0447ED3C49DB7"
+				icon: "spectrum:item_detector"
+				title: "Unlock Item Detector"
 			}]
 		}
 		{
@@ -489,38 +489,38 @@
 			y: -1.5d
 			id: "1791A2D41004968A"
 			tasks: [{
-				id: "2CD0A52FCFE51582"
 				type: "advancement"
-				title: "Unlock Block Light Detector"
-				icon: "spectrum:light_level_detector"
 				advancement: "spectrum:progression/detectors/unlock_light_level_detector"
 				criterion: ""
+				id: "2CD0A52FCFE51582"
+				icon: "spectrum:light_level_detector"
+				title: "Unlock Block Light Detector"
 			}]
 		}
 		{
-			icon: "spectrum:player_detector"
-			x: -3.0d
-			y: -1.5d
-			id: "210315462D910C68"
 			tasks: [{
-				id: "5685C2D3C14D7241"
 				type: "advancement"
-				title: "Unlock Player Detector"
 				advancement: "spectrum:progression/detectors/unlock_player_detector"
 				criterion: ""
+				id: "5685C2D3C14D7241"
+				title: "Unlock Player Detector"
 			}]
+			id: "210315462D910C68"
+			y: -1.5d
+			x: -3.0d
+			icon: "spectrum:player_detector"
 		}
 		{
 			x: -1.0d
 			y: -1.5d
 			id: "50B761ABAFF6ED46"
 			tasks: [{
-				id: "021C8E6CFBD733AF"
 				type: "advancement"
-				title: "Enchantment: §eAutosmelt§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/autosmelt"
 				criterion: ""
+				id: "021C8E6CFBD733AF"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eAutosmelt§r"
 			}]
 		}
 		{
@@ -528,12 +528,12 @@
 			y: -1.5d
 			id: "03D73F832CB3FA4F"
 			tasks: [{
-				id: "3161858B30FB8C88"
 				type: "advancement"
-				title: "Enchantment: §eBig Catch§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/big_catch"
 				criterion: ""
+				id: "3161858B30FB8C88"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eBig Catch§r"
 			}]
 		}
 		{
@@ -541,12 +541,12 @@
 			y: -1.5d
 			id: "2108D821B819EC58"
 			tasks: [{
-				id: "191F8752582766BE"
 				type: "advancement"
-				title: "Enchantment: §eClover's Favor§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/clovers_favor"
 				criterion: ""
+				id: "191F8752582766BE"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eClover's Favor§r"
 			}]
 		}
 		{
@@ -554,12 +554,12 @@
 			y: -1.5d
 			id: "371863F8BA489EFE"
 			tasks: [{
-				id: "36BCF45C059548F7"
 				type: "advancement"
-				title: "Enchantment: §eDisarming§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/disarming"
 				criterion: ""
+				id: "36BCF45C059548F7"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eDisarming§r"
 			}]
 		}
 		{
@@ -567,12 +567,12 @@
 			y: -1.5d
 			id: "7F6E7EEA7523F2A6"
 			tasks: [{
-				id: "371D5FFB93FC96EA"
 				type: "advancement"
-				title: "Enchantment: §eExuberance§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/exuberance"
 				criterion: ""
+				id: "371D5FFB93FC96EA"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eExuberance§r"
 			}]
 		}
 		{
@@ -580,12 +580,12 @@
 			y: -1.5d
 			id: "1BE502080CF3F983"
 			tasks: [{
-				id: "033F2E959A473FCE"
 				type: "advancement"
-				title: "Enchantment: §eFirst Strike§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/first_strike"
 				criterion: ""
+				id: "033F2E959A473FCE"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eFirst Strike§r"
 			}]
 		}
 		{
@@ -593,12 +593,12 @@
 			y: -1.5d
 			id: "1E8A530A0FDE5B45"
 			tasks: [{
-				id: "36B53CDF08D6E135"
 				type: "advancement"
-				title: "Enchantment: §eImproved Critical§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/improved_critical"
 				criterion: ""
+				id: "36B53CDF08D6E135"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eImproved Critical§r"
 			}]
 		}
 		{
@@ -606,12 +606,12 @@
 			y: -1.5d
 			id: "175BA9DF117544AC"
 			tasks: [{
-				id: "486EC65B6265D4C4"
 				type: "advancement"
-				title: "Enchantment: §eIndestructible§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/indestructible"
 				criterion: ""
+				id: "486EC65B6265D4C4"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eIndestructible§r"
 			}]
 		}
 		{
@@ -619,12 +619,12 @@
 			y: -1.5d
 			id: "238F42025EA0FD21"
 			tasks: [{
-				id: "37C0CC7A7EE8EBAD"
 				type: "advancement"
-				title: "Enchantment: §eInertia§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/inertia"
 				criterion: ""
+				id: "37C0CC7A7EE8EBAD"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eInertia§r"
 			}]
 		}
 		{
@@ -632,12 +632,12 @@
 			y: -1.5d
 			id: "49A9D6712581C8C0"
 			tasks: [{
-				id: "4C9228913124B8DC"
 				type: "advancement"
-				title: "Enchantment: §eInventory Insertion§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/inventory_insertion"
 				criterion: ""
+				id: "4C9228913124B8DC"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eInventory Insertion§r"
 			}]
 		}
 		{
@@ -645,12 +645,12 @@
 			y: -0.5d
 			id: "30F5DEEB8E574039"
 			tasks: [{
-				id: "5ADB33A0B35A5351"
 				type: "advancement"
-				title: "Enchantment: §ePest Control§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/pest_control"
 				criterion: ""
+				id: "5ADB33A0B35A5351"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §ePest Control§r"
 			}]
 		}
 		{
@@ -658,12 +658,12 @@
 			y: -0.5d
 			id: "21F2FE0BF95A6A09"
 			tasks: [{
-				id: "0818B37D38160B34"
 				type: "advancement"
-				title: "Enchantment: §eResonance§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/resonance"
 				criterion: ""
+				id: "0818B37D38160B34"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eResonance§r"
 			}]
 		}
 		{
@@ -671,12 +671,12 @@
 			y: -0.5d
 			id: "6B50A34A4A597C31"
 			tasks: [{
-				id: "336B47B0B94A46B9"
 				type: "advancement"
-				title: "Enchantment: §eSniper§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/sniper"
 				criterion: ""
+				id: "336B47B0B94A46B9"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eSniper§r"
 			}]
 		}
 		{
@@ -684,12 +684,12 @@
 			y: -0.5d
 			id: "7D31CA63A5910EFD"
 			tasks: [{
-				id: "2C803F29B4FEEB36"
 				type: "advancement"
-				title: "Enchantment: §eSteadfast§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/steadfast"
 				criterion: ""
+				id: "2C803F29B4FEEB36"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eSteadfast§r"
 			}]
 		}
 		{
@@ -697,12 +697,12 @@
 			y: -0.5d
 			id: "0660DC8D510599EF"
 			tasks: [{
-				id: "39812B6C32A147BA"
 				type: "advancement"
-				title: "Enchantment: §eTight Grip§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/tight_grip"
 				criterion: ""
+				id: "39812B6C32A147BA"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eTight Grip§r"
 			}]
 		}
 		{
@@ -710,12 +710,12 @@
 			y: -0.5d
 			id: "165CD9FEEF62BC8D"
 			tasks: [{
-				id: "3900AB8B82005640"
 				type: "advancement"
-				title: "Enchantment: §eTreasure Hunter§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/treasure_hunter"
 				criterion: ""
+				id: "3900AB8B82005640"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eTreasure Hunter§r"
 			}]
 		}
 		{
@@ -723,12 +723,12 @@
 			y: -0.5d
 			id: "7AD143A367A97469"
 			tasks: [{
-				id: "7396F6FC7567F3A5"
 				type: "advancement"
-				title: "§cVanilla Curses§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/vanilla_curses"
 				criterion: ""
+				id: "7396F6FC7567F3A5"
+				icon: "minecraft:enchanted_book"
+				title: "§cVanilla Curses§r"
 			}]
 		}
 		{
@@ -736,12 +736,12 @@
 			y: -0.5d
 			id: "523BA7CC77911A6E"
 			tasks: [{
-				id: "3D7A782EF2BF4EE2"
 				type: "advancement"
-				title: "Enchantment: §eSharpness§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/vanilla_damage"
 				criterion: ""
+				id: "3D7A782EF2BF4EE2"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eSharpness§r"
 			}]
 		}
 		{
@@ -749,12 +749,12 @@
 			y: -0.5d
 			id: "77266C7664638BE1"
 			tasks: [{
-				id: "1B1A42E8FB809477"
 				type: "advancement"
-				title: "Enchantment: §eLooting and Fortune§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/vanilla_luck"
 				criterion: ""
+				id: "1B1A42E8FB809477"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eLooting and Fortune§r"
 			}]
 		}
 		{
@@ -762,12 +762,12 @@
 			y: -0.5d
 			id: "4D352BF23E0EB30A"
 			tasks: [{
-				id: "1E9ED0D7CA5BC685"
 				type: "advancement"
-				title: "Enchantment: §ePower§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/vanilla_projectile"
 				criterion: ""
+				id: "1E9ED0D7CA5BC685"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §ePower§r"
 			}]
 		}
 		{
@@ -775,12 +775,12 @@
 			y: -0.5d
 			id: "1468A96DF6DDE364"
 			tasks: [{
-				id: "5C553E41878D63F4"
 				type: "advancement"
-				title: "Enchantment: §eInfinity§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/vanilla_projectile_infinity"
 				criterion: ""
+				id: "5C553E41878D63F4"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eInfinity§r"
 			}]
 		}
 		{
@@ -788,12 +788,12 @@
 			y: -0.5d
 			id: "509F7B2DAF9ACF78"
 			tasks: [{
-				id: "5B9A51B5D81BFB98"
 				type: "advancement"
-				title: "Enchantment: §eProtection§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/vanilla_protection"
 				criterion: ""
+				id: "5B9A51B5D81BFB98"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eProtection§r"
 			}]
 		}
 		{
@@ -801,12 +801,12 @@
 			y: -0.5d
 			id: "7A292112E488F1B5"
 			tasks: [{
-				id: "6D03A04834018B4D"
 				type: "advancement"
-				title: "Enchantment: §eQuitoxic???§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/vanilla_quitoxic"
 				criterion: ""
+				id: "6D03A04834018B4D"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eQuitoxic???§r"
 			}]
 		}
 		{
@@ -814,12 +814,12 @@
 			y: -0.5d
 			id: "4D0FA199B705AE6B"
 			tasks: [{
-				id: "290D7147C745B01B"
 				type: "advancement"
-				title: "Enchantment: §eSilk Touch§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/vanilla_silk_touch"
 				criterion: ""
+				id: "290D7147C745B01B"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eSilk Touch§r"
 			}]
 		}
 		{
@@ -827,12 +827,12 @@
 			y: -0.5d
 			id: "1E2FB92D19909245"
 			tasks: [{
-				id: "70AA3622411C78A1"
 				type: "advancement"
-				title: "Enchantment: §eMending, Frost Walker§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/vanilla_treasure"
 				criterion: ""
+				id: "70AA3622411C78A1"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eMending, Frost Walker§r"
 			}]
 		}
 		{
@@ -840,12 +840,12 @@
 			y: -0.5d
 			id: "41C0AC21C2AF21FF"
 			tasks: [{
-				id: "0B4AEA3A0682FD99"
 				type: "advancement"
-				title: "Enchantment: §eRiptide, Impaling§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/vanilla_trident"
 				criterion: ""
+				id: "0B4AEA3A0682FD99"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eRiptide, Impaling§r"
 			}]
 		}
 		{
@@ -853,12 +853,12 @@
 			y: 0.5d
 			id: "061CDC06CE8F61D9"
 			tasks: [{
-				id: "7BD4C8F89E35D77D"
 				type: "advancement"
-				title: "Enchantment: §eChanelling§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/vanilla_trident_channeling"
 				criterion: ""
+				id: "7BD4C8F89E35D77D"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eChanelling§r"
 			}]
 		}
 		{
@@ -866,12 +866,12 @@
 			y: 0.5d
 			id: "404D3B9110FADFA5"
 			tasks: [{
-				id: "73986A1CF2A06CFD"
 				type: "advancement"
-				title: "Enchantment: §eUnbreaking§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/vanilla_unbreaking"
 				criterion: ""
+				id: "73986A1CF2A06CFD"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eUnbreaking§r"
 			}]
 		}
 		{
@@ -879,12 +879,12 @@
 			y: 0.5d
 			id: "38519A47957AEB35"
 			tasks: [{
-				id: "46DE88DD39E81559"
 				type: "advancement"
-				title: "Enchantment: §eAqua Affinity, Respiration§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/vanilla_water"
 				criterion: ""
+				id: "46DE88DD39E81559"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eAqua Affinity, Respiration§r"
 			}]
 		}
 		{
@@ -892,12 +892,12 @@
 			y: 0.5d
 			id: "7A538C663A67B933"
 			tasks: [{
-				id: "21A866B08D29740D"
 				type: "advancement"
-				title: "Enchantment: §eLuck of the Sea§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/vanilla_water_luck"
 				criterion: ""
+				id: "21A866B08D29740D"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eLuck of the Sea§r"
 			}]
 		}
 		{
@@ -905,12 +905,12 @@
 			y: 0.5d
 			id: "43FBC49DAFAA12D0"
 			tasks: [{
-				id: "5124D00E5ABF891F"
 				type: "advancement"
-				title: "Enchantment: §eVoiding§r"
-				icon: "minecraft:enchanted_book"
 				advancement: "spectrum:progression/enchantments/voiding"
 				criterion: ""
+				id: "5124D00E5ABF891F"
+				icon: "minecraft:enchanted_book"
+				title: "Enchantment: §eVoiding§r"
 			}]
 		}
 		{
@@ -918,12 +918,12 @@
 			y: 0.5d
 			id: "378669A7C6863B46"
 			tasks: [{
-				id: "05778016C5E6943D"
 				type: "advancement"
-				title: "Unlock Any Chime"
-				icon: "spectrum:moonstone_chime"
 				advancement: "spectrum:progression/gemstone_chimes/unlock_any_chime"
 				criterion: ""
+				id: "05778016C5E6943D"
+				icon: "spectrum:moonstone_chime"
+				title: "Unlock Any Chime"
 			}]
 		}
 		{
@@ -931,12 +931,12 @@
 			y: 0.5d
 			id: "3D7B97C4CC44E6AD"
 			tasks: [{
-				id: "1E2DF2F2AEA7630A"
 				type: "advancement"
-				title: "Unlock Amethyst Chime"
-				icon: "spectrum:amethyst_chime"
 				advancement: "spectrum:progression/gemstone_chimes/unlock_amethyst_chime"
 				criterion: ""
+				id: "1E2DF2F2AEA7630A"
+				icon: "spectrum:amethyst_chime"
+				title: "Unlock Amethyst Chime"
 			}]
 		}
 		{
@@ -944,12 +944,12 @@
 			y: 0.5d
 			id: "511AC1120B2B89DF"
 			tasks: [{
-				id: "275CE0E55F0BA5CE"
 				type: "advancement"
-				title: "Unlock Citrine Chime"
-				icon: "spectrum:citrine_chime"
 				advancement: "spectrum:progression/gemstone_chimes/unlock_citrine_chime"
 				criterion: ""
+				id: "275CE0E55F0BA5CE"
+				icon: "spectrum:citrine_chime"
+				title: "Unlock Citrine Chime"
 			}]
 		}
 		{
@@ -957,12 +957,12 @@
 			y: 0.5d
 			id: "24A15B51A8476E1D"
 			tasks: [{
-				id: "4EA71F694B1BFCD7"
 				type: "advancement"
-				title: "Unlock Moonstone Chime"
-				icon: "spectrum:moonstone_chime"
 				advancement: "spectrum:progression/gemstone_chimes/unlock_moonstone_chime"
 				criterion: ""
+				id: "4EA71F694B1BFCD7"
+				icon: "spectrum:moonstone_chime"
+				title: "Unlock Moonstone Chime"
 			}]
 		}
 		{
@@ -970,12 +970,12 @@
 			y: 0.5d
 			id: "1281DDC3D8D05DAA"
 			tasks: [{
-				id: "0985681882C074C6"
 				type: "advancement"
-				title: "Unlock Onyx Chime"
-				icon: "spectrum:onyx_chime"
 				advancement: "spectrum:progression/gemstone_chimes/unlock_onyx_chime"
 				criterion: ""
+				id: "0985681882C074C6"
+				icon: "spectrum:onyx_chime"
+				title: "Unlock Onyx Chime"
 			}]
 		}
 		{
@@ -983,12 +983,12 @@
 			y: 0.5d
 			id: "29A426616EB0AE3E"
 			tasks: [{
-				id: "46B05326E3919FDF"
 				type: "advancement"
-				title: "Unlock Topaz Chime"
-				icon: "spectrum:topaz_chime"
 				advancement: "spectrum:progression/gemstone_chimes/unlock_topaz_chime"
 				criterion: ""
+				id: "46B05326E3919FDF"
+				icon: "spectrum:topaz_chime"
+				title: "Unlock Topaz Chime"
 			}]
 		}
 		{
@@ -996,12 +996,12 @@
 			y: 0.5d
 			id: "3EC79D03E2FBAE72"
 			tasks: [{
-				id: "2798E56D33563C53"
 				type: "advancement"
-				title: "Unlock Any Gemstone Lamp"
-				icon: "spectrum:moonstone_calcite_lamp"
 				advancement: "spectrum:progression/gemstone_lamps/unlock_any_gemstone_lamp"
 				criterion: ""
+				id: "2798E56D33563C53"
+				icon: "spectrum:moonstone_calcite_lamp"
+				title: "Unlock Any Gemstone Lamp"
 			}]
 		}
 		{
@@ -1009,12 +1009,12 @@
 			y: 0.5d
 			id: "1D9E30DC81874887"
 			tasks: [{
-				id: "2C3C6F8B491EC39A"
 				type: "advancement"
-				title: "Unlock Amethyst Lamps"
-				icon: "spectrum:amethyst_basalt_lamp"
 				advancement: "spectrum:progression/gemstone_lamps/unlock_amethyst_lamps"
 				criterion: ""
+				id: "2C3C6F8B491EC39A"
+				icon: "spectrum:amethyst_basalt_lamp"
+				title: "Unlock Amethyst Lamps"
 			}]
 		}
 		{
@@ -1022,12 +1022,12 @@
 			y: 0.5d
 			id: "7180551E3EECE689"
 			tasks: [{
-				id: "0D97DB7F84653771"
 				type: "advancement"
-				title: "Unlock Citrine Lamps"
-				icon: "spectrum:citrine_basalt_lamp"
 				advancement: "spectrum:progression/gemstone_lamps/unlock_citrine_lamps"
 				criterion: ""
+				id: "0D97DB7F84653771"
+				icon: "spectrum:citrine_basalt_lamp"
+				title: "Unlock Citrine Lamps"
 			}]
 		}
 		{
@@ -1035,12 +1035,12 @@
 			y: 0.5d
 			id: "371A7D4D7BF15CE8"
 			tasks: [{
-				id: "6A5945885A7210B9"
 				type: "advancement"
-				title: "Unlock Moonstone Lamps"
-				icon: "spectrum:moonstone_basalt_lamp"
 				advancement: "spectrum:progression/gemstone_lamps/unlock_moonstone_lamps"
 				criterion: ""
+				id: "6A5945885A7210B9"
+				icon: "spectrum:moonstone_basalt_lamp"
+				title: "Unlock Moonstone Lamps"
 			}]
 		}
 		{
@@ -1048,12 +1048,12 @@
 			y: 0.5d
 			id: "4C0D91438F1DB975"
 			tasks: [{
-				id: "7D066C584D36FF94"
 				type: "advancement"
-				title: "Unlock Onyx Lamps"
-				icon: "spectrum:onyx_basalt_lamp"
 				advancement: "spectrum:progression/gemstone_lamps/unlock_onyx_lamps"
 				criterion: ""
+				id: "7D066C584D36FF94"
+				icon: "spectrum:onyx_basalt_lamp"
+				title: "Unlock Onyx Lamps"
 			}]
 		}
 		{
@@ -1061,12 +1061,12 @@
 			y: 1.5d
 			id: "1D9C7634D56C3213"
 			tasks: [{
-				id: "4C835035D4BB871D"
 				type: "advancement"
-				title: "Unlock Topaz Lamps"
-				icon: "spectrum:topaz_basalt_lamp"
 				advancement: "spectrum:progression/gemstone_lamps/unlock_topaz_lamps"
 				criterion: ""
+				id: "4C835035D4BB871D"
+				icon: "spectrum:topaz_basalt_lamp"
+				title: "Unlock Topaz Lamps"
 			}]
 		}
 		{
@@ -1074,12 +1074,12 @@
 			y: 1.5d
 			id: "10BAA3EEAD48CAAD"
 			tasks: [{
-				id: "6742C8EEA2295BE6"
 				type: "advancement"
-				title: "Unlock Any Glowblock"
-				icon: "blockus:rainbow_colored_tiles"
 				advancement: "spectrum:progression/glowblocks/unlock_any_glowblock"
 				criterion: ""
+				id: "6742C8EEA2295BE6"
+				icon: "blockus:rainbow_colored_tiles"
+				title: "Unlock Any Glowblock"
 			}]
 		}
 		{
@@ -1087,12 +1087,12 @@
 			y: 1.5d
 			id: "18184A5F5121E66A"
 			tasks: [{
-				id: "38D383D84908D613"
 				type: "advancement"
-				title: "Unlock Black Glowblock"
-				icon: "spectrum:black_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_black_glowblock"
 				criterion: ""
+				id: "38D383D84908D613"
+				icon: "spectrum:black_glowblock"
+				title: "Unlock Black Glowblock"
 			}]
 		}
 		{
@@ -1100,12 +1100,12 @@
 			y: 1.5d
 			id: "047334A7DE2BC7E1"
 			tasks: [{
-				id: "00CD5A2B35C33A71"
 				type: "advancement"
-				title: "Unlock Blue Glowblock"
-				icon: "spectrum:blue_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_blue_glowblock"
 				criterion: ""
+				id: "00CD5A2B35C33A71"
+				icon: "spectrum:blue_glowblock"
+				title: "Unlock Blue Glowblock"
 			}]
 		}
 		{
@@ -1113,12 +1113,12 @@
 			y: 1.5d
 			id: "5CF7736A19FF39FB"
 			tasks: [{
-				id: "0FDBA709AFA7E612"
 				type: "advancement"
-				title: "Unlock Brown Glowblock"
-				icon: "spectrum:brown_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_brown_glowblock"
 				criterion: ""
+				id: "0FDBA709AFA7E612"
+				icon: "spectrum:brown_glowblock"
+				title: "Unlock Brown Glowblock"
 			}]
 		}
 		{
@@ -1126,12 +1126,12 @@
 			y: 1.5d
 			id: "3DBC9A00C6ED0B55"
 			tasks: [{
-				id: "736E70F49AC4D908"
 				type: "advancement"
-				title: "Unlock Cyan Glowblock"
-				icon: "spectrum:cyan_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_cyan_glowblock"
 				criterion: ""
+				id: "736E70F49AC4D908"
+				icon: "spectrum:cyan_glowblock"
+				title: "Unlock Cyan Glowblock"
 			}]
 		}
 		{
@@ -1139,12 +1139,12 @@
 			y: 1.5d
 			id: "7612CFD3895832D2"
 			tasks: [{
-				id: "11B3C247CB0C5240"
 				type: "advancement"
-				title: "Unlock Gray Glowblock"
-				icon: "spectrum:gray_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_gray_glowblock"
 				criterion: ""
+				id: "11B3C247CB0C5240"
+				icon: "spectrum:gray_glowblock"
+				title: "Unlock Gray Glowblock"
 			}]
 		}
 		{
@@ -1152,12 +1152,12 @@
 			y: 1.5d
 			id: "4B7A3727EC66F2A6"
 			tasks: [{
-				id: "53398B79691E1CA7"
 				type: "advancement"
-				title: "Unlock Green Glowblock"
-				icon: "spectrum:green_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_green_glowblock"
 				criterion: ""
+				id: "53398B79691E1CA7"
+				icon: "spectrum:green_glowblock"
+				title: "Unlock Green Glowblock"
 			}]
 		}
 		{
@@ -1165,12 +1165,12 @@
 			y: 1.5d
 			id: "0DFD9576C870FAE3"
 			tasks: [{
-				id: "5A75FF667D5A91EC"
 				type: "advancement"
-				title: "Unlock Light Blue Glowblock"
-				icon: "spectrum:light_blue_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_light_blue_glowblock"
 				criterion: ""
+				id: "5A75FF667D5A91EC"
+				icon: "spectrum:light_blue_glowblock"
+				title: "Unlock Light Blue Glowblock"
 			}]
 		}
 		{
@@ -1178,12 +1178,12 @@
 			y: 1.5d
 			id: "06E044A73371E1A8"
 			tasks: [{
-				id: "7A6055E049B7247A"
 				type: "advancement"
-				title: "Unlock Light Gray Glowblock"
-				icon: "spectrum:light_gray_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_light_gray_glowblock"
 				criterion: ""
+				id: "7A6055E049B7247A"
+				icon: "spectrum:light_gray_glowblock"
+				title: "Unlock Light Gray Glowblock"
 			}]
 		}
 		{
@@ -1191,12 +1191,12 @@
 			y: 1.5d
 			id: "38A059B0CE7C8CA9"
 			tasks: [{
-				id: "547906EA42612DEC"
 				type: "advancement"
-				title: "Unlock Lime Glowblock"
-				icon: "spectrum:lime_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_lime_glowblock"
 				criterion: ""
+				id: "547906EA42612DEC"
+				icon: "spectrum:lime_glowblock"
+				title: "Unlock Lime Glowblock"
 			}]
 		}
 		{
@@ -1204,12 +1204,12 @@
 			y: 1.5d
 			id: "76B18CDDB9A4287E"
 			tasks: [{
-				id: "10FB2312343A3F34"
 				type: "advancement"
-				title: "Unlock Magenta Glowblock"
-				icon: "spectrum:magenta_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_magenta_glowblock"
 				criterion: ""
+				id: "10FB2312343A3F34"
+				icon: "spectrum:magenta_glowblock"
+				title: "Unlock Magenta Glowblock"
 			}]
 		}
 		{
@@ -1217,12 +1217,12 @@
 			y: 1.5d
 			id: "7989FD6E36E88D8F"
 			tasks: [{
-				id: "44C87A6834757EDF"
 				type: "advancement"
-				title: "Unlock Orange Glowblock"
-				icon: "spectrum:orange_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_orange_glowblock"
 				criterion: ""
+				id: "44C87A6834757EDF"
+				icon: "spectrum:orange_glowblock"
+				title: "Unlock Orange Glowblock"
 			}]
 		}
 		{
@@ -1230,12 +1230,12 @@
 			y: 1.5d
 			id: "280F27BA835CDF38"
 			tasks: [{
-				id: "0C8F2BBED724629F"
 				type: "advancement"
-				title: "Unlock Pink Glowblock"
-				icon: "spectrum:pink_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_pink_glowblock"
 				criterion: ""
+				id: "0C8F2BBED724629F"
+				icon: "spectrum:pink_glowblock"
+				title: "Unlock Pink Glowblock"
 			}]
 		}
 		{
@@ -1243,12 +1243,12 @@
 			y: 1.5d
 			id: "24E8C35E9FA9F1B5"
 			tasks: [{
-				id: "696B51BB855482DE"
 				type: "advancement"
-				title: "Unlock Purple Glowblock"
-				icon: "spectrum:purple_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_purple_glowblock"
 				criterion: ""
+				id: "696B51BB855482DE"
+				icon: "spectrum:purple_glowblock"
+				title: "Unlock Purple Glowblock"
 			}]
 		}
 		{
@@ -1256,12 +1256,12 @@
 			y: 1.5d
 			id: "06FF1F1DBA931FA4"
 			tasks: [{
-				id: "763B65F8C7798BAC"
 				type: "advancement"
-				title: "Unlock Red Glowblock"
-				icon: "spectrum:red_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_red_glowblock"
 				criterion: ""
+				id: "763B65F8C7798BAC"
+				icon: "spectrum:red_glowblock"
+				title: "Unlock Red Glowblock"
 			}]
 		}
 		{
@@ -1269,12 +1269,12 @@
 			y: 2.5d
 			id: "0FC025E02D7EC9B4"
 			tasks: [{
-				id: "6CE0410F80E3EC23"
 				type: "advancement"
-				title: "Unlock White Glowblock"
-				icon: "spectrum:white_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_white_glowblock"
 				criterion: ""
+				id: "6CE0410F80E3EC23"
+				icon: "spectrum:white_glowblock"
+				title: "Unlock White Glowblock"
 			}]
 		}
 		{
@@ -1282,12 +1282,12 @@
 			y: 2.5d
 			id: "7D21954BA7A74452"
 			tasks: [{
-				id: "03AD379EA6A16965"
 				type: "advancement"
-				title: "Unlock Yellow Glowblock"
-				icon: "spectrum:yellow_glowblock"
 				advancement: "spectrum:progression/glowblocks/unlock_yellow_glowblock"
 				criterion: ""
+				id: "03AD379EA6A16965"
+				icon: "spectrum:yellow_glowblock"
+				title: "Unlock Yellow Glowblock"
 			}]
 		}
 		{
@@ -1295,12 +1295,12 @@
 			y: 2.5d
 			id: "57132B38DE3CF6AF"
 			tasks: [{
-				id: "5B9DE58DBBD285BD"
 				type: "advancement"
-				title: "Unlock Basic Pastel Network Nodes"
-				icon: "spectrum:storage_node"
 				advancement: "spectrum:progression/pastel_network/unlock_basic_nodes"
 				criterion: ""
+				id: "5B9DE58DBBD285BD"
+				icon: "spectrum:storage_node"
+				title: "Unlock Basic Pastel Network Nodes"
 			}]
 		}
 		{
@@ -1308,12 +1308,12 @@
 			y: 2.5d
 			id: "7D7833DDEFF53835"
 			tasks: [{
-				id: "657330568B91687C"
 				type: "advancement"
-				title: "Unlock Pastel Network Interaction Node"
-				icon: "spectrum:interaction_node"
 				advancement: "spectrum:progression/pastel_network/unlock_interaction_node"
 				criterion: ""
+				id: "657330568B91687C"
+				icon: "spectrum:interaction_node"
+				title: "Unlock Pastel Network Interaction Node"
 			}]
 		}
 		{
@@ -1321,9 +1321,10 @@
 			y: 2.5d
 			id: "5DC93E6646A9170E"
 			tasks: [{
-				id: "0CB4166462CAA566"
 				type: "advancement"
-				title: "Unlock Levitation Potion"
+				advancement: "spectrum:progression/potions/unlock_levitation_potion"
+				criterion: ""
+				id: "0CB4166462CAA566"
 				icon: {
 					id: "minecraft:potion"
 					Count: 1b
@@ -1340,8 +1341,7 @@
 						}]
 					}
 				}
-				advancement: "spectrum:progression/potions/unlock_levitation_potion"
-				criterion: ""
+				title: "Unlock Levitation Potion"
 			}]
 		}
 		{
@@ -1349,9 +1349,10 @@
 			y: 2.5d
 			id: "0A6800C96DA96F78"
 			tasks: [{
-				id: "1C8FECAA54E52DB1"
 				type: "advancement"
-				title: "Unlock Luck Potion"
+				advancement: "spectrum:progression/potions/unlock_luck_potion"
+				criterion: ""
+				id: "1C8FECAA54E52DB1"
 				icon: {
 					id: "minecraft:potion"
 					Count: 1b
@@ -1368,8 +1369,7 @@
 						}]
 					}
 				}
-				advancement: "spectrum:progression/potions/unlock_luck_potion"
-				criterion: ""
+				title: "Unlock Luck Potion"
 			}]
 		}
 		{
@@ -1377,9 +1377,10 @@
 			y: 2.5d
 			id: "16E4E2719320F868"
 			tasks: [{
-				id: "77C7EF8C2F3EA708"
 				type: "advancement"
-				title: "Unlock Wither Potion"
+				advancement: "spectrum:progression/potions/unlock_wither_potion"
+				criterion: ""
+				id: "77C7EF8C2F3EA708"
 				icon: {
 					id: "minecraft:potion"
 					Count: 1b
@@ -1396,8 +1397,7 @@
 						}]
 					}
 				}
-				advancement: "spectrum:progression/potions/unlock_wither_potion"
-				criterion: ""
+				title: "Unlock Wither Potion"
 			}]
 		}
 		{
@@ -1405,9 +1405,10 @@
 			y: 2.5d
 			id: "3FBD02BB01B8B53F"
 			tasks: [{
-				id: "238AE676524FA27F"
 				type: "advancement"
-				title: "Unlock Any Preenchanted Tool"
+				advancement: "spectrum:progression/tools/unlock_any_preenchanted_tool"
+				criterion: ""
+				id: "238AE676524FA27F"
 				icon: {
 					id: "minecraft:diamond_pickaxe"
 					Count: 1b
@@ -1419,8 +1420,7 @@
 						}]
 					}
 				}
-				advancement: "spectrum:progression/tools/unlock_any_preenchanted_tool"
-				criterion: ""
+				title: "Unlock Any Preenchanted Tool"
 			}]
 		}
 		{
@@ -1428,9 +1428,10 @@
 			y: 2.5d
 			id: "643D98379B5E53AF"
 			tasks: [{
-				id: "40968333E465D078"
 				type: "advancement"
-				title: "Unlock Lucky Pickaxe"
+				advancement: "spectrum:progression/tools/unlock_fortune_pickaxe"
+				criterion: ""
+				id: "40968333E465D078"
 				icon: {
 					id: "spectrum:fortune_pickaxe"
 					Count: 1b
@@ -1442,8 +1443,7 @@
 						}]
 					}
 				}
-				advancement: "spectrum:progression/tools/unlock_fortune_pickaxe"
-				criterion: ""
+				title: "Unlock Lucky Pickaxe"
 			}]
 		}
 		{
@@ -1451,9 +1451,10 @@
 			y: 2.5d
 			id: "7EEAE70F78021C42"
 			tasks: [{
-				id: "1C7F0A1406AD99A0"
 				type: "advancement"
-				title: "Unlock Razor Falchion"
+				advancement: "spectrum:progression/tools/unlock_looting_falchion"
+				criterion: ""
+				id: "1C7F0A1406AD99A0"
 				icon: {
 					id: "spectrum:looting_falchion"
 					Count: 1b
@@ -1465,8 +1466,7 @@
 						}]
 					}
 				}
-				advancement: "spectrum:progression/tools/unlock_looting_falchion"
-				criterion: ""
+				title: "Unlock Razor Falchion"
 			}]
 		}
 		{
@@ -1474,9 +1474,10 @@
 			y: 2.5d
 			id: "45AE9AE47679A29B"
 			tasks: [{
-				id: "47C3FE34DBF6CEA6"
 				type: "advancement"
-				title: "Unlock Resonant Pickaxe"
+				advancement: "spectrum:progression/tools/unlock_resonant_pickaxe"
+				criterion: ""
+				id: "47C3FE34DBF6CEA6"
 				icon: {
 					id: "spectrum:resonant_pickaxe"
 					Count: 1b
@@ -1488,8 +1489,7 @@
 						}]
 					}
 				}
-				advancement: "spectrum:progression/tools/unlock_resonant_pickaxe"
-				criterion: ""
+				title: "Unlock Resonant Pickaxe"
 			}]
 		}
 		{
@@ -1497,9 +1497,10 @@
 			y: 2.5d
 			id: "569E295FEADD6C12"
 			tasks: [{
-				id: "66ACAC86A57BDBB7"
 				type: "advancement"
-				title: "Unlock Tender Pickaxe"
+				advancement: "spectrum:progression/tools/unlock_silker_pickaxe"
+				criterion: ""
+				id: "66ACAC86A57BDBB7"
 				icon: {
 					id: "spectrum:silker_pickaxe"
 					Count: 1b
@@ -1511,8 +1512,7 @@
 						}]
 					}
 				}
-				advancement: "spectrum:progression/tools/unlock_silker_pickaxe"
-				criterion: ""
+				title: "Unlock Tender Pickaxe"
 			}]
 		}
 		{
@@ -1520,9 +1520,10 @@
 			y: 2.5d
 			id: "5B81FC73A73F78B1"
 			tasks: [{
-				id: "3B39AF618CD08E25"
 				type: "advancement"
-				title: "Unlock Oblivion Pickaxe"
+				advancement: "spectrum:progression/tools/unlock_voiding_pickaxe"
+				criterion: ""
+				id: "3B39AF618CD08E25"
 				icon: {
 					id: "spectrum:voiding_pickaxe"
 					Count: 1b
@@ -1534,8 +1535,7 @@
 						}]
 					}
 				}
-				advancement: "spectrum:progression/tools/unlock_voiding_pickaxe"
-				criterion: ""
+				title: "Unlock Oblivion Pickaxe"
 			}]
 		}
 		{
@@ -1543,12 +1543,12 @@
 			y: 2.5d
 			id: "021B721D42F25D93"
 			tasks: [{
-				id: "10384B334BD01230"
 				type: "advancement"
-				title: "Unlock Any Azure Dike Equipment"
-				icon: "spectrum:azure_dike_ring"
 				advancement: "spectrum:progression/unlock_any_azure_dike_equipment"
 				criterion: ""
+				id: "10384B334BD01230"
+				icon: "spectrum:azure_dike_ring"
+				title: "Unlock Any Azure Dike Equipment"
 			}]
 		}
 		{
@@ -1556,12 +1556,12 @@
 			y: 2.5d
 			id: "20E5E569098497AD"
 			tasks: [{
-				id: "17FF342F770CA6A6"
 				type: "advancement"
-				title: "Unlock Any Base Trinket"
-				icon: "spectrum:fanciful_stone_ring"
 				advancement: "spectrum:progression/unlock_any_base_trinket"
 				criterion: ""
+				id: "17FF342F770CA6A6"
+				icon: "spectrum:fanciful_stone_ring"
+				title: "Unlock Any Base Trinket"
 			}]
 		}
 		{
@@ -1569,12 +1569,12 @@
 			y: 3.5d
 			id: "3441D4F97AEA17F7"
 			tasks: [{
-				id: "36DFEF896699C318"
 				type: "advancement"
-				title: "Unlock Artist's Palette"
-				icon: "spectrum:artists_palette"
 				advancement: "spectrum:progression/unlock_artists_palette"
 				criterion: ""
+				id: "36DFEF896699C318"
+				icon: "spectrum:artists_palette"
+				title: "Unlock Artist's Palette"
 			}]
 		}
 		{
@@ -1582,12 +1582,12 @@
 			y: 3.5d
 			id: "2F7F6147016201FC"
 			tasks: [{
-				id: "4DE282F362EC3384"
 				type: "advancement"
-				title: "Unlock Ashen Circlet"
-				icon: "spectrum:ashen_circlet"
 				advancement: "spectrum:progression/unlock_ashen_circlet"
 				criterion: ""
+				id: "4DE282F362EC3384"
+				icon: "spectrum:ashen_circlet"
+				title: "Unlock Ashen Circlet"
 			}]
 		}
 		{
@@ -1595,12 +1595,12 @@
 			y: 3.5d
 			id: "102D56159E02862F"
 			tasks: [{
-				id: "4D7E3006F496CC1D"
 				type: "advancement"
-				title: "Unlock Shieldgrasp Amulet"
-				icon: "spectrum:shieldgrasp_amulet"
 				advancement: "spectrum:progression/unlock_azure_dike_amulet"
 				criterion: ""
+				id: "4D7E3006F496CC1D"
+				icon: "spectrum:shieldgrasp_amulet"
+				title: "Unlock Shieldgrasp Amulet"
 			}]
 		}
 		{
@@ -1608,12 +1608,12 @@
 			y: 3.5d
 			id: "30DA3B190DF0DD43"
 			tasks: [{
-				id: "683AD4056ED53667"
 				type: "advancement"
-				title: "Unlock Azure Dike Belt"
-				icon: "spectrum:azure_dike_belt"
 				advancement: "spectrum:progression/unlock_azure_dike_belt"
 				criterion: ""
+				id: "683AD4056ED53667"
+				icon: "spectrum:azure_dike_belt"
+				title: "Unlock Azure Dike Belt"
 			}]
 		}
 		{
@@ -1621,12 +1621,12 @@
 			y: 3.5d
 			id: "251FB09351DD23B1"
 			tasks: [{
-				id: "0988060970E95A6C"
 				type: "advancement"
-				title: "Unlock Azure Dike Ring"
-				icon: "spectrum:azure_dike_ring"
 				advancement: "spectrum:progression/unlock_azure_dike_ring"
 				criterion: ""
+				id: "0988060970E95A6C"
+				icon: "spectrum:azure_dike_ring"
+				title: "Unlock Azure Dike Ring"
 			}]
 		}
 		{
@@ -1634,9 +1634,10 @@
 			y: 3.5d
 			id: "29B816165E4FDB2A"
 			tasks: [{
-				id: "6E8D676697CBE939"
 				type: "advancement"
-				title: "Unlock Bedrock Tools"
+				advancement: "spectrum:progression/unlock_bedrock_tools"
+				criterion: ""
+				id: "6E8D676697CBE939"
 				icon: {
 					id: "spectrum:bedrock_pickaxe"
 					Count: 1b
@@ -1647,8 +1648,7 @@
 						}]
 					}
 				}
-				advancement: "spectrum:progression/unlock_bedrock_tools"
-				criterion: ""
+				title: "Unlock Bedrock Tools"
 			}]
 		}
 		{
@@ -1656,12 +1656,12 @@
 			y: 3.5d
 			id: "18DCF3C08FAE6A70"
 			tasks: [{
-				id: "537E12CD48E2F85A"
 				type: "advancement"
-				title: "Unlock Block Flooder"
-				icon: "spectrum:block_flooder"
 				advancement: "spectrum:progression/unlock_block_flooder"
 				criterion: ""
+				id: "537E12CD48E2F85A"
+				icon: "spectrum:block_flooder"
+				title: "Unlock Block Flooder"
 			}]
 		}
 		{
@@ -1669,12 +1669,12 @@
 			y: 3.5d
 			id: "100072B38201D3BF"
 			tasks: [{
-				id: "0DE960ADED9F6221"
 				type: "advancement"
-				title: "Unlock Block Placer"
-				icon: "spectrum:block_placer"
 				advancement: "spectrum:progression/unlock_block_placer"
 				criterion: ""
+				id: "0DE960ADED9F6221"
+				icon: "spectrum:block_placer"
+				title: "Unlock Block Placer"
 			}]
 		}
 		{
@@ -1682,12 +1682,12 @@
 			y: 3.5d
 			id: "6033AC1AD2FEDCD5"
 			tasks: [{
-				id: "401C9A73A0A7DBFF"
 				type: "advancement"
-				title: "Unlock Blood Orchid"
-				icon: "spectrum:blood_orchid"
 				advancement: "spectrum:progression/unlock_blood_orchid"
 				criterion: ""
+				id: "401C9A73A0A7DBFF"
+				icon: "spectrum:blood_orchid"
+				title: "Unlock Blood Orchid"
 			}]
 		}
 		{
@@ -1695,12 +1695,12 @@
 			y: 3.5d
 			id: "4490F9D5524FF1C3"
 			tasks: [{
-				id: "511E775BF5AC9A6B"
 				type: "advancement"
-				title: "Unlock Bodacious Berry Bar"
-				icon: "spectrum:bodacious_berry_bar"
 				advancement: "spectrum:progression/unlock_bodacious_berry_bar"
 				criterion: ""
+				id: "511E775BF5AC9A6B"
+				icon: "spectrum:bodacious_berry_bar"
+				title: "Unlock Bodacious Berry Bar"
 			}]
 		}
 		{
@@ -1708,12 +1708,12 @@
 			y: 3.5d
 			id: "3031E4DB5B8CDB59"
 			tasks: [{
-				id: "3E5A63FF47838B3A"
 				type: "advancement"
-				title: "Unlock Bottle of Decay Away"
-				icon: "spectrum:bottle_of_decay_away"
 				advancement: "spectrum:progression/unlock_bottle_of_decay_away"
 				criterion: ""
+				id: "3E5A63FF47838B3A"
+				icon: "spectrum:bottle_of_decay_away"
+				title: "Unlock Bottle of Decay Away"
 			}]
 		}
 		{
@@ -1721,12 +1721,12 @@
 			y: 3.5d
 			id: "19FCD59E0B1040CE"
 			tasks: [{
-				id: "25082C09C58C0D69"
 				type: "advancement"
-				title: "Unlock Bottle of Fading"
-				icon: "spectrum:bottle_of_fading"
 				advancement: "spectrum:progression/unlock_bottle_of_fading"
 				criterion: ""
+				id: "25082C09C58C0D69"
+				icon: "spectrum:bottle_of_fading"
+				title: "Unlock Bottle of Fading"
 			}]
 		}
 		{
@@ -1734,12 +1734,12 @@
 			y: 3.5d
 			id: "0AF7C374B4ADD9FF"
 			tasks: [{
-				id: "28315D1D9ACEBD2C"
 				type: "advancement"
-				title: "Unlock Bottle of Failing"
-				icon: "spectrum:bottle_of_failing"
 				advancement: "spectrum:progression/unlock_bottle_of_failing"
 				criterion: ""
+				id: "28315D1D9ACEBD2C"
+				icon: "spectrum:bottle_of_failing"
+				title: "Unlock Bottle of Failing"
 			}]
 		}
 		{
@@ -1747,12 +1747,12 @@
 			y: 3.5d
 			id: "7A03C4C30F50A489"
 			tasks: [{
-				id: "03CA41EE9419114D"
 				type: "advancement"
-				title: "Unlock Bottle of Ruin"
-				icon: "spectrum:bottle_of_ruin"
 				advancement: "spectrum:progression/unlock_bottle_of_ruin"
 				criterion: ""
+				id: "03CA41EE9419114D"
+				icon: "spectrum:bottle_of_ruin"
+				title: "Unlock Bottle of Ruin"
 			}]
 		}
 		{
@@ -1760,12 +1760,12 @@
 			y: 3.5d
 			id: "510DECE53B6F3A29"
 			tasks: [{
-				id: "17FB3A6371B0B91C"
 				type: "advancement"
-				title: "Unlock Bottle of Terror"
-				icon: "spectrum:bottle_of_terror"
 				advancement: "spectrum:progression/unlock_bottle_of_terror"
 				criterion: ""
+				id: "17FB3A6371B0B91C"
+				icon: "spectrum:bottle_of_terror"
+				title: "Unlock Bottle of Terror"
 			}]
 		}
 		{
@@ -1773,12 +1773,12 @@
 			y: 3.5d
 			id: "1B7EA5E4A7B62A4E"
 			tasks: [{
-				id: "72FBDA0FF6180DE0"
 				type: "advancement"
-				title: "Unlock Budding Onyx"
-				icon: "spectrum:budding_onyx"
 				advancement: "spectrum:progression/unlock_budding_onyx"
 				criterion: ""
+				id: "72FBDA0FF6180DE0"
+				icon: "spectrum:budding_onyx"
+				title: "Unlock Budding Onyx"
 			}]
 		}
 		{
@@ -1786,12 +1786,12 @@
 			y: 4.5d
 			id: "0C753FC6D3A86584"
 			tasks: [{
-				id: "31D6D6E3268D6CDD"
 				type: "advancement"
-				title: "Unlock Celestial Pocketwatch"
-				icon: "spectrum:celestial_pocketwatch"
 				advancement: "spectrum:progression/unlock_celestial_pocketwatch"
 				criterion: ""
+				id: "31D6D6E3268D6CDD"
+				icon: "spectrum:celestial_pocketwatch"
+				title: "Unlock Celestial Pocketwatch"
 			}]
 		}
 		{
@@ -1799,12 +1799,12 @@
 			y: 4.5d
 			id: "7D2E215513B40BD4"
 			tasks: [{
-				id: "05135BFF41FF0AD2"
 				type: "advancement"
-				title: "Unlock Cinderhearth"
-				icon: "spectrum:cinderhearth"
 				advancement: "spectrum:progression/unlock_cinderhearth"
 				criterion: ""
+				id: "05135BFF41FF0AD2"
+				icon: "spectrum:cinderhearth"
+				title: "Unlock Cinderhearth"
 			}]
 		}
 		{
@@ -1812,12 +1812,12 @@
 			y: 4.5d
 			id: "321D43F7AABE2795"
 			tasks: [{
-				id: "6BBBDB7582F1E47D"
 				type: "advancement"
-				title: "Unlock CMY Pedestal"
-				icon: "spectrum:pedestal_all_basic"
 				advancement: "spectrum:progression/unlock_cmy_pedestal"
 				criterion: ""
+				id: "6BBBDB7582F1E47D"
+				icon: "spectrum:pedestal_all_basic"
+				title: "Unlock CMY Pedestal"
 			}]
 		}
 		{
@@ -1825,12 +1825,12 @@
 			y: 4.5d
 			id: "5BCDB83BE2259B65"
 			tasks: [{
-				id: "76C246FF11DBE4CF"
 				type: "advancement"
-				title: "Unlock Color Picker"
-				icon: "spectrum:color_picker"
 				advancement: "spectrum:progression/unlock_color_picker"
 				criterion: ""
+				id: "76C246FF11DBE4CF"
+				icon: "spectrum:color_picker"
+				title: "Unlock Color Picker"
 			}]
 		}
 		{
@@ -1838,12 +1838,12 @@
 			y: 4.5d
 			id: "5A4300428C3BF9AB"
 			tasks: [{
-				id: "05C8B67386128596"
 				type: "advancement"
-				title: "Unlock Colored Spore Blossoms"
-				icon: "spectrum:red_spore_blossom"
 				advancement: "spectrum:progression/unlock_colored_spore_blossoms"
 				criterion: ""
+				id: "05C8B67386128596"
+				icon: "spectrum:red_spore_blossom"
+				title: "Unlock Colored Spore Blossoms"
 			}]
 		}
 		{
@@ -1851,12 +1851,12 @@
 			y: 4.5d
 			id: "478DCBC5E4FB62F1"
 			tasks: [{
-				id: "71A8AFD2DCAE9952"
 				type: "advancement"
-				title: "Unlock Compacting Chest"
-				icon: "spectrum:compacting_chest"
 				advancement: "spectrum:progression/unlock_compacting_chest"
 				criterion: ""
+				id: "71A8AFD2DCAE9952"
+				icon: "spectrum:compacting_chest"
+				title: "Unlock Compacting Chest"
 			}]
 		}
 		{
@@ -1864,12 +1864,12 @@
 			y: 4.5d
 			id: "4FE47757F7704104"
 			tasks: [{
-				id: "0B7ADB1A5153ABE7"
 				type: "advancement"
-				title: "Unlock Crafting Tablet"
-				icon: "spectrum:crafting_tablet"
 				advancement: "spectrum:progression/unlock_crafting_tablet"
 				criterion: ""
+				id: "0B7ADB1A5153ABE7"
+				icon: "spectrum:crafting_tablet"
+				title: "Unlock Crafting Tablet"
 			}]
 		}
 		{
@@ -1877,12 +1877,12 @@
 			y: 4.5d
 			id: "59297EFB142A39FA"
 			tasks: [{
-				id: "1FAB295DB092324B"
 				type: "advancement"
-				title: "Unlock Crescent Clock"
-				icon: "spectrum:crescent_clock"
 				advancement: "spectrum:progression/unlock_crescent_clock"
 				criterion: ""
+				id: "1FAB295DB092324B"
+				icon: "spectrum:crescent_clock"
+				title: "Unlock Crescent Clock"
 			}]
 		}
 		{
@@ -1890,12 +1890,12 @@
 			y: 4.5d
 			id: "2D9CE3180B811E56"
 			tasks: [{
-				id: "45A84BC1F83BB766"
 				type: "advancement"
-				title: "Unlock Crystal Apothecary"
-				icon: "spectrum:crystal_apothecary"
 				advancement: "spectrum:progression/unlock_crystal_apothecary"
 				criterion: ""
+				id: "45A84BC1F83BB766"
+				icon: "spectrum:crystal_apothecary"
+				title: "Unlock Crystal Apothecary"
 			}]
 		}
 		{
@@ -1903,12 +1903,12 @@
 			y: 4.5d
 			id: "4447908F3DC18E5E"
 			tasks: [{
-				id: "5B778ED4BB965754"
 				type: "advancement"
-				title: "Unlock Crystallarieum"
-				icon: "spectrum:crystallarieum"
 				advancement: "spectrum:progression/unlock_crystallarieum"
 				criterion: ""
+				id: "5B778ED4BB965754"
+				icon: "spectrum:crystallarieum"
+				title: "Unlock Crystallarieum"
 			}]
 		}
 		{
@@ -1916,12 +1916,12 @@
 			y: 4.5d
 			id: "099851DC2AD744C7"
 			tasks: [{
-				id: "63417BD6A2DAA3C6"
 				type: "advancement"
-				title: "Unlock Demon Tea"
-				icon: "spectrum:demon_tea"
 				advancement: "spectrum:progression/unlock_demon_tea"
 				criterion: ""
+				id: "63417BD6A2DAA3C6"
+				icon: "spectrum:demon_tea"
+				title: "Unlock Demon Tea"
 			}]
 		}
 		{
@@ -1929,12 +1929,12 @@
 			y: 4.5d
 			id: "2F194B45527710CF"
 			tasks: [{
-				id: "45515217C7DE9AA6"
 				type: "advancement"
-				title: "Unlock Demon Trifle"
-				icon: "spectrum:demon_trifle"
 				advancement: "spectrum:progression/unlock_demon_trifle"
 				criterion: ""
+				id: "45515217C7DE9AA6"
+				icon: "spectrum:demon_trifle"
+				title: "Unlock Demon Trifle"
 			}]
 		}
 		{
@@ -1942,9 +1942,10 @@
 			y: 4.5d
 			id: "55FF3F222F9AAC09"
 			tasks: [{
-				id: "32407D8DED883214"
 				type: "advancement"
-				title: "Unlock Dreamflayer"
+				advancement: "spectrum:progression/unlock_dreamflayer"
+				criterion: ""
+				id: "32407D8DED883214"
 				icon: {
 					id: "spectrum:dreamflayer"
 					Count: 1b
@@ -1952,8 +1953,7 @@
 						Damage: 0
 					}
 				}
-				advancement: "spectrum:progression/unlock_dreamflayer"
-				criterion: ""
+				title: "Unlock Dreamflayer"
 			}]
 		}
 		{
@@ -1961,12 +1961,12 @@
 			y: 4.5d
 			id: "7FED41BD59277F38"
 			tasks: [{
-				id: "6E9E5E19786191F6"
 				type: "advancement"
-				title: "Unlock Egg Laying Wooly Pig Head"
-				icon: "spectrum:egg_laying_wooly_pig_head"
 				advancement: "spectrum:progression/unlock_egg_laying_wooly_pig_head"
 				criterion: ""
+				id: "6E9E5E19786191F6"
+				icon: "spectrum:egg_laying_wooly_pig_head"
+				title: "Unlock Egg Laying Wooly Pig Head"
 			}]
 		}
 		{
@@ -1974,12 +1974,12 @@
 			y: 4.5d
 			id: "594A52DE69AD93CA"
 			tasks: [{
-				id: "41C8194397A83E85"
 				type: "advancement"
-				title: "Unlock Enchanter"
-				icon: "spectrum:enchanter"
 				advancement: "spectrum:progression/unlock_enchanter"
 				criterion: ""
+				id: "41C8194397A83E85"
+				icon: "spectrum:enchanter"
+				title: "Unlock Enchanter"
 			}]
 		}
 		{
@@ -1987,12 +1987,12 @@
 			y: 4.5d
 			id: "6C51EC561DD7376E"
 			tasks: [{
-				id: "6DCCFB9EC9DDABCA"
 				type: "advancement"
-				title: "Unlock Enchantment Canvas"
-				icon: "spectrum:enchantment_canvas"
 				advancement: "spectrum:progression/unlock_enchantment_canvas"
 				criterion: ""
+				id: "6DCCFB9EC9DDABCA"
+				icon: "spectrum:enchantment_canvas"
+				title: "Unlock Enchantment Canvas"
 			}]
 		}
 		{
@@ -2000,12 +2000,12 @@
 			y: 5.5d
 			id: "5A03CC71A99DF1BB"
 			tasks: [{
-				id: "21D8BCFD6DD4344E"
 				type: "advancement"
-				title: "Unlock End Portal Cracker"
-				icon: "spectrum:end_portal_cracker"
 				advancement: "spectrum:progression/unlock_end_portal_cracker"
 				criterion: ""
+				id: "21D8BCFD6DD4344E"
+				icon: "spectrum:end_portal_cracker"
+				title: "Unlock End Portal Cracker"
 			}]
 		}
 		{
@@ -2013,12 +2013,12 @@
 			y: 5.5d
 			id: "5CEF944A274DF983"
 			tasks: [{
-				id: "0F1FC9D58EBA7E87"
 				type: "advancement"
-				title: "Unlock Ender Blocks"
-				icon: "spectrum:ender_hopper"
 				advancement: "spectrum:progression/unlock_ender_blocks"
 				criterion: ""
+				id: "0F1FC9D58EBA7E87"
+				icon: "spectrum:ender_hopper"
+				title: "Unlock Ender Blocks"
 			}]
 		}
 		{
@@ -2026,12 +2026,12 @@
 			y: 5.5d
 			id: "756AE5E6D2BA0D61"
 			tasks: [{
-				id: "43515967465FE6D5"
 				type: "advancement"
-				title: "Unlock Ender Glass"
-				icon: "spectrum:ender_glass"
 				advancement: "spectrum:progression/unlock_ender_glass"
 				criterion: ""
+				id: "43515967465FE6D5"
+				icon: "spectrum:ender_glass"
+				title: "Unlock Ender Glass"
 			}]
 		}
 		{
@@ -2039,12 +2039,12 @@
 			y: 5.5d
 			id: "54A9DF1CDD398DA8"
 			tasks: [{
-				id: "6469F639FCDC4DB6"
 				type: "advancement"
-				title: "Unlock Ender Splice"
-				icon: "spectrum:ender_splice"
 				advancement: "spectrum:progression/unlock_ender_splice"
 				criterion: ""
+				id: "6469F639FCDC4DB6"
+				icon: "spectrum:ender_splice"
+				title: "Unlock Ender Splice"
 			}]
 		}
 		{
@@ -2052,12 +2052,12 @@
 			y: 5.5d
 			id: "3F6A68A21516A58B"
 			tasks: [{
-				id: "0826D98F29E1D144"
 				type: "advancement"
-				title: "Unlock Ethereal Platform"
-				icon: "spectrum:ethereal_platform"
 				advancement: "spectrum:progression/unlock_ethereal_platform"
 				criterion: ""
+				id: "0826D98F29E1D144"
+				icon: "spectrum:ethereal_platform"
+				title: "Unlock Ethereal Platform"
 			}]
 		}
 		{
@@ -2065,16 +2065,16 @@
 			y: 5.5d
 			id: "1C2A6D6E9452CC84"
 			tasks: [{
-				id: "027693AABE6E67BB"
 				type: "advancement"
-				title: "Unlock Exchanging Staff"
+				advancement: "spectrum:progression/unlock_exchange_staff"
+				criterion: ""
+				id: "027693AABE6E67BB"
 				icon: {
 					id: "spectrum:exchange_staff"
 					Count: 1b
 					tag: { }
 				}
-				advancement: "spectrum:progression/unlock_exchange_staff"
-				criterion: ""
+				title: "Unlock Exchanging Staff"
 			}]
 		}
 		{
@@ -2082,12 +2082,12 @@
 			y: 5.5d
 			id: "2B706ABFD6BE1023"
 			tasks: [{
-				id: "39FA97FB8DD20DB7"
 				type: "advancement"
-				title: "Unlock Fanciful Belt"
-				icon: "spectrum:fanciful_belt"
 				advancement: "spectrum:progression/unlock_fanciful_belt"
 				criterion: ""
+				id: "39FA97FB8DD20DB7"
+				icon: "spectrum:fanciful_belt"
+				title: "Unlock Fanciful Belt"
 			}]
 		}
 		{
@@ -2095,12 +2095,12 @@
 			y: 5.5d
 			id: "05E745BE7FE332D2"
 			tasks: [{
-				id: "2C05DE244FC7553A"
 				type: "advancement"
-				title: "Unlock Fanciful Circlet"
-				icon: "spectrum:fanciful_circlet"
 				advancement: "spectrum:progression/unlock_fanciful_circlet"
 				criterion: ""
+				id: "2C05DE244FC7553A"
+				icon: "spectrum:fanciful_circlet"
+				title: "Unlock Fanciful Circlet"
 			}]
 		}
 		{
@@ -2108,12 +2108,12 @@
 			y: 5.5d
 			id: "27189002E5B7D5FD"
 			tasks: [{
-				id: "2D42179748C56110"
 				type: "advancement"
-				title: "Unlock Fanciful Gloves"
-				icon: "spectrum:fanciful_gloves"
 				advancement: "spectrum:progression/unlock_fanciful_gloves"
 				criterion: ""
+				id: "2D42179748C56110"
+				icon: "spectrum:fanciful_gloves"
+				title: "Unlock Fanciful Gloves"
 			}]
 		}
 		{
@@ -2121,12 +2121,12 @@
 			y: 5.5d
 			id: "2B1172A39AAA22C1"
 			tasks: [{
-				id: "41A2DD06B1B154FC"
 				type: "advancement"
-				title: "Unlock Fanciful Pendant"
-				icon: "spectrum:fanciful_pendant"
 				advancement: "spectrum:progression/unlock_fanciful_pendant"
 				criterion: ""
+				id: "41A2DD06B1B154FC"
+				icon: "spectrum:fanciful_pendant"
+				title: "Unlock Fanciful Pendant"
 			}]
 		}
 		{
@@ -2134,36 +2134,37 @@
 			y: 5.5d
 			id: "5A3CC5725513C9E2"
 			tasks: [{
-				id: "212CD934CF4680C4"
 				type: "advancement"
-				title: "Unlock Fanciful Stone Ring"
-				icon: "spectrum:fanciful_stone_ring"
 				advancement: "spectrum:progression/unlock_fanciful_stone_ring"
 				criterion: ""
+				id: "212CD934CF4680C4"
+				icon: "spectrum:fanciful_stone_ring"
+				title: "Unlock Fanciful Stone Ring"
 			}]
 		}
 		{
-			icon: "spectrum:freigeist"
-			x: 4.0d
-			y: 5.5d
-			id: "7D30D67D64C88F02"
 			tasks: [{
-				id: "3202EFA3B8761C6B"
 				type: "advancement"
-				title: "Unlock Freigeist"
-				icon: "spectrum:freigeist"
 				advancement: "spectrum:progression/unlock_freigeist"
 				criterion: ""
+				id: "3202EFA3B8761C6B"
+				icon: "spectrum:freigeist"
+				title: "Unlock Freigeist"
 			}]
+			id: "7D30D67D64C88F02"
+			y: 5.5d
+			x: 4.0d
+			icon: "spectrum:freigeist"
 		}
 		{
 			x: 5.0d
 			y: 5.5d
 			id: "0EEC5A277FDA2CF0"
 			tasks: [{
-				id: "0D628FBBF258C94A"
 				type: "advancement"
-				title: "Unlock Gemstone Armor"
+				advancement: "spectrum:progression/unlock_gemstone_armor_category"
+				criterion: ""
+				id: "0D628FBBF258C94A"
 				icon: {
 					id: "spectrum:emergency_chestplate"
 					Count: 1b
@@ -2171,8 +2172,7 @@
 						Damage: 0
 					}
 				}
-				advancement: "spectrum:progression/unlock_gemstone_armor_category"
-				criterion: ""
+				title: "Unlock Gemstone Armor"
 			}]
 		}
 		{
@@ -2180,12 +2180,12 @@
 			y: 5.5d
 			id: "69DF665C21942E02"
 			tasks: [{
-				id: "130274DD545AE895"
 				type: "advancement"
-				title: "Unlock Gilded Book"
-				icon: "spectrum:gilded_book"
 				advancement: "spectrum:progression/unlock_gilded_book"
 				criterion: ""
+				id: "130274DD545AE895"
+				icon: "spectrum:gilded_book"
+				title: "Unlock Gilded Book"
 			}]
 		}
 		{
@@ -2193,9 +2193,10 @@
 			y: 5.5d
 			id: "1106EE465C8087B6"
 			tasks: [{
-				id: "605945AEF1D1FD4C"
 				type: "advancement"
-				title: "Unlock Gin"
+				advancement: "spectrum:progression/unlock_gin"
+				criterion: ""
+				id: "605945AEF1D1FD4C"
 				icon: {
 					id: "spectrum:infused_beverage"
 					Count: 1b
@@ -2215,8 +2216,7 @@
 						AlcPercent: 33
 					}
 				}
-				advancement: "spectrum:progression/unlock_gin"
-				criterion: ""
+				title: "Unlock Gin"
 			}]
 		}
 		{
@@ -2224,12 +2224,12 @@
 			y: 5.5d
 			id: "158866FA06C7704E"
 			tasks: [{
-				id: "260F6EE352F64C5A"
 				type: "advancement"
-				title: "Unlock Gleaming Pin"
-				icon: "spectrum:gleaming_pin"
 				advancement: "spectrum:progression/unlock_gleaming_pin"
 				criterion: ""
+				id: "260F6EE352F64C5A"
+				icon: "spectrum:gleaming_pin"
+				title: "Unlock Gleaming Pin"
 			}]
 		}
 		{
@@ -2237,12 +2237,12 @@
 			y: 6.5d
 			id: "0ECBFD727A476887"
 			tasks: [{
-				id: "7A57797B6C399407"
 				type: "advancement"
-				title: "Unlock Glistering Jelly Tea"
-				icon: "spectrum:glistering_jelly_tea"
 				advancement: "spectrum:progression/unlock_glistering_jelly_tea"
 				criterion: ""
+				id: "7A57797B6C399407"
+				icon: "spectrum:glistering_jelly_tea"
+				title: "Unlock Glistering Jelly Tea"
 			}]
 		}
 		{
@@ -2250,12 +2250,12 @@
 			y: 6.5d
 			id: "3890B865F694AB41"
 			tasks: [{
-				id: "73A4F3C9E328CC9E"
 				type: "advancement"
-				title: "Unlock Gloves of Dawn's Grasp"
-				icon: "spectrum:gloves_of_dawns_grasp"
 				advancement: "spectrum:progression/unlock_gloves_of_dawns_grasp"
 				criterion: ""
+				id: "73A4F3C9E328CC9E"
+				icon: "spectrum:gloves_of_dawns_grasp"
+				title: "Unlock Gloves of Dawn's Grasp"
 			}]
 		}
 		{
@@ -2263,12 +2263,12 @@
 			y: 6.5d
 			id: "7BC881C6053B05F2"
 			tasks: [{
-				id: "1B7652DE2B25FD55"
 				type: "advancement"
-				title: "Unlock Glow Vision Helmet"
-				icon: "spectrum:glow_vision_helmet"
 				advancement: "spectrum:progression/unlock_glow_vision_helmet"
 				criterion: ""
+				id: "1B7652DE2B25FD55"
+				icon: "spectrum:glow_vision_helmet"
+				title: "Unlock Glow Vision Helmet"
 			}]
 		}
 		{
@@ -2276,12 +2276,12 @@
 			y: 6.5d
 			id: "0DDBCCB0CCFE1CA7"
 			tasks: [{
-				id: "78BAA688C7491225"
 				type: "advancement"
-				title: "Unlock Greater Potion Pendant"
-				icon: "spectrum:greater_potion_pendant"
 				advancement: "spectrum:progression/unlock_greater_potion_pendant"
 				criterion: ""
+				id: "78BAA688C7491225"
+				icon: "spectrum:greater_potion_pendant"
+				title: "Unlock Greater Potion Pendant"
 			}]
 		}
 		{
@@ -2289,12 +2289,12 @@
 			y: 6.5d
 			id: "6E531535E83FCAD2"
 			tasks: [{
-				id: "3CB268F7EF47EEA4"
 				type: "advancement"
-				title: "Unlock Heartsinger's Reward"
-				icon: "spectrum:heartsingers_reward"
 				advancement: "spectrum:progression/unlock_heartsingers_reward"
 				criterion: ""
+				id: "3CB268F7EF47EEA4"
+				icon: "spectrum:heartsingers_reward"
+				title: "Unlock Heartsinger's Reward"
 			}]
 		}
 		{
@@ -2302,12 +2302,12 @@
 			y: 6.5d
 			id: "7DAFEADC36C43532"
 			tasks: [{
-				id: "76721E5BBCB1BEE2"
 				type: "advancement"
-				title: "Unlock Incandescent Amalgam"
-				icon: "spectrum:incandescent_amalgam"
 				advancement: "spectrum:progression/unlock_incandescent_amalgam"
 				criterion: ""
+				id: "76721E5BBCB1BEE2"
+				icon: "spectrum:incandescent_amalgam"
+				title: "Unlock Incandescent Amalgam"
 			}]
 		}
 		{
@@ -2315,12 +2315,12 @@
 			y: 6.5d
 			id: "062F50B91925C02C"
 			tasks: [{
-				id: "5C03353460B1FE8A"
 				type: "advancement"
-				title: "Unlock Ink Assortment"
-				icon: "spectrum:ink_assortment"
 				advancement: "spectrum:progression/unlock_ink_assortment"
 				criterion: ""
+				id: "5C03353460B1FE8A"
+				icon: "spectrum:ink_assortment"
+				title: "Unlock Ink Assortment"
 			}]
 		}
 		{
@@ -2328,12 +2328,12 @@
 			y: 6.5d
 			id: "0B95AFD3DDFA6809"
 			tasks: [{
-				id: "1A0A9D969C66612D"
 				type: "advancement"
-				title: "Unlock Ink Duct"
-				icon: "spectrum:ink_duct"
 				advancement: "spectrum:progression/unlock_ink_duct"
 				criterion: ""
+				id: "1A0A9D969C66612D"
+				icon: "spectrum:ink_duct"
+				title: "Unlock Ink Duct"
 			}]
 		}
 		{
@@ -2341,12 +2341,12 @@
 			y: 6.5d
 			id: "535FE089B146DA9D"
 			tasks: [{
-				id: "493497C21B2DA1DF"
 				type: "advancement"
-				title: "Unlock Ink Flask"
-				icon: "spectrum:ink_flask"
 				advancement: "spectrum:progression/unlock_ink_flask"
 				criterion: ""
+				id: "493497C21B2DA1DF"
+				icon: "spectrum:ink_flask"
+				title: "Unlock Ink Flask"
 			}]
 		}
 		{
@@ -2354,12 +2354,12 @@
 			y: 6.5d
 			id: "12C109AA604417D6"
 			tasks: [{
-				id: "3682AC7A2F8065C6"
 				type: "advancement"
-				title: "Unlock Inkwell"
-				icon: "spectrum:inkwell"
 				advancement: "spectrum:progression/unlock_inkwell"
 				criterion: ""
+				id: "3682AC7A2F8065C6"
+				icon: "spectrum:inkwell"
+				title: "Unlock Inkwell"
 			}]
 		}
 		{
@@ -2367,12 +2367,12 @@
 			y: 6.5d
 			id: "5E12F0297F3D4139"
 			tasks: [{
-				id: "1574D7D842D4B2F6"
 				type: "advancement"
-				title: "Unlock Item Bowl"
-				icon: "spectrum:item_bowl_basalt"
 				advancement: "spectrum:progression/unlock_item_bowl"
 				criterion: ""
+				id: "1574D7D842D4B2F6"
+				icon: "spectrum:item_bowl_basalt"
+				title: "Unlock Item Bowl"
 			}]
 		}
 		{
@@ -2380,12 +2380,12 @@
 			y: 6.5d
 			id: "45F7E6DD0A68BE7D"
 			tasks: [{
-				id: "491A997E45EC55DE"
 				type: "advancement"
-				title: "Unlock Item Roundel"
-				icon: "spectrum:item_roundel"
 				advancement: "spectrum:progression/unlock_item_roundel"
 				criterion: ""
+				id: "491A997E45EC55DE"
+				icon: "spectrum:item_roundel"
+				title: "Unlock Item Roundel"
 			}]
 		}
 		{
@@ -2393,12 +2393,12 @@
 			y: 6.5d
 			id: "4E4A9243D8CB6773"
 			tasks: [{
-				id: "42EB3A545CC3E04C"
 				type: "advancement"
-				title: "Unlock Jade Wine"
-				icon: "spectrum:jade_wine"
 				advancement: "spectrum:progression/unlock_jade_wine"
 				criterion: ""
+				id: "42EB3A545CC3E04C"
+				icon: "spectrum:jade_wine"
+				title: "Unlock Jade Wine"
 			}]
 		}
 		{
@@ -2406,12 +2406,12 @@
 			y: 6.5d
 			id: "7AB032B6D7D0A61B"
 			tasks: [{
-				id: "1493EA058FC63614"
 				type: "advancement"
-				title: "Unlock Jaramel"
-				icon: "spectrum:jaramel"
 				advancement: "spectrum:progression/unlock_jaramel"
 				criterion: ""
+				id: "1493EA058FC63614"
+				icon: "spectrum:jaramel"
+				title: "Unlock Jaramel"
 			}]
 		}
 		{
@@ -2419,12 +2419,12 @@
 			y: 6.5d
 			id: "3E6E495E9F3A732E"
 			tasks: [{
-				id: "3C87F3E3D49AB4AF"
 				type: "advancement"
-				title: "Unlock Jeopardant"
-				icon: "spectrum:jeopardant"
 				advancement: "spectrum:progression/unlock_jeopardant"
 				criterion: ""
+				id: "3C87F3E3D49AB4AF"
+				icon: "spectrum:jeopardant"
+				title: "Unlock Jeopardant"
 			}]
 		}
 		{
@@ -2432,12 +2432,12 @@
 			y: 6.5d
 			id: "73BCFBED056639D3"
 			tasks: [{
-				id: "6336D2C934CD98B4"
 				type: "advancement"
-				title: "Unlock Knowledge Gem"
-				icon: "spectrum:knowledge_gem"
 				advancement: "spectrum:progression/unlock_knowledge_gem"
 				criterion: ""
+				id: "6336D2C934CD98B4"
+				icon: "spectrum:knowledge_gem"
+				title: "Unlock Knowledge Gem"
 			}]
 		}
 		{
@@ -2445,9 +2445,10 @@
 			y: 7.5d
 			id: "5F49C0FB468B399F"
 			tasks: [{
-				id: "4492B739C756AC9F"
 				type: "advancement"
-				title: "Unlock Lagoon Rod"
+				advancement: "spectrum:progression/unlock_lagoon_rod"
+				criterion: ""
+				id: "4492B739C756AC9F"
 				icon: {
 					id: "spectrum:lagoon_rod"
 					Count: 1b
@@ -2459,8 +2460,7 @@
 						}]
 					}
 				}
-				advancement: "spectrum:progression/unlock_lagoon_rod"
-				criterion: ""
+				title: "Unlock Lagoon Rod"
 			}]
 		}
 		{
@@ -2468,12 +2468,12 @@
 			y: 7.5d
 			id: "2DD23EC1A9581D5A"
 			tasks: [{
-				id: "22BE22DF92208E24"
 				type: "advancement"
-				title: "Unlock Lava Sponge"
-				icon: "spectrum:lava_sponge"
 				advancement: "spectrum:progression/unlock_lava_sponge"
 				criterion: ""
+				id: "22BE22DF92208E24"
+				icon: "spectrum:lava_sponge"
+				title: "Unlock Lava Sponge"
 			}]
 		}
 		{
@@ -2481,12 +2481,12 @@
 			y: 7.5d
 			id: "2BDD29E53268EF5F"
 			tasks: [{
-				id: "7B41D5301D7B6E42"
 				type: "advancement"
-				title: "Unlock Lesser Potion Pendant"
-				icon: "spectrum:lesser_potion_pendant"
 				advancement: "spectrum:progression/unlock_lesser_potion_pendant"
 				criterion: ""
+				id: "7B41D5301D7B6E42"
+				icon: "spectrum:lesser_potion_pendant"
+				title: "Unlock Lesser Potion Pendant"
 			}]
 		}
 		{
@@ -2494,12 +2494,12 @@
 			y: 7.5d
 			id: "2470EDBF2689AFAA"
 			tasks: [{
-				id: "2205A87647F70200"
 				type: "advancement"
-				title: "Unlock Radiance Staff"
-				icon: "spectrum:light_staff"
 				advancement: "spectrum:progression/unlock_light_staff"
 				criterion: ""
+				id: "2205A87647F70200"
+				icon: "spectrum:light_staff"
+				title: "Unlock Radiance Staff"
 			}]
 		}
 		{
@@ -2507,12 +2507,12 @@
 			y: 7.5d
 			id: "222D28F8D0BD3DD4"
 			tasks: [{
-				id: "3DB1E29F425F8E9E"
 				type: "advancement"
-				title: "Unlock Liquid Crystal Bucket"
-				icon: "spectrum:liquid_crystal_bucket"
 				advancement: "spectrum:progression/unlock_liquid_crystal_bucket"
 				criterion: ""
+				id: "3DB1E29F425F8E9E"
+				icon: "spectrum:liquid_crystal_bucket"
+				title: "Unlock Liquid Crystal Bucket"
 			}]
 		}
 		{
@@ -2520,12 +2520,12 @@
 			y: 7.5d
 			id: "257EB6DADD18F8F1"
 			tasks: [{
-				id: "1CD5A9D7085F0797"
 				type: "advancement"
-				title: "Unlock Lucky Roll"
-				icon: "spectrum:lucky_roll"
 				advancement: "spectrum:progression/unlock_lucky_roll"
 				criterion: ""
+				id: "1CD5A9D7085F0797"
+				icon: "spectrum:lucky_roll"
+				title: "Unlock Lucky Roll"
 			}]
 		}
 		{
@@ -2533,12 +2533,12 @@
 			y: 7.5d
 			id: "74622C7DC94EB19E"
 			tasks: [{
-				id: "64CC5E8231F61F20"
 				type: "advancement"
-				title: "Unlock Midnight Aberration"
-				icon: "spectrum:midnight_aberration"
 				advancement: "spectrum:progression/unlock_midnight_aberration"
 				criterion: ""
+				id: "64CC5E8231F61F20"
+				icon: "spectrum:midnight_aberration"
+				title: "Unlock Midnight Aberration"
 			}]
 		}
 		{
@@ -2546,12 +2546,12 @@
 			y: 7.5d
 			id: "13A9CB8023146AE0"
 			tasks: [{
-				id: "3ED1BCBBF81EDE4F"
 				type: "advancement"
-				title: "Unlock Midnight Solution"
-				icon: "spectrum:midnight_solution_bucket"
 				advancement: "spectrum:progression/unlock_midnight_solution"
 				criterion: ""
+				id: "3ED1BCBBF81EDE4F"
+				icon: "spectrum:midnight_solution_bucket"
+				title: "Unlock Midnight Solution"
 			}]
 		}
 		{
@@ -2559,16 +2559,16 @@
 			y: 7.5d
 			id: "47097D823757351C"
 			tasks: [{
-				id: "578D09F261D9388C"
 				type: "advancement"
-				title: "Unlock Mint Beverages"
+				advancement: "spectrum:progression/unlock_mint_beverages"
+				criterion: ""
+				id: "578D09F261D9388C"
 				icon: {
 					id: "spectrum:infused_beverage"
 					Count: 1b
 					tag: { }
 				}
-				advancement: "spectrum:progression/unlock_mint_beverages"
-				criterion: ""
+				title: "Unlock Mint Beverages"
 			}]
 		}
 		{
@@ -2576,9 +2576,10 @@
 			y: 7.5d
 			id: "19FF4E1B355BA825"
 			tasks: [{
-				id: "27F3FFC288BA1648"
 				type: "advancement"
-				title: "Unlock Molten Rod"
+				advancement: "spectrum:progression/unlock_molten_rod"
+				criterion: ""
+				id: "27F3FFC288BA1648"
 				icon: {
 					id: "spectrum:molten_rod"
 					Count: 1b
@@ -2586,8 +2587,7 @@
 						Damage: 0
 					}
 				}
-				advancement: "spectrum:progression/unlock_molten_rod"
-				criterion: ""
+				title: "Unlock Molten Rod"
 			}]
 		}
 		{
@@ -2595,12 +2595,12 @@
 			y: 7.5d
 			id: "41E973C0072887F5"
 			tasks: [{
-				id: "4393938242718B1A"
 				type: "advancement"
-				title: "Unlock Moonshine"
-				icon: "spectrum:moonshine"
 				advancement: "spectrum:progression/unlock_moonshine"
 				criterion: ""
+				id: "4393938242718B1A"
+				icon: "spectrum:moonshine"
+				title: "Unlock Moonshine"
 			}]
 		}
 		{
@@ -2608,12 +2608,12 @@
 			y: 7.5d
 			id: "12BE6513681F980C"
 			tasks: [{
-				id: "6F8D93B679DB74F2"
 				type: "advancement"
-				title: "Unlock Semi-Permeable Moonstone Glass"
-				icon: "spectrum:moonstone_player_only_glass"
 				advancement: "spectrum:progression/unlock_moonstone_player_only_glass"
 				criterion: ""
+				id: "6F8D93B679DB74F2"
+				icon: "spectrum:moonstone_player_only_glass"
+				title: "Unlock Semi-Permeable Moonstone Glass"
 			}]
 		}
 		{
@@ -2621,12 +2621,12 @@
 			y: 7.5d
 			id: "47B92537B3B62653"
 			tasks: [{
-				id: "4B62B460942B736C"
 				type: "advancement"
-				title: "Unlock Mud Bucket"
-				icon: "spectrum:mud_bucket"
 				advancement: "spectrum:progression/unlock_mud_bucket"
 				criterion: ""
+				id: "4B62B460942B736C"
+				icon: "spectrum:mud_bucket"
+				title: "Unlock Mud Bucket"
 			}]
 		}
 		{
@@ -2634,12 +2634,12 @@
 			y: 7.5d
 			id: "34E14CC985ABBB30"
 			tasks: [{
-				id: "15396ECF572A5547"
 				type: "advancement"
-				title: "Unlock Nature's Staff"
-				icon: "spectrum:natures_staff"
 				advancement: "spectrum:progression/unlock_natures_staff"
 				criterion: ""
+				id: "15396ECF572A5547"
+				icon: "spectrum:natures_staff"
+				title: "Unlock Nature's Staff"
 			}]
 		}
 		{
@@ -2647,12 +2647,12 @@
 			y: 7.5d
 			id: "25DF2E686AECF370"
 			tasks: [{
-				id: "6D1B9823506063F0"
 				type: "advancement"
-				title: "Unlock Neat Ring"
-				icon: "spectrum:neat_ring"
 				advancement: "spectrum:progression/unlock_neat_ring"
 				criterion: ""
+				id: "6D1B9823506063F0"
+				icon: "spectrum:neat_ring"
+				title: "Unlock Neat Ring"
 			}]
 		}
 		{
@@ -2660,12 +2660,12 @@
 			y: 7.5d
 			id: "0ADAF1E113D46A4B"
 			tasks: [{
-				id: "33FDC71E07DFF1CE"
 				type: "advancement"
-				title: "Unlock Netherite Ingot Fusion Recipe"
-				icon: "minecraft:netherite_ingot"
 				advancement: "spectrum:progression/unlock_netherite_ingot_fusion_recipe"
 				criterion: ""
+				id: "33FDC71E07DFF1CE"
+				icon: "minecraft:netherite_ingot"
+				title: "Unlock Netherite Ingot Fusion Recipe"
 			}]
 		}
 		{
@@ -2673,12 +2673,12 @@
 			y: 8.5d
 			id: "5F98BB34B7C6A03C"
 			tasks: [{
-				id: "7F926D231961B100"
 				type: "advancement"
-				title: "Unlock Ominous Sapling"
-				icon: "spectrum:ominous_sapling"
 				advancement: "spectrum:progression/unlock_ominous_sapling"
 				criterion: ""
+				id: "7F926D231961B100"
+				icon: "spectrum:ominous_sapling"
+				title: "Unlock Ominous Sapling"
 			}]
 		}
 		{
@@ -2686,12 +2686,12 @@
 			y: 8.5d
 			id: "7DC09AEE1655470E"
 			tasks: [{
-				id: "79A7CD939734B38D"
 				type: "advancement"
-				title: "Unlock Particle Spawner"
-				icon: "spectrum:particle_spawner"
 				advancement: "spectrum:progression/unlock_particle_spawner"
 				criterion: ""
+				id: "79A7CD939734B38D"
+				icon: "spectrum:particle_spawner"
+				title: "Unlock Particle Spawner"
 			}]
 		}
 		{
@@ -2699,12 +2699,12 @@
 			y: 8.5d
 			id: "444EB8843BF736E6"
 			tasks: [{
-				id: "18BF1B6455C37723"
 				type: "advancement"
-				title: "Unlock Pies"
-				icon: "minecraft:pumpkin_pie"
 				advancement: "spectrum:progression/unlock_pies"
 				criterion: ""
+				id: "18BF1B6455C37723"
+				icon: "minecraft:pumpkin_pie"
+				title: "Unlock Pies"
 			}]
 		}
 		{
@@ -2712,12 +2712,12 @@
 			y: 8.5d
 			id: "45C2718BE92D2776"
 			tasks: [{
-				id: "6846250A506D791D"
 				type: "advancement"
-				title: "Unlock Pigment Palette"
-				icon: "spectrum:pigment_palette"
 				advancement: "spectrum:progression/unlock_pigment_palette"
 				criterion: ""
+				id: "6846250A506D791D"
+				icon: "spectrum:pigment_palette"
+				title: "Unlock Pigment Palette"
 			}]
 		}
 		{
@@ -2725,12 +2725,12 @@
 			y: 8.5d
 			id: "2DE5FA8EACB66B42"
 			tasks: [{
-				id: "6E4270128CF951CC"
 				type: "advancement"
-				title: "Unlock Constructor's Staff"
-				icon: "spectrum:placement_staff"
 				advancement: "spectrum:progression/unlock_placement_staff"
 				criterion: ""
+				id: "6E4270128CF951CC"
+				icon: "spectrum:placement_staff"
+				title: "Unlock Constructor's Staff"
 			}]
 		}
 		{
@@ -2738,12 +2738,12 @@
 			y: 8.5d
 			id: "21D0CFB183706A87"
 			tasks: [{
-				id: "2423E3FD3EEE7018"
 				type: "advancement"
-				title: "Unlock Potion Workshop"
-				icon: "spectrum:potion_workshop"
 				advancement: "spectrum:progression/unlock_potion_workshop"
 				criterion: ""
+				id: "2423E3FD3EEE7018"
+				icon: "spectrum:potion_workshop"
+				title: "Unlock Potion Workshop"
 			}]
 		}
 		{
@@ -2751,12 +2751,12 @@
 			y: 8.5d
 			id: "548CDD5B65C9F802"
 			tasks: [{
-				id: "5A80805A63F02FC8"
 				type: "advancement"
-				title: "Unlock Present"
-				icon: "spectrum:present"
 				advancement: "spectrum:progression/unlock_present"
 				criterion: ""
+				id: "5A80805A63F02FC8"
+				icon: "spectrum:present"
+				title: "Unlock Present"
 			}]
 		}
 		{
@@ -2764,12 +2764,12 @@
 			y: 8.5d
 			id: "320F1900BF16F36A"
 			tasks: [{
-				id: "2217A352985F7960"
 				type: "advancement"
-				title: "Unlock Heartbound Chest"
-				icon: "spectrum:private_chest"
 				advancement: "spectrum:progression/unlock_private_chest"
 				criterion: ""
+				id: "2217A352985F7960"
+				icon: "spectrum:private_chest"
+				title: "Unlock Heartbound Chest"
 			}]
 		}
 		{
@@ -2777,12 +2777,12 @@
 			y: 8.5d
 			id: "06009C659A6DAA68"
 			tasks: [{
-				id: "128A20744F4EA912"
 				type: "advancement"
-				title: "Unlock Puff Circlet"
-				icon: "spectrum:puff_circlet"
 				advancement: "spectrum:progression/unlock_puff_circlet"
 				criterion: ""
+				id: "128A20744F4EA912"
+				icon: "spectrum:puff_circlet"
+				title: "Unlock Puff Circlet"
 			}]
 		}
 		{
@@ -2790,9 +2790,10 @@
 			y: 8.5d
 			id: "51A77B8F6D4C2B13"
 			tasks: [{
-				id: "537D3722E50EE1C4"
 				type: "advancement"
-				title: "Unlock Rabbit Poison"
+				advancement: "spectrum:progression/unlock_rabbit_poison"
+				criterion: ""
+				id: "537D3722E50EE1C4"
 				icon: {
 					id: "spectrum:infused_beverage"
 					Count: 1b
@@ -2846,8 +2847,7 @@
 						AlcPercent: 5
 					}
 				}
-				advancement: "spectrum:progression/unlock_rabbit_poison"
-				criterion: ""
+				title: "Unlock Rabbit Poison"
 			}]
 		}
 		{
@@ -2855,12 +2855,12 @@
 			y: 8.5d
 			id: "0E2793F826157B98"
 			tasks: [{
-				id: "6CE4E7F0BEA819F1"
 				type: "advancement"
-				title: "Unlock Radiance Pin"
-				icon: "spectrum:radiance_pin"
 				advancement: "spectrum:progression/unlock_radiance_pin"
 				criterion: ""
+				id: "6CE4E7F0BEA819F1"
+				icon: "spectrum:radiance_pin"
+				title: "Unlock Radiance Pin"
 			}]
 		}
 		{
@@ -2868,12 +2868,12 @@
 			y: 8.5d
 			id: "366545E4140D5C6D"
 			tasks: [{
-				id: "4D49F973612FE318"
 				type: "advancement"
-				title: "Unlock Redstone Calculator"
-				icon: "spectrum:redstone_calculator"
 				advancement: "spectrum:progression/unlock_redstone_calculator"
 				criterion: ""
+				id: "4D49F973612FE318"
+				icon: "spectrum:redstone_calculator"
+				title: "Unlock Redstone Calculator"
 			}]
 		}
 		{
@@ -2881,12 +2881,12 @@
 			y: 8.5d
 			id: "1C54EF3C39750BB0"
 			tasks: [{
-				id: "0917722CC0F258D7"
 				type: "advancement"
-				title: "Unlock Redstone Sand"
-				icon: "spectrum:redstone_sand"
 				advancement: "spectrum:progression/unlock_redstone_sand"
 				criterion: ""
+				id: "0917722CC0F258D7"
+				icon: "spectrum:redstone_sand"
+				title: "Unlock Redstone Sand"
 			}]
 		}
 		{
@@ -2894,12 +2894,12 @@
 			y: 8.5d
 			id: "7160FE9DAB7FC8A4"
 			tasks: [{
-				id: "37CD09BD4F974043"
 				type: "advancement"
-				title: "Unlock Redstone Timer"
-				icon: "spectrum:redstone_timer"
 				advancement: "spectrum:progression/unlock_redstone_timer"
 				criterion: ""
+				id: "37CD09BD4F974043"
+				icon: "spectrum:redstone_timer"
+				title: "Unlock Redstone Timer"
 			}]
 		}
 		{
@@ -2907,12 +2907,12 @@
 			y: 8.5d
 			id: "782CA7A197A8E5BE"
 			tasks: [{
-				id: "70F619545B4DB5B1"
 				type: "advancement"
-				title: "Unlock Reprise"
-				icon: "spectrum:reprise"
 				advancement: "spectrum:progression/unlock_reprise"
 				criterion: ""
+				id: "70F619545B4DB5B1"
+				icon: "spectrum:reprise"
+				title: "Unlock Reprise"
 			}]
 		}
 		{
@@ -2920,12 +2920,12 @@
 			y: 8.5d
 			id: "23219EA1B4B0CDE8"
 			tasks: [{
-				id: "69877BAAF6FD0762"
 				type: "advancement"
-				title: "Unlock FABRICation Chest"
-				icon: "spectrum:restocking_chest"
 				advancement: "spectrum:progression/unlock_restocking_chest"
 				criterion: ""
+				id: "69877BAAF6FD0762"
+				icon: "spectrum:restocking_chest"
+				title: "Unlock FABRICation Chest"
 			}]
 		}
 		{
@@ -2933,12 +2933,12 @@
 			y: 9.5d
 			id: "47AD895C8E856A49"
 			tasks: [{
-				id: "6AA6E2D21C629424"
 				type: "advancement"
-				title: "Unlock Restoration Tea"
-				icon: "spectrum:restoration_tea"
 				advancement: "spectrum:progression/unlock_restoration_tea"
 				criterion: ""
+				id: "6AA6E2D21C629424"
+				icon: "spectrum:restoration_tea"
+				title: "Unlock Restoration Tea"
 			}]
 		}
 		{
@@ -2946,12 +2946,12 @@
 			y: 9.5d
 			id: "288165DCDB64789A"
 			tasks: [{
-				id: "759C8C10C844885D"
 				type: "advancement"
-				title: "Unlock Rock Candy"
-				icon: "spectrum:rock_candy"
 				advancement: "spectrum:progression/unlock_rock_candy"
 				criterion: ""
+				id: "759C8C10C844885D"
+				icon: "spectrum:rock_candy"
+				title: "Unlock Rock Candy"
 			}]
 		}
 		{
@@ -2959,12 +2959,12 @@
 			y: 9.5d
 			id: "0A38B81C9F177637"
 			tasks: [{
-				id: "2DC13A9E43B9239C"
 				type: "advancement"
-				title: "Unlock Seven League Boots"
-				icon: "spectrum:seven_league_boots"
 				advancement: "spectrum:progression/unlock_seven_league_boots"
 				criterion: ""
+				id: "2DC13A9E43B9239C"
+				icon: "spectrum:seven_league_boots"
+				title: "Unlock Seven League Boots"
 			}]
 		}
 		{
@@ -2972,12 +2972,12 @@
 			y: 9.5d
 			id: "519393ABB8559F39"
 			tasks: [{
-				id: "5F8EA8B93FAA3945"
 				type: "advancement"
-				title: "Unlock Shieldgrasp Amulet"
-				icon: "spectrum:shieldgrasp_amulet"
 				advancement: "spectrum:progression/unlock_shieldgrasp_amulet"
 				criterion: ""
+				id: "5F8EA8B93FAA3945"
+				icon: "spectrum:shieldgrasp_amulet"
+				title: "Unlock Shieldgrasp Amulet"
 			}]
 		}
 		{
@@ -2985,12 +2985,12 @@
 			y: 9.5d
 			id: "18EEA27132984F2A"
 			tasks: [{
-				id: "53D84CDA6642DC5C"
 				type: "advancement"
-				title: "Unlock Shimmerstone Lights"
-				icon: "spectrum:basalt_sparklestone_light"
 				advancement: "spectrum:progression/unlock_sparklestone_lights"
 				criterion: ""
+				id: "53D84CDA6642DC5C"
+				icon: "spectrum:basalt_sparklestone_light"
+				title: "Unlock Shimmerstone Lights"
 			}]
 		}
 		{
@@ -2998,12 +2998,12 @@
 			y: 9.5d
 			id: "63DE50F3F2E0E189"
 			tasks: [{
-				id: "47BAD816E1669131"
 				type: "advancement"
-				title: "Unlock Spirit Instiller"
-				icon: "spectrum:spirit_instiller"
 				advancement: "spectrum:progression/unlock_spirit_instiller"
 				criterion: ""
+				id: "47BAD816E1669131"
+				icon: "spectrum:spirit_instiller"
+				title: "Unlock Spirit Instiller"
 			}]
 		}
 		{
@@ -3011,12 +3011,12 @@
 			y: 9.5d
 			id: "0A9E677AD387C5B2"
 			tasks: [{
-				id: "74F7C45F589F3293"
 				type: "advancement"
-				title: "Unlock Star Candy"
-				icon: "spectrum:star_candy"
 				advancement: "spectrum:progression/unlock_star_candy"
 				criterion: ""
+				id: "74F7C45F589F3293"
+				icon: "spectrum:star_candy"
+				title: "Unlock Star Candy"
 			}]
 		}
 		{
@@ -3024,12 +3024,12 @@
 			y: 9.5d
 			id: "5D2F6F6D747CA195"
 			tasks: [{
-				id: "5D5986E3E20E60E0"
 				type: "advancement"
-				title: "Unlock Black Hole Chest"
-				icon: "spectrum:sucking_chest"
 				advancement: "spectrum:progression/unlock_sucking_chest"
 				criterion: ""
+				id: "5D5986E3E20E60E0"
+				icon: "spectrum:sucking_chest"
+				title: "Unlock Black Hole Chest"
 			}]
 		}
 		{
@@ -3037,12 +3037,12 @@
 			y: 9.5d
 			id: "44F2519E20E09578"
 			tasks: [{
-				id: "3310707CF511D78D"
 				type: "advancement"
-				title: "Unlock Suspicious Brew"
-				icon: "spectrum:suspicious_brew"
 				advancement: "spectrum:progression/unlock_suspicious_brew"
 				criterion: ""
+				id: "3310707CF511D78D"
+				icon: "spectrum:suspicious_brew"
+				title: "Unlock Suspicious Brew"
 			}]
 		}
 		{
@@ -3050,12 +3050,12 @@
 			y: 9.5d
 			id: "07E469967B175B13"
 			tasks: [{
-				id: "739EF2D8783C8379"
 				type: "advancement"
-				title: "Unlock Take-Off Belt"
-				icon: "spectrum:take_off_belt"
 				advancement: "spectrum:progression/unlock_take_off_belt"
 				criterion: ""
+				id: "739EF2D8783C8379"
+				icon: "spectrum:take_off_belt"
+				title: "Unlock Take-Off Belt"
 			}]
 		}
 		{
@@ -3063,12 +3063,12 @@
 			y: 9.5d
 			id: "14B5BE711EE666DF"
 			tasks: [{
-				id: "286670E5F062303B"
 				type: "advancement"
-				title: "Unlock Tarts"
-				icon: "spectrum:jaramel_tart"
 				advancement: "spectrum:progression/unlock_tarts"
 				criterion: ""
+				id: "286670E5F062303B"
+				icon: "spectrum:jaramel_tart"
+				title: "Unlock Tarts"
 			}]
 		}
 		{
@@ -3076,12 +3076,12 @@
 			y: 9.5d
 			id: "10F914EE2FBFD5A2"
 			tasks: [{
-				id: "160FA5BDF833CF02"
 				type: "advancement"
-				title: "Unlock Weeping Circlet"
-				icon: "spectrum:tidal_circlet"
 				advancement: "spectrum:progression/unlock_tidal_circlet"
 				criterion: ""
+				id: "160FA5BDF833CF02"
+				icon: "spectrum:tidal_circlet"
+				title: "Unlock Weeping Circlet"
 			}]
 		}
 		{
@@ -3089,12 +3089,12 @@
 			y: 9.5d
 			id: "192712A7BAA31C2A"
 			tasks: [{
-				id: "3936C775DDA3B94C"
 				type: "advancement"
-				title: "Unlock Titration Barrel"
-				icon: "spectrum:titration_barrel"
 				advancement: "spectrum:progression/unlock_titration_barrel"
 				criterion: ""
+				id: "3936C775DDA3B94C"
+				icon: "spectrum:titration_barrel"
+				title: "Unlock Titration Barrel"
 			}]
 		}
 		{
@@ -3102,12 +3102,12 @@
 			y: 9.5d
 			id: "00544378EBA946FF"
 			tasks: [{
-				id: "7537EB12F0B00249"
 				type: "advancement"
-				title: "Unlock Totem Pendant"
-				icon: "spectrum:totem_pendant"
 				advancement: "spectrum:progression/unlock_totem_pendant"
 				criterion: ""
+				id: "7537EB12F0B00249"
+				icon: "spectrum:totem_pendant"
+				title: "Unlock Totem Pendant"
 			}]
 		}
 		{
@@ -3115,12 +3115,12 @@
 			y: 9.5d
 			id: "7F2200B4324198A8"
 			tasks: [{
-				id: "42492C400C6F18F6"
 				type: "advancement"
-				title: "Unlock Trifles"
-				icon: "spectrum:jaramel_trifle"
 				advancement: "spectrum:progression/unlock_trifles"
 				criterion: ""
+				id: "42492C400C6F18F6"
+				icon: "spectrum:jaramel_trifle"
+				title: "Unlock Trifles"
 			}]
 		}
 		{
@@ -3128,12 +3128,12 @@
 			y: 9.5d
 			id: "6F5F476873A45DBB"
 			tasks: [{
-				id: "1FF26C9EBE5A487D"
 				type: "advancement"
-				title: "Unlock Triple Meat Pot Pie"
-				icon: "spectrum:triple_meat_pot_pie"
 				advancement: "spectrum:progression/unlock_triple_meat_pot_pie"
 				criterion: ""
+				id: "1FF26C9EBE5A487D"
+				icon: "spectrum:triple_meat_pot_pie"
+				title: "Unlock Triple Meat Pot Pie"
 			}]
 		}
 		{
@@ -3141,12 +3141,12 @@
 			y: 10.5d
 			id: "683D044353905635"
 			tasks: [{
-				id: "2680E6141705240E"
 				type: "advancement"
-				title: "Unlock Universe Spyhole"
-				icon: "spectrum:universe_spyhole"
 				advancement: "spectrum:progression/unlock_universe_spyhole"
 				criterion: ""
+				id: "2680E6141705240E"
+				icon: "spectrum:universe_spyhole"
+				title: "Unlock Universe Spyhole"
 			}]
 		}
 		{
@@ -3154,12 +3154,12 @@
 			y: 10.5d
 			id: "712496AFBC93E741"
 			tasks: [{
-				id: "34069E1965D3B153"
 				type: "advancement"
-				title: "Unlock Efficiency Slope T2"
-				icon: "spectrum:upgrade_efficiency2"
 				advancement: "spectrum:progression/unlock_upgrade_efficiency2"
 				criterion: ""
+				id: "34069E1965D3B153"
+				icon: "spectrum:upgrade_efficiency2"
+				title: "Unlock Efficiency Slope T2"
 			}]
 		}
 		{
@@ -3167,12 +3167,12 @@
 			y: 10.5d
 			id: "213532433ECED547"
 			tasks: [{
-				id: "5A7B043E6046C7E7"
 				type: "advancement"
-				title: "Unlock Knowledge Focus"
-				icon: "spectrum:upgrade_experience"
 				advancement: "spectrum:progression/unlock_upgrade_experience"
 				criterion: ""
+				id: "5A7B043E6046C7E7"
+				icon: "spectrum:upgrade_experience"
+				title: "Unlock Knowledge Focus"
 			}]
 		}
 		{
@@ -3180,12 +3180,12 @@
 			y: 10.5d
 			id: "6F3B4456D0327B09"
 			tasks: [{
-				id: "47717682E3B66A1A"
 				type: "advancement"
-				title: "Unlock Knowledge Focus T2"
-				icon: "spectrum:upgrade_experience2"
 				advancement: "spectrum:progression/unlock_upgrade_experience2"
 				criterion: ""
+				id: "47717682E3B66A1A"
+				icon: "spectrum:upgrade_experience2"
+				title: "Unlock Knowledge Focus T2"
 			}]
 		}
 		{
@@ -3193,12 +3193,12 @@
 			y: 10.5d
 			id: "354D9DC694EC3DA6"
 			tasks: [{
-				id: "217C206A3E467319"
 				type: "advancement"
-				title: "Unlock Crafting Accelerator T2"
-				icon: "spectrum:upgrade_speed2"
 				advancement: "spectrum:progression/unlock_upgrade_speed2"
 				criterion: ""
+				id: "217C206A3E467319"
+				icon: "spectrum:upgrade_speed2"
+				title: "Unlock Crafting Accelerator T2"
 			}]
 		}
 		{
@@ -3206,12 +3206,12 @@
 			y: 10.5d
 			id: "4198D28DA05A73E2"
 			tasks: [{
-				id: "1E7582B7CF5306F3"
 				type: "advancement"
-				title: "Unlock Crafting Accelerator T3"
-				icon: "spectrum:upgrade_speed3"
 				advancement: "spectrum:progression/unlock_upgrade_speed3"
 				criterion: ""
+				id: "1E7582B7CF5306F3"
+				icon: "spectrum:upgrade_speed3"
+				title: "Unlock Crafting Accelerator T3"
 			}]
 		}
 		{
@@ -3219,12 +3219,12 @@
 			y: 10.5d
 			id: "4C556F3E31A3D285"
 			tasks: [{
-				id: "687DE79212CCD90F"
 				type: "advancement"
-				title: "Unlock Production Surge T2"
-				icon: "spectrum:upgrade_yield2"
 				advancement: "spectrum:progression/unlock_upgrade_yield2"
 				criterion: ""
+				id: "687DE79212CCD90F"
+				icon: "spectrum:upgrade_yield2"
+				title: "Unlock Production Surge T2"
 			}]
 		}
 		{
@@ -3232,16 +3232,16 @@
 			y: 10.5d
 			id: "5A796984A17E4E61"
 			tasks: [{
-				id: "1A1625D64DB97C4E"
 				type: "advancement"
-				title: "Unlock Bottomless Bundle"
+				advancement: "spectrum:progression/unlock_void_bundle"
+				criterion: ""
+				id: "1A1625D64DB97C4E"
 				icon: {
 					id: "spectrum:void_bundle"
 					Count: 1b
 					tag: { }
 				}
-				advancement: "spectrum:progression/unlock_void_bundle"
-				criterion: ""
+				title: "Unlock Bottomless Bundle"
 			}]
 		}
 		{
@@ -3249,12 +3249,12 @@
 			y: 10.5d
 			id: "302ADA4A6DE96546"
 			tasks: [{
-				id: "122C051EBA861091"
 				type: "advancement"
-				title: "Unlock Whispy Circlet"
-				icon: "spectrum:whispy_circlet"
 				advancement: "spectrum:progression/unlock_whispy_circlet"
 				criterion: ""
+				id: "122C051EBA861091"
+				icon: "spectrum:whispy_circlet"
+				title: "Unlock Whispy Circlet"
 			}]
 		}
 		{
@@ -3262,12 +3262,12 @@
 			y: 10.5d
 			id: "7608D23896252119"
 			tasks: [{
-				id: "1BEBECDB8EB20959"
 				type: "advancement"
-				title: "Weather: §eClear§r"
-				icon: "minecraft:sunflower"
 				advancement: "spectrum:progression/weather/weather_clear"
 				criterion: ""
+				id: "1BEBECDB8EB20959"
+				icon: "minecraft:sunflower"
+				title: "Weather: §eClear§r"
 			}]
 		}
 		{
@@ -3275,12 +3275,12 @@
 			y: 10.5d
 			id: "59E70F471B355DE5"
 			tasks: [{
-				id: "458875E04A57A149"
 				type: "advancement"
-				title: "Weather: §eRain§r"
-				icon: "minecraft:water_bucket"
 				advancement: "spectrum:progression/weather/weather_rain"
 				criterion: ""
+				id: "458875E04A57A149"
+				icon: "minecraft:water_bucket"
+				title: "Weather: §eRain§r"
 			}]
 		}
 		{
@@ -3288,12 +3288,12 @@
 			y: 10.5d
 			id: "6955765B4BE2E0A0"
 			tasks: [{
-				id: "22DB3714A786D476"
 				type: "advancement"
-				title: "Weather: §eThunder§r"
-				icon: "spectrum:lightning_stone"
 				advancement: "spectrum:progression/weather/weather_thunder"
 				criterion: ""
+				id: "22DB3714A786D476"
+				icon: "spectrum:lightning_stone"
+				title: "Weather: §eThunder§r"
 			}]
 		}
 		{
@@ -3301,9 +3301,10 @@
 			y: 2.5d
 			id: "3321EA1F416017D3"
 			tasks: [{
-				id: "482C63117A1BF880"
 				type: "advancement"
-				title: "Unlock Resistance Potion"
+				advancement: "spectrum:progression/potions/unlock_resistance_potion"
+				criterion: ""
+				id: "482C63117A1BF880"
 				icon: {
 					id: "minecraft:potion"
 					Count: 1b
@@ -3320,8 +3321,7 @@
 						}]
 					}
 				}
-				advancement: "spectrum:progression/potions/unlock_resistance_potion"
-				criterion: ""
+				title: "Unlock Resistance Potion"
 			}]
 		}
 	]

--- a/config/ftbquests/quests/chapters/storage.snbt
+++ b/config/ftbquests/quests/chapters/storage.snbt
@@ -1,20 +1,15 @@
 {
-	id: "2D905E8603BFEC34"
-	group: "33A417364C0A17FE"
-	order_index: 0
-	filename: "storage"
-	title: "Storage"
-	icon: "expandedstorage:wood_chest"
-	default_quest_shape: "square"
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "33A417364C0A17FE"
+	id: "2D905E8603BFEC34"
+	filename: "storage"
+	default_quest_shape: "square"
+	icon: "expandedstorage:wood_chest"
+	title: "Storage"
+	order_index: 0
 	quests: [
 		{
-			title: "Storage on the go"
-			x: 4.5d
-			y: -3.5d
-			subtitle: "Craft your first backpack."
-			dependencies: ["6F2E92752228528C"]
-			id: "15E104B33E6D3388"
 			tasks: [{
 				id: "53EFF04F0D471D35"
 				type: "item"
@@ -24,19 +19,19 @@
 					tag: { }
 				}
 			}]
+			id: "15E104B33E6D3388"
+			x: 4.5d
+			y: -3.5d
+			title: "Storage on the go"
 			rewards: [{
 				id: "57DD8F8CF6FAFAF1"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Craft your first backpack."
+			dependencies: ["6F2E92752228528C"]
 		}
 		{
-			title: "More storage on the go"
-			x: 4.5d
-			y: -2.5d
-			subtitle: "Same backpack, more storage."
-			dependencies: ["15E104B33E6D3388"]
-			id: "54DB5154498B9336"
 			tasks: [{
 				id: "0389793A9B8ED02D"
 				type: "item"
@@ -46,19 +41,19 @@
 					tag: { }
 				}
 			}]
+			id: "54DB5154498B9336"
+			x: 4.5d
+			y: -2.5d
+			title: "More storage on the go"
 			rewards: [{
 				id: "7936B91387F2CCB8"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Same backpack, more storage."
+			dependencies: ["15E104B33E6D3388"]
 		}
 		{
-			title: "Golden Backpack"
-			x: 4.5d
-			y: -1.5d
-			subtitle: "Bag of Holding? Almost."
-			dependencies: ["54DB5154498B9336"]
-			id: "1569F3E295EA86B5"
 			tasks: [{
 				id: "7698650D341A24A6"
 				type: "item"
@@ -68,18 +63,19 @@
 					tag: { }
 				}
 			}]
+			id: "1569F3E295EA86B5"
+			x: 4.5d
+			y: -1.5d
+			title: "Golden Backpack"
 			rewards: [{
 				id: "093438DB7724CE5A"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Bag of Holding? Almost."
+			dependencies: ["54DB5154498B9336"]
 		}
 		{
-			title: "All the storage you need!"
-			x: 4.5d
-			y: -0.5d
-			dependencies: ["1569F3E295EA86B5"]
-			id: "5DF23C8638C479E3"
 			tasks: [{
 				id: "11B5FCEFA2E08385"
 				type: "item"
@@ -89,19 +85,18 @@
 					tag: { }
 				}
 			}]
+			id: "5DF23C8638C479E3"
+			x: 4.5d
+			y: -0.5d
+			title: "All the storage you need!"
 			rewards: [{
 				id: "1A139DA541EE830D"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["1569F3E295EA86B5"]
 		}
 		{
-			title: "Bag of the withered"
-			x: 4.5d
-			y: 0.5d
-			subtitle: "Made from the depths of the nether!"
-			dependencies: ["5DF23C8638C479E3"]
-			id: "516BB48E835F9956"
 			tasks: [{
 				id: "27200ED2DA9EDDEE"
 				type: "item"
@@ -111,19 +106,19 @@
 					tag: { }
 				}
 			}]
+			id: "516BB48E835F9956"
+			x: 4.5d
+			y: 0.5d
+			title: "Bag of the withered"
 			rewards: [{
 				id: "3611255090A8177B"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Made from the depths of the nether!"
+			dependencies: ["5DF23C8638C479E3"]
 		}
 		{
-			title: "Ultimate Backpack!"
-			x: 4.5d
-			y: 1.5d
-			subtitle: "It dosent get any bigger than this."
-			dependencies: ["516BB48E835F9956"]
-			id: "7EAF41F12D2F3612"
 			tasks: [{
 				id: "1725505C8D72840E"
 				type: "item"
@@ -133,58 +128,64 @@
 					tag: { }
 				}
 			}]
+			id: "7EAF41F12D2F3612"
+			x: 4.5d
+			y: 1.5d
+			title: "Ultimate Backpack!"
 			rewards: [{
 				id: "060047D996FD4061"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "It dosent get any bigger than this."
+			dependencies: ["516BB48E835F9956"]
 		}
 		{
-			title: "Bigger Chests"
-			x: 5.5d
-			y: -3.5d
-			subtitle: "Can be placed both horizontally and vertically."
-			dependencies: ["6F2E92752228528C"]
-			id: "775BEA78AEB9EE77"
 			tasks: [{
 				id: "4E720A38A6D9CFE6"
 				type: "item"
 				item: "expandedstorage:iron_chest"
 			}]
+			id: "775BEA78AEB9EE77"
+			x: 5.5d
+			y: -3.5d
+			title: "Bigger Chests"
 			rewards: [{
 				id: "08455867B00D4D26"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Can be placed both horizontally and vertically."
+			dependencies: ["6F2E92752228528C"]
 		}
 		{
-			title: "Even bigger chests"
-			x: 5.5d
-			y: -2.5d
-			subtitle: "May the chests be shining."
-			dependencies: ["775BEA78AEB9EE77"]
-			id: "04E1293B787FF906"
 			tasks: [{
 				id: "3D1ED067C24B1134"
 				type: "item"
 				item: "expandedstorage:gold_chest"
 			}]
+			id: "04E1293B787FF906"
+			x: 5.5d
+			y: -2.5d
+			title: "Even bigger chests"
 			rewards: [{
 				id: "26ECA55A20005337"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "May the chests be shining."
+			dependencies: ["775BEA78AEB9EE77"]
 		}
 		{
-			x: 5.5d
-			y: -1.5d
-			dependencies: ["04E1293B787FF906"]
-			id: "7F69917A95491A52"
 			tasks: [{
 				id: "1ED0C18AAD522A97"
 				type: "item"
 				item: "expandedstorage:diamond_chest"
 			}]
+			dependencies: ["04E1293B787FF906"]
+			id: "7F69917A95491A52"
+			y: -1.5d
+			x: 5.5d
 			rewards: [{
 				id: "3D53EC7914EF5751"
 				type: "loot"
@@ -192,15 +193,15 @@
 			}]
 		}
 		{
-			x: 5.5d
-			y: -0.5d
-			dependencies: ["7F69917A95491A52"]
-			id: "723E09B161CC9E33"
 			tasks: [{
 				id: "6C3A22620D3799C5"
 				type: "item"
 				item: "expandedstorage:obsidian_chest"
 			}]
+			dependencies: ["7F69917A95491A52"]
+			id: "723E09B161CC9E33"
+			y: -0.5d
+			x: 5.5d
 			rewards: [{
 				id: "1501D60DB65390F8"
 				type: "loot"
@@ -208,15 +209,15 @@
 			}]
 		}
 		{
-			x: 5.5d
-			y: 0.5d
-			dependencies: ["723E09B161CC9E33"]
-			id: "072E1CD9A57ABD85"
 			tasks: [{
 				id: "29DEDBBF10195987"
 				type: "item"
 				item: "expandedstorage:netherite_chest"
 			}]
+			dependencies: ["723E09B161CC9E33"]
+			id: "072E1CD9A57ABD85"
+			y: 0.5d
+			x: 5.5d
 			rewards: [{
 				id: "72052FCFB50514BA"
 				type: "loot"
@@ -224,37 +225,37 @@
 			}]
 		}
 		{
-			x: 11.5d
-			y: -3.5d
-			subtitle: "Another storage drawer in disguise."
-			description: [
-				"Bronze barrels can used to store and move 32 stacks of one item."
-				""
-				"Amount of stacks allowed increase for each tier of barrel."
-			]
-			dependencies: ["523A049CF07AD75B"]
-			id: "701620712CC907D7"
 			tasks: [{
 				id: "00779B056A43DEEA"
 				type: "item"
 				item: "modern_industrialization:bronze_barrel"
 			}]
+			description: [
+				"Bronze barrels can used to store and move 32 stacks of one item."
+				""
+				"Amount of stacks allowed increase for each tier of barrel."
+			]
+			id: "701620712CC907D7"
+			x: 11.5d
+			y: -3.5d
 			rewards: [{
 				id: "7E841FEBD3FFD55E"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Another storage drawer in disguise."
+			dependencies: ["523A049CF07AD75B"]
 		}
 		{
-			x: 11.5d
-			y: -2.5d
-			dependencies: ["701620712CC907D7"]
-			id: "3E9D89B146C5CD1A"
 			tasks: [{
 				id: "31025F43DEF2146E"
 				type: "item"
 				item: "modern_industrialization:steel_barrel"
 			}]
+			dependencies: ["701620712CC907D7"]
+			id: "3E9D89B146C5CD1A"
+			y: -2.5d
+			x: 11.5d
 			rewards: [{
 				id: "032A78A85DC1C75C"
 				type: "loot"
@@ -262,15 +263,15 @@
 			}]
 		}
 		{
-			x: 11.5d
-			y: -1.5d
-			dependencies: ["3E9D89B146C5CD1A"]
-			id: "4D0BDC938DA76D16"
 			tasks: [{
 				id: "6A117D9E6E6C396A"
 				type: "item"
 				item: "modern_industrialization:aluminum_barrel"
 			}]
+			dependencies: ["3E9D89B146C5CD1A"]
+			id: "4D0BDC938DA76D16"
+			y: -1.5d
+			x: 11.5d
 			rewards: [{
 				id: "43FE11BD6BE7201F"
 				type: "loot"
@@ -278,15 +279,15 @@
 			}]
 		}
 		{
-			x: 11.5d
-			y: -0.5d
-			dependencies: ["4D0BDC938DA76D16"]
-			id: "11A648D56AFA31D1"
 			tasks: [{
 				id: "1D224B514E4D27BB"
 				type: "item"
 				item: "modern_industrialization:stainless_steel_barrel"
 			}]
+			dependencies: ["4D0BDC938DA76D16"]
+			id: "11A648D56AFA31D1"
+			y: -0.5d
+			x: 11.5d
 			rewards: [{
 				id: "046C52D067C51B60"
 				type: "loot"
@@ -294,15 +295,15 @@
 			}]
 		}
 		{
-			x: 11.5d
-			y: 0.5d
-			dependencies: ["11A648D56AFA31D1"]
-			id: "4D59362F0B630ACA"
 			tasks: [{
 				id: "477D2F4E7B22493B"
 				type: "item"
 				item: "modern_industrialization:titanium_barrel"
 			}]
+			dependencies: ["11A648D56AFA31D1"]
+			id: "4D59362F0B630ACA"
+			y: 0.5d
+			x: 11.5d
 			rewards: [{
 				id: "3B0FB3ABB1A43297"
 				type: "loot"
@@ -310,15 +311,15 @@
 			}]
 		}
 		{
-			x: 11.5d
-			y: 1.5d
-			dependencies: ["4D59362F0B630ACA"]
-			id: "21BD1BBF2F0833A9"
 			tasks: [{
 				id: "01BCEFA7EAD4F9DB"
 				type: "item"
 				item: "modern_industrialization:quantum_barrel"
 			}]
+			dependencies: ["4D59362F0B630ACA"]
+			id: "21BD1BBF2F0833A9"
+			y: 1.5d
+			x: 11.5d
 			rewards: [{
 				id: "32C13CE6DE692EEB"
 				type: "loot"
@@ -326,38 +327,38 @@
 			}]
 		}
 		{
-			x: 12.5d
-			y: -3.5d
-			subtitle: "Right-click with buckets or other tanks to transfer fluids."
+			tasks: [{
+				id: "0E647B945E58B453"
+				type: "item"
+				item: "modern_industrialization:bronze_tank"
+			}]
 			description: [
 				"Bronze Tanks can store up to 4 buckets each."
 				"You can use that to interact with machines and can also be placed in the world."
 				""
 				"TIP: Tanks are stackable if containing the same fluid."
 			]
-			dependencies: ["523A049CF07AD75B"]
 			id: "3C5A8EA9636BF12F"
-			tasks: [{
-				id: "0E647B945E58B453"
-				type: "item"
-				item: "modern_industrialization:bronze_tank"
-			}]
+			x: 12.5d
+			y: -3.5d
 			rewards: [{
 				id: "055CC327890FDAE1"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Right-click with buckets or other tanks to transfer fluids."
+			dependencies: ["523A049CF07AD75B"]
 		}
 		{
-			x: 12.5d
-			y: -2.5d
-			dependencies: ["3C5A8EA9636BF12F"]
-			id: "57370D36B9C896E2"
 			tasks: [{
 				id: "0AA5B170D809E302"
 				type: "item"
 				item: "modern_industrialization:steel_tank"
 			}]
+			dependencies: ["3C5A8EA9636BF12F"]
+			id: "57370D36B9C896E2"
+			y: -2.5d
+			x: 12.5d
 			rewards: [{
 				id: "07C3C1EFAD4AFC19"
 				type: "loot"
@@ -365,15 +366,15 @@
 			}]
 		}
 		{
-			x: 12.5d
-			y: -1.5d
-			dependencies: ["57370D36B9C896E2"]
-			id: "4DC3D05A8F8BBF75"
 			tasks: [{
 				id: "0D0319BE9A5E8567"
 				type: "item"
 				item: "modern_industrialization:aluminum_tank"
 			}]
+			dependencies: ["57370D36B9C896E2"]
+			id: "4DC3D05A8F8BBF75"
+			y: -1.5d
+			x: 12.5d
 			rewards: [{
 				id: "2E3857945F941551"
 				type: "loot"
@@ -381,15 +382,15 @@
 			}]
 		}
 		{
-			x: 12.5d
-			y: -0.5d
-			dependencies: ["4DC3D05A8F8BBF75"]
-			id: "7493E18AF65B41DE"
 			tasks: [{
 				id: "6436BE309468817B"
 				type: "item"
 				item: "modern_industrialization:stainless_steel_tank"
 			}]
+			dependencies: ["4DC3D05A8F8BBF75"]
+			id: "7493E18AF65B41DE"
+			y: -0.5d
+			x: 12.5d
 			rewards: [{
 				id: "1EB932E5F0E116B7"
 				type: "loot"
@@ -397,15 +398,15 @@
 			}]
 		}
 		{
-			x: 12.5d
-			y: 0.5d
-			dependencies: ["7493E18AF65B41DE"]
-			id: "73629FD7B57CD7AB"
 			tasks: [{
 				id: "535970933372DF89"
 				type: "item"
 				item: "modern_industrialization:titanium_tank"
 			}]
+			dependencies: ["7493E18AF65B41DE"]
+			id: "73629FD7B57CD7AB"
+			y: 0.5d
+			x: 12.5d
 			rewards: [{
 				id: "6AE90D4823037DB2"
 				type: "loot"
@@ -413,15 +414,15 @@
 			}]
 		}
 		{
-			x: 12.5d
-			y: 1.5d
-			dependencies: ["73629FD7B57CD7AB"]
-			id: "49DE26F91AA4CE1A"
 			tasks: [{
 				id: "0F1698CB2970E678"
 				type: "item"
 				item: "modern_industrialization:quantum_tank"
 			}]
+			dependencies: ["73629FD7B57CD7AB"]
+			id: "49DE26F91AA4CE1A"
+			y: 1.5d
+			x: 12.5d
 			rewards: [{
 				id: "11896AC8256BAEB5"
 				type: "loot"
@@ -429,86 +430,86 @@
 			}]
 		}
 		{
-			x: 9.0d
-			y: -3.5d
-			subtitle: "Right click with buckets or other tanks to transfer fluids."
-			dependencies: ["64082742D6539923"]
-			id: "691F1102DCB3851D"
 			tasks: [{
 				id: "2D8DB2A4B2A7CCBE"
 				type: "item"
 				item: "techreborn:basic_tank_unit"
 			}]
+			id: "691F1102DCB3851D"
+			x: 9.0d
+			y: -3.5d
 			rewards: [{
 				id: "4D664FB0AC8364E4"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Right click with buckets or other tanks to transfer fluids."
+			dependencies: ["64082742D6539923"]
 		}
 		{
-			title: "Crude Storage Unit"
-			x: 8.0d
-			y: -3.5d
-			subtitle: "Storage drawer in disguise."
-			dependencies: ["64082742D6539923"]
-			id: "16D84060C075DC03"
 			tasks: [{
 				id: "14EAC75C541EAC9F"
 				type: "item"
 				item: "techreborn:crude_storage_unit"
 			}]
+			id: "16D84060C075DC03"
+			x: 8.0d
+			y: -3.5d
+			title: "Crude Storage Unit"
 			rewards: [{
 				id: "24DD47F4717CE294"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Storage drawer in disguise."
+			dependencies: ["64082742D6539923"]
 		}
 		{
-			title: "Bigger Barrels"
-			x: 6.5d
-			y: -3.5d
-			subtitle: "Goes well as buffers in automation setups."
-			dependencies: ["6F2E92752228528C"]
-			id: "3341ED2C0B9631BE"
 			tasks: [{
 				id: "2B4C0EB03500550D"
 				type: "item"
 				item: "expandedstorage:iron_barrel"
 			}]
+			id: "3341ED2C0B9631BE"
+			x: 6.5d
+			y: -3.5d
+			title: "Bigger Barrels"
 			rewards: [{
 				id: "4618B62B0B015AD2"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Goes well as buffers in automation setups."
+			dependencies: ["6F2E92752228528C"]
 		}
 		{
-			title: "Even bigger barrels"
-			x: 6.5d
-			y: -2.5d
-			subtitle: "May the barrels be shining."
-			dependencies: ["3341ED2C0B9631BE"]
-			id: "213D8E0BB7F2E924"
 			tasks: [{
 				id: "68460F5575BF476F"
 				type: "item"
 				item: "expandedstorage:gold_barrel"
 			}]
+			id: "213D8E0BB7F2E924"
+			x: 6.5d
+			y: -2.5d
+			title: "Even bigger barrels"
 			rewards: [{
 				id: "200B0B6DA425345F"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "May the barrels be shining."
+			dependencies: ["3341ED2C0B9631BE"]
 		}
 		{
-			x: 6.5d
-			y: -1.5d
-			dependencies: ["213D8E0BB7F2E924"]
-			id: "0E970E8E69BA207A"
 			tasks: [{
 				id: "4740CF82772243A9"
 				type: "item"
 				item: "expandedstorage:diamond_barrel"
 			}]
+			dependencies: ["213D8E0BB7F2E924"]
+			id: "0E970E8E69BA207A"
+			y: -1.5d
+			x: 6.5d
 			rewards: [{
 				id: "7D2F0DDFB2DDA70A"
 				type: "loot"
@@ -516,15 +517,15 @@
 			}]
 		}
 		{
-			x: 6.5d
-			y: -0.5d
-			dependencies: ["0E970E8E69BA207A"]
-			id: "19D64FC4F94A9B6A"
 			tasks: [{
 				id: "02CBDF3A4275A06B"
 				type: "item"
 				item: "expandedstorage:obsidian_barrel"
 			}]
+			dependencies: ["0E970E8E69BA207A"]
+			id: "19D64FC4F94A9B6A"
+			y: -0.5d
+			x: 6.5d
 			rewards: [{
 				id: "3DBE9209B629B233"
 				type: "loot"
@@ -532,15 +533,15 @@
 			}]
 		}
 		{
-			x: 6.5d
-			y: 0.5d
-			dependencies: ["19D64FC4F94A9B6A"]
-			id: "3593C7DBFDF77FE9"
 			tasks: [{
 				id: "6CBB00C8CB2DE300"
 				type: "item"
 				item: "expandedstorage:netherite_barrel"
 			}]
+			dependencies: ["19D64FC4F94A9B6A"]
+			id: "3593C7DBFDF77FE9"
+			y: 0.5d
+			x: 6.5d
 			rewards: [{
 				id: "02A9714C694B6524"
 				type: "loot"
@@ -548,15 +549,15 @@
 			}]
 		}
 		{
-			x: 8.0d
-			y: -2.5d
-			dependencies: ["16D84060C075DC03"]
-			id: "3E37A08E65F102D8"
 			tasks: [{
 				id: "332A6C8DE153FB8A"
 				type: "item"
 				item: "techreborn:basic_storage_unit"
 			}]
+			dependencies: ["16D84060C075DC03"]
+			id: "3E37A08E65F102D8"
+			y: -2.5d
+			x: 8.0d
 			rewards: [{
 				id: "099D38D9F10DC19B"
 				type: "loot"
@@ -564,15 +565,15 @@
 			}]
 		}
 		{
-			x: 9.0d
-			y: -2.5d
-			dependencies: ["691F1102DCB3851D"]
-			id: "2AEBEE27B2451EEA"
 			tasks: [{
 				id: "34281E506046CD51"
 				type: "item"
 				item: "techreborn:advanced_tank_unit"
 			}]
+			dependencies: ["691F1102DCB3851D"]
+			id: "2AEBEE27B2451EEA"
+			y: -2.5d
+			x: 9.0d
 			rewards: [{
 				id: "5E9A29D6D7228FD8"
 				type: "loot"
@@ -580,15 +581,15 @@
 			}]
 		}
 		{
-			x: 8.0d
-			y: -1.5d
-			dependencies: ["3E37A08E65F102D8"]
-			id: "3BBD2850B68661AB"
 			tasks: [{
 				id: "22CE468B3AC15142"
 				type: "item"
 				item: "techreborn:advanced_storage_unit"
 			}]
+			dependencies: ["3E37A08E65F102D8"]
+			id: "3BBD2850B68661AB"
+			y: -1.5d
+			x: 8.0d
 			rewards: [{
 				id: "758FC50B506E696A"
 				type: "loot"
@@ -596,15 +597,15 @@
 			}]
 		}
 		{
-			x: 8.0d
-			y: -0.5d
-			dependencies: ["3BBD2850B68661AB"]
-			id: "6A0AF132BE5A8AAE"
 			tasks: [{
 				id: "012C6C1DF6C46F0F"
 				type: "item"
 				item: "techreborn:industrial_storage_unit"
 			}]
+			dependencies: ["3BBD2850B68661AB"]
+			id: "6A0AF132BE5A8AAE"
+			y: -0.5d
+			x: 8.0d
 			rewards: [{
 				id: "57719B1C0562B58F"
 				type: "loot"
@@ -612,15 +613,15 @@
 			}]
 		}
 		{
-			x: 8.0d
-			y: 0.5d
-			dependencies: ["6A0AF132BE5A8AAE"]
-			id: "3A44CCFDB872EA17"
 			tasks: [{
 				id: "272347DF31B60E19"
 				type: "item"
 				item: "techreborn:quantum_storage_unit"
 			}]
+			dependencies: ["6A0AF132BE5A8AAE"]
+			id: "3A44CCFDB872EA17"
+			y: 0.5d
+			x: 8.0d
 			rewards: [{
 				id: "6E639141403D1AE1"
 				type: "loot"
@@ -628,15 +629,15 @@
 			}]
 		}
 		{
-			x: 9.0d
-			y: -1.5d
-			dependencies: ["2AEBEE27B2451EEA"]
-			id: "1A19CF23FD98EC6B"
 			tasks: [{
 				id: "41F08E4226C2B034"
 				type: "item"
 				item: "techreborn:industrial_tank_unit"
 			}]
+			dependencies: ["2AEBEE27B2451EEA"]
+			id: "1A19CF23FD98EC6B"
+			y: -1.5d
+			x: 9.0d
 			rewards: [{
 				id: "172DADCD25EAF4F1"
 				type: "loot"
@@ -644,15 +645,15 @@
 			}]
 		}
 		{
-			x: 9.0d
-			y: -0.5d
-			dependencies: ["1A19CF23FD98EC6B"]
-			id: "7F5430EAC0D58A99"
 			tasks: [{
 				id: "1B1315F65EE4559C"
 				type: "item"
 				item: "techreborn:quantum_tank_unit"
 			}]
+			dependencies: ["1A19CF23FD98EC6B"]
+			id: "7F5430EAC0D58A99"
+			y: -0.5d
+			x: 9.0d
 			rewards: [{
 				id: "33FB6AFE217087BA"
 				type: "loot"
@@ -660,9 +661,11 @@
 			}]
 		}
 		{
-			x: 12.0d
-			y: -5.0d
-			subtitle: "Barrels and tanks of different sizes. You know what they are.. They have no disguises."
+			tasks: [{
+				id: "7279364B4E1843D4"
+				type: "checkmark"
+				title: "Modern Industrialization"
+			}]
 			description: [
 				"Barrels are used for mass storage of the same item. Shows count and item on front. "
 				""
@@ -670,16 +673,17 @@
 				"Can be used as a buffer and is movable with contents intact on break."
 				"Tanks are stackable if containing the same fluid."
 			]
+			subtitle: "Barrels and tanks of different sizes. You know what they are.. They have no disguises."
 			id: "523A049CF07AD75B"
-			tasks: [{
-				id: "7279364B4E1843D4"
-				type: "checkmark"
-				title: "Modern Industrialization"
-			}]
+			y: -5.0d
+			x: 12.0d
 		}
 		{
-			x: 9.0d
-			y: -5.0d
+			tasks: [{
+				id: "77F4F6BBF4F8AF10"
+				type: "checkmark"
+				title: "Tech Reborn"
+			}]
 			description: [
 				"Storage units are single item, mass storage devices with an inventory count on the face."
 				""
@@ -689,16 +693,15 @@
 				"You can view their inventory and use the slot they have to charge devices."
 			]
 			id: "64082742D6539923"
-			tasks: [{
-				id: "77F4F6BBF4F8AF10"
-				type: "checkmark"
-				title: "Tech Reborn"
-			}]
+			y: -5.0d
+			x: 9.0d
 		}
 		{
-			x: 5.5d
-			y: -5.0d
-			subtitle: "Learn about the basics of storage."
+			tasks: [{
+				id: "4A26CDEE07DCD4B8"
+				type: "checkmark"
+				title: "Basic Storage"
+			}]
 			description: [
 				"Backpacks for increased inventory"
 				""
@@ -708,40 +711,38 @@
 				""
 				"Danks for automatic portable storage and dynamic inventory block placement."
 			]
+			subtitle: "Learn about the basics of storage."
 			id: "6F2E92752228528C"
-			tasks: [{
-				id: "4A26CDEE07DCD4B8"
-				type: "checkmark"
-				title: "Basic Storage"
-			}]
+			y: -5.0d
+			x: 5.5d
 		}
 		{
-			x: 10.0d
-			y: -3.5d
-			subtitle: "Stores energy and charges items. "
-			dependencies: ["64082742D6539923"]
-			id: "02C255C9CAC286C8"
 			tasks: [{
 				id: "2901054D6A1E5169"
 				type: "item"
 				item: "techreborn:low_voltage_su"
 			}]
+			id: "02C255C9CAC286C8"
+			x: 10.0d
+			y: -3.5d
 			rewards: [{
 				id: "6BCFFC63E293FF33"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Stores energy and charges items. "
+			dependencies: ["64082742D6539923"]
 		}
 		{
-			x: 10.0d
-			y: -2.5d
-			dependencies: ["02C255C9CAC286C8"]
-			id: "363CEF71CB948F73"
 			tasks: [{
 				id: "3E91DD78CB3B5A29"
 				type: "item"
 				item: "techreborn:medium_voltage_su"
 			}]
+			dependencies: ["02C255C9CAC286C8"]
+			id: "363CEF71CB948F73"
+			y: -2.5d
+			x: 10.0d
 			rewards: [{
 				id: "60800D3A82F21651"
 				type: "loot"
@@ -749,15 +750,15 @@
 			}]
 		}
 		{
-			x: 10.0d
-			y: -1.5d
-			dependencies: ["363CEF71CB948F73"]
-			id: "1DA0468352954BA9"
 			tasks: [{
 				id: "729C6F46550B4901"
 				type: "item"
 				item: "techreborn:high_voltage_su"
 			}]
+			dependencies: ["363CEF71CB948F73"]
+			id: "1DA0468352954BA9"
+			y: -1.5d
+			x: 10.0d
 			rewards: [{
 				id: "4D088EC493C6DA6F"
 				type: "loot"
@@ -765,15 +766,15 @@
 			}]
 		}
 		{
-			x: 10.0d
-			y: -0.5d
-			dependencies: ["1DA0468352954BA9"]
-			id: "247204A995A00576"
 			tasks: [{
 				id: "619C6FB574819C0A"
 				type: "item"
 				item: "techreborn:interdimensional_su"
 			}]
+			dependencies: ["1DA0468352954BA9"]
+			id: "247204A995A00576"
+			y: -0.5d
+			x: 10.0d
 			rewards: [{
 				id: "49D278C607B09127"
 				type: "loot"
@@ -781,44 +782,44 @@
 			}]
 		}
 		{
-			x: 14.0d
-			y: -5.0d
-			subtitle: "Let the energy revolutionize!"
-			description: ["An Indrevian version of an energy storage device."]
-			id: "679464B1F04B106E"
 			tasks: [{
 				id: "0FB2E00F0013C475"
 				type: "checkmark"
 				title: "Industrial Revolution"
 			}]
+			description: ["An Indrevian version of an energy storage device."]
+			subtitle: "Let the energy revolutionize!"
+			id: "679464B1F04B106E"
+			y: -5.0d
+			x: 14.0d
 		}
 		{
-			x: 14.0d
-			y: -3.5d
-			subtitle: "Stores energy and charges items. "
-			dependencies: ["679464B1F04B106E"]
-			id: "17F540DAE69F9836"
 			tasks: [{
 				id: "7659005A22D97F38"
 				type: "item"
 				item: "indrev:lazuli_flux_container_mk1"
 			}]
+			id: "17F540DAE69F9836"
+			x: 14.0d
+			y: -3.5d
 			rewards: [{
 				id: "4CCDE717AD8C1D5D"
 				type: "loot"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Stores energy and charges items. "
+			dependencies: ["679464B1F04B106E"]
 		}
 		{
-			x: 14.0d
-			y: -2.5d
-			dependencies: ["17F540DAE69F9836"]
-			id: "4D4D4AB0102E6B6E"
 			tasks: [{
 				id: "6C0809992B96502B"
 				type: "item"
 				item: "indrev:lazuli_flux_container_mk2"
 			}]
+			dependencies: ["17F540DAE69F9836"]
+			id: "4D4D4AB0102E6B6E"
+			y: -2.5d
+			x: 14.0d
 			rewards: [{
 				id: "00457C7CE2CE5D1C"
 				type: "loot"
@@ -826,15 +827,15 @@
 			}]
 		}
 		{
-			x: 14.0d
-			y: -1.5d
-			dependencies: ["4D4D4AB0102E6B6E"]
-			id: "02B1E8CECB57D77C"
 			tasks: [{
 				id: "20203EEE0087B7A5"
 				type: "item"
 				item: "indrev:lazuli_flux_container_mk3"
 			}]
+			dependencies: ["4D4D4AB0102E6B6E"]
+			id: "02B1E8CECB57D77C"
+			y: -1.5d
+			x: 14.0d
 			rewards: [{
 				id: "1B8728447568CD51"
 				type: "loot"
@@ -842,15 +843,15 @@
 			}]
 		}
 		{
-			x: 14.0d
-			y: -0.5d
-			dependencies: ["02B1E8CECB57D77C"]
-			id: "4A9EAB93BC030448"
 			tasks: [{
 				id: "46EBA4968DDC5066"
 				type: "item"
 				item: "indrev:lazuli_flux_container_mk4"
 			}]
+			dependencies: ["02B1E8CECB57D77C"]
+			id: "4A9EAB93BC030448"
+			y: -0.5d
+			x: 14.0d
 			rewards: [{
 				id: "51DF4433C363C8A8"
 				type: "loot"
@@ -858,27 +859,17 @@
 			}]
 		}
 		{
-			x: 0.5d
-			y: -5.0d
-			subtitle: "Single item, mass storage devices with an inventory count on the face."
-			id: "54065F780CDDB84C"
 			tasks: [{
 				id: "5F2AC7BB6BFEE2F2"
 				type: "checkmark"
 				title: "Storage Drawers"
 			}]
+			subtitle: "Single item, mass storage devices with an inventory count on the face."
+			id: "54065F780CDDB84C"
+			y: -5.0d
+			x: 0.5d
 		}
 		{
-			x: 0.5d
-			y: -3.0d
-			subtitle: "Comes in three flavors: Single, Double and Quad."
-			description: [
-				"(Single) Drawer holds 1024 Items."
-				"Double Drawer holds 512 Items per slot."
-				"Quad Drawer holds 256 Items per slot."
-			]
-			dependencies: ["54065F780CDDB84C"]
-			id: "0A7BD337DC8ADBCB"
 			tasks: [{
 				id: "0170F73CC524BC6A"
 				type: "item"
@@ -906,131 +897,141 @@
 					}
 				}
 			}]
+			description: [
+				"(Single) Drawer holds 1024 Items."
+				"Double Drawer holds 512 Items per slot."
+				"Quad Drawer holds 256 Items per slot."
+			]
+			id: "0A7BD337DC8ADBCB"
+			x: 0.5d
+			y: -3.0d
+			subtitle: "Comes in three flavors: Single, Double and Quad."
+			dependencies: ["54065F780CDDB84C"]
 		}
 		{
-			x: 0.5d
-			y: -2.0d
-			subtitle: "Doubles maximum storage capacity."
-			description: ["Note, that upgrades are installed *per slot*, not per drawer!"]
-			dependencies: ["0A7BD337DC8ADBCB"]
-			id: "27BA62770DC82F9B"
 			tasks: [{
 				id: "212356C714693E23"
 				type: "item"
 				item: "extended_drawers:t1_upgrade"
 			}]
+			description: ["Note, that upgrades are installed *per slot*, not per drawer!"]
+			id: "27BA62770DC82F9B"
+			x: 0.5d
+			y: -2.0d
+			subtitle: "Doubles maximum storage capacity."
+			dependencies: ["0A7BD337DC8ADBCB"]
 		}
 		{
-			x: -0.5d
-			y: -1.5d
-			subtitle: "Quadruples maximum storage capacity. (4x)"
-			dependencies: ["27BA62770DC82F9B"]
-			id: "0E31BC8C0E47FF79"
 			tasks: [{
 				id: "775C7D205FDCF869"
 				type: "item"
 				item: "extended_drawers:t2_upgrade"
 			}]
+			dependencies: ["27BA62770DC82F9B"]
+			subtitle: "Quadruples maximum storage capacity. (4x)"
+			id: "0E31BC8C0E47FF79"
+			y: -1.5d
+			x: -0.5d
 		}
 		{
-			x: -1.0d
-			y: -0.5d
-			subtitle: "Octuples maximum storage capacity. (8x)"
-			dependencies: ["0E31BC8C0E47FF79"]
-			id: "4950B4335A61C04E"
 			tasks: [{
 				id: "0F127ED9F8CA30A4"
 				type: "item"
 				item: "extended_drawers:t3_upgrade"
 			}]
+			dependencies: ["0E31BC8C0E47FF79"]
+			subtitle: "Octuples maximum storage capacity. (8x)"
+			id: "4950B4335A61C04E"
+			y: -0.5d
+			x: -1.0d
 		}
 		{
-			x: -0.5d
-			y: 0.5d
-			subtitle: "Sexdecuples maximum storage capacity. (16x)"
-			dependencies: ["4950B4335A61C04E"]
-			id: "6414628E793DC1B2"
 			tasks: [{
 				id: "52C604ECECB1631D"
 				type: "item"
 				item: "extended_drawers:t4_upgrade"
 			}]
+			dependencies: ["4950B4335A61C04E"]
+			subtitle: "Sexdecuples maximum storage capacity. (16x)"
+			id: "6414628E793DC1B2"
+			y: 0.5d
+			x: -0.5d
 		}
 		{
-			x: -1.0d
-			y: -2.5d
-			subtitle: "Reduces maximum storage to a single stack. Useful for small, lockable buffers!"
-			dependencies: ["0A7BD337DC8ADBCB"]
-			id: "0F5BE8087A25E091"
 			tasks: [{
 				id: "62FC56011CAA7DE1"
 				type: "item"
 				item: "extended_drawers:downgrade"
 			}]
+			dependencies: ["0A7BD337DC8ADBCB"]
+			subtitle: "Reduces maximum storage to a single stack. Useful for small, lockable buffers!"
+			id: "0F5BE8087A25E091"
+			y: -2.5d
+			x: -1.0d
 		}
 		{
-			x: 2.0d
-			y: -2.5d
-			subtitle: "Connects Drawers together."
-			dependencies: ["0A7BD337DC8ADBCB"]
-			id: "65995D6871EBAAB7"
 			tasks: [{
 				id: "4A3F35AEC4C33EA7"
 				type: "item"
 				item: "extended_drawers:controller"
 			}]
+			dependencies: ["0A7BD337DC8ADBCB"]
+			subtitle: "Connects Drawers together."
+			id: "65995D6871EBAAB7"
+			y: -2.5d
+			x: 2.0d
 		}
 		{
-			x: 0.5d
-			y: 1.0d
-			dependencies: ["6414628E793DC1B2"]
-			id: "6C93BF9FB6925110"
 			tasks: [{
 				id: "34B4CB7EE9AF4A71"
 				type: "item"
 				item: "kubejs:s1_upgrade"
 			}]
+			dependencies: ["6414628E793DC1B2"]
+			id: "6C93BF9FB6925110"
+			y: 1.0d
+			x: 0.5d
 		}
 		{
-			x: 1.5d
-			y: 0.5d
-			dependencies: ["6C93BF9FB6925110"]
-			id: "4E3C22290C818BE6"
 			tasks: [{
 				id: "1A59808BA7F955B4"
 				type: "item"
 				item: "kubejs:s2_upgrade"
 			}]
+			dependencies: ["6C93BF9FB6925110"]
+			id: "4E3C22290C818BE6"
+			y: 0.5d
+			x: 1.5d
 		}
 		{
-			x: 2.0d
-			y: -0.5d
-			dependencies: ["4E3C22290C818BE6"]
-			id: "0D264AE4AFEA97CE"
 			tasks: [{
 				id: "5D5C764B08DB8489"
 				type: "item"
 				item: "kubejs:s3_upgrade"
 			}]
+			dependencies: ["4E3C22290C818BE6"]
+			id: "0D264AE4AFEA97CE"
+			y: -0.5d
+			x: 2.0d
 		}
 		{
-			x: 1.5d
-			y: -1.5d
-			dependencies: ["0D264AE4AFEA97CE"]
-			id: "6D8576C4FB205222"
 			tasks: [{
 				id: "4E61F6C5F0B89900"
 				type: "item"
 				item: "kubejs:s4_upgrade"
 			}]
+			dependencies: ["0D264AE4AFEA97CE"]
+			id: "6D8576C4FB205222"
+			y: -1.5d
+			x: 1.5d
 		}
 		{
+			size: 1.5d
 			x: 0.5d
+			id: "1808B3BBC5EDD537"
 			y: -0.5d
 			shape: "circle"
 			dependencies: ["6D8576C4FB205222"]
-			size: 1.5d
-			id: "1808B3BBC5EDD537"
 			tasks: [{
 				id: "74D9D8F035A01D3D"
 				type: "item"
@@ -1038,22 +1039,24 @@
 			}]
 		}
 		{
-			x: -1.0d
-			y: -3.5d
-			subtitle: "Acts as a dummy drawer for linking Drawers with the Drawer Access point."
-			description: ["Useful as a lag-less solution for extending the Access Point's range!"]
-			dependencies: ["0A7BD337DC8ADBCB"]
-			id: "0D7391372DD8F434"
 			tasks: [{
 				id: "650A9DCB215FDB6F"
 				type: "item"
 				item: "extended_drawers:connector"
 			}]
+			description: ["Useful as a lag-less solution for extending the Access Point's range!"]
+			id: "0D7391372DD8F434"
+			x: -1.0d
+			y: -3.5d
+			subtitle: "Acts as a dummy drawer for linking Drawers with the Drawer Access point."
+			dependencies: ["0A7BD337DC8ADBCB"]
 		}
 		{
-			x: 2.0d
-			y: -3.5d
-			subtitle: "Acts like a \"proxy\" for your drawers!"
+			tasks: [{
+				id: "51521BD4F865307D"
+				type: "item"
+				item: "extended_drawers:shadow_drawer"
+			}]
 			description: [
 				"Let's suppose you have 3 drawers with 64 Stone each."
 				""
@@ -1063,14 +1066,11 @@
 				""
 				"You can insert and extract items like you would do on a normal drawer, but the items will be extracted from/inserted to normal drawers."
 			]
-			dependencies: ["0A7BD337DC8ADBCB"]
 			id: "4198BC6C45F3B486"
-			tasks: [{
-				id: "51521BD4F865307D"
-				type: "item"
-				item: "extended_drawers:shadow_drawer"
-			}]
+			x: 2.0d
+			y: -3.5d
+			subtitle: "Acts like a \"proxy\" for your drawers!"
+			dependencies: ["0A7BD337DC8ADBCB"]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/tech_reborn.snbt
+++ b/config/ftbquests/quests/chapters/tech_reborn.snbt
@@ -1,18 +1,15 @@
 {
-	id: "72B7D7CF2F338EAC"
-	group: "0815C5D80307ECDF"
-	order_index: 1
-	filename: "tech_reborn"
-	title: "Tech Reborn"
-	icon: "techreborn:matter_fabricator"
-	default_quest_shape: ""
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "0815C5D80307ECDF"
+	id: "72B7D7CF2F338EAC"
+	filename: "tech_reborn"
+	default_quest_shape: ""
+	icon: "techreborn:matter_fabricator"
+	title: "Tech Reborn"
+	order_index: 1
 	quests: [
 		{
-			x: -1.0d
-			y: -3.5d
-			hide: true
-			id: "088A517FCA17971C"
 			tasks: [{
 				id: "5C84159CEE6CC90D"
 				type: "item"
@@ -29,183 +26,183 @@
 				type: "item"
 				item: "techreborn:manual"
 			}]
+			id: "088A517FCA17971C"
+			y: -3.5d
+			x: -1.0d
+			hide: true
 		}
 		{
-			x: 0.0d
-			y: -3.5d
-			dependencies: ["088A517FCA17971C"]
-			id: "05C2515BE5FBC38D"
 			tasks: [{
 				id: "4EA81CBAE4EDA319"
 				type: "item"
 				item: "techreborn:sap"
 			}]
+			dependencies: ["088A517FCA17971C"]
+			id: "05C2515BE5FBC38D"
+			y: -3.5d
+			x: 0.0d
 		}
 		{
-			x: 2.0d
-			y: -2.5d
-			dependencies: ["05C2515BE5FBC38D"]
-			id: "5F5158F365EDF4F8"
 			tasks: [{
 				id: "26C18B56C2786B97"
 				type: "item"
 				item: "techreborn:rubber"
 			}]
+			dependencies: ["05C2515BE5FBC38D"]
+			id: "5F5158F365EDF4F8"
+			y: -2.5d
+			x: 2.0d
 		}
 		{
-			x: 2.0d
-			y: -1.5d
-			dependencies: ["5F5158F365EDF4F8"]
-			id: "070906D7884D6CB8"
 			tasks: [{
 				id: "03C2D4953504058A"
 				type: "item"
 				item: "techreborn:red_cell_battery"
 			}]
+			dependencies: ["5F5158F365EDF4F8"]
+			id: "070906D7884D6CB8"
+			y: -1.5d
+			x: 2.0d
 		}
 		{
-			x: 3.0d
-			y: -2.0d
-			dependencies: ["070906D7884D6CB8"]
-			id: "75A0FED0A0C875B2"
 			tasks: [{
 				id: "31C9D75F9C8BC5E1"
 				type: "item"
 				item: "techreborn:basic_drill"
 			}]
+			dependencies: ["070906D7884D6CB8"]
+			id: "75A0FED0A0C875B2"
+			y: -2.0d
+			x: 3.0d
 		}
 		{
-			x: 4.0d
-			y: -2.0000000000000004d
-			dependencies: ["75A0FED0A0C875B2"]
-			id: "1DB86ECA16717102"
 			tasks: [{
 				id: "2C2D1AAF10FB95E9"
 				type: "item"
 				item: "techreborn:advanced_drill"
 			}]
+			dependencies: ["75A0FED0A0C875B2"]
+			id: "1DB86ECA16717102"
+			y: -2.0000000000000004d
+			x: 4.0d
 		}
 		{
-			x: 5.0d
-			y: -2.000000000000001d
-			dependencies: ["1DB86ECA16717102"]
-			id: "4BEDBDF578AEA4E2"
 			tasks: [{
 				id: "56E8D43C3CBBB7B1"
 				type: "item"
 				item: "techreborn:industrial_drill"
 			}]
+			dependencies: ["1DB86ECA16717102"]
+			id: "4BEDBDF578AEA4E2"
+			y: -2.000000000000001d
+			x: 5.0d
 		}
 		{
-			x: 4.0d
-			y: -0.9999999999999999d
-			dependencies: ["6F5A3FD2AD2C82F9"]
-			id: "660AA4804E337D4C"
 			tasks: [{
 				id: "20D32DBEA3A7EACC"
 				type: "item"
 				item: "techreborn:advanced_chainsaw"
 			}]
+			dependencies: ["6F5A3FD2AD2C82F9"]
+			id: "660AA4804E337D4C"
+			y: -0.9999999999999999d
+			x: 4.0d
 		}
 		{
-			x: 5.0d
-			y: -0.9999999999999999d
-			dependencies: ["660AA4804E337D4C"]
-			id: "7B03A60FE4A1B23E"
 			tasks: [{
 				id: "0A19C3ED6E80B1F5"
 				type: "item"
 				item: "techreborn:industrial_chainsaw"
 			}]
+			dependencies: ["660AA4804E337D4C"]
+			id: "7B03A60FE4A1B23E"
+			y: -0.9999999999999999d
+			x: 5.0d
 		}
 		{
-			x: 3.0d
-			y: -1.0d
-			dependencies: ["070906D7884D6CB8"]
-			id: "6F5A3FD2AD2C82F9"
 			tasks: [{
 				id: "4EE5986E2FD04398"
 				type: "item"
 				item: "techreborn:basic_chainsaw"
 			}]
+			dependencies: ["070906D7884D6CB8"]
+			id: "6F5A3FD2AD2C82F9"
+			y: -1.0d
+			x: 3.0d
 		}
 		{
-			x: 0.0d
-			y: -0.5d
-			dependencies: [
-				"070906D7884D6CB8"
-				"6F9F95E6D044341F"
-			]
-			id: "106BE5A97833D6DA"
 			tasks: [{
 				id: "3832E9513617E8FE"
 				type: "item"
 				item: "techreborn:solid_fuel_generator"
 			}]
+			dependencies: [
+				"070906D7884D6CB8"
+				"6F9F95E6D044341F"
+			]
+			id: "106BE5A97833D6DA"
+			y: -0.5d
+			x: 0.0d
 		}
 		{
-			x: 2.0d
-			y: 0.5d
-			dependencies: ["106BE5A97833D6DA"]
-			id: "305115BA557F938E"
 			tasks: [{
 				id: "799BE728AB678880"
 				type: "item"
 				item: "techreborn:basic_solar_panel"
 			}]
+			dependencies: ["106BE5A97833D6DA"]
+			id: "305115BA557F938E"
+			y: 0.5d
+			x: 2.0d
 		}
 		{
-			x: 3.0d
-			y: 1.0d
-			dependencies: ["305115BA557F938E"]
-			id: "40AE79F697FC3E78"
 			tasks: [{
 				id: "032BC7DC3E242236"
 				type: "item"
 				item: "techreborn:advanced_solar_panel"
 			}]
+			dependencies: ["305115BA557F938E"]
+			id: "40AE79F697FC3E78"
+			y: 1.0d
+			x: 3.0d
 		}
 		{
-			x: 2.0d
-			y: 1.5d
-			dependencies: ["40AE79F697FC3E78"]
-			id: "0D26A00CBE8A4A39"
 			tasks: [{
 				id: "18B785BCEFD56CB7"
 				type: "item"
 				item: "techreborn:industrial_solar_panel"
 			}]
+			dependencies: ["40AE79F697FC3E78"]
+			id: "0D26A00CBE8A4A39"
+			y: 1.5d
+			x: 2.0d
 		}
 		{
-			x: 3.0d
-			y: 2.0d
-			dependencies: ["0D26A00CBE8A4A39"]
-			id: "44D31F46EAF59CCF"
 			tasks: [{
 				id: "3DAE13298EEB8C36"
 				type: "item"
 				item: "techreborn:ultimate_solar_panel"
 			}]
+			dependencies: ["0D26A00CBE8A4A39"]
+			id: "44D31F46EAF59CCF"
+			y: 2.0d
+			x: 3.0d
 		}
 		{
-			x: 2.0d
-			y: 2.5d
-			dependencies: [
-				"44D31F46EAF59CCF"
-				"00435BCDAA795687"
-			]
-			id: "12B4B33547112806"
 			tasks: [{
 				id: "11DE0F8B63150D8F"
 				type: "item"
 				item: "techreborn:quantum_solar_panel"
 			}]
+			dependencies: [
+				"44D31F46EAF59CCF"
+				"00435BCDAA795687"
+			]
+			id: "12B4B33547112806"
+			y: 2.5d
+			x: 2.0d
 		}
 		{
-			x: -1.0d
-			y: -1.0d
-			hide: true
-			id: "6F9F95E6D044341F"
 			tasks: [{
 				id: "61D70D5392BFFADA"
 				type: "item"
@@ -216,68 +213,67 @@
 				type: "item"
 				item: "techreborn:manual"
 			}]
+			id: "6F9F95E6D044341F"
+			y: -1.0d
+			x: -1.0d
+			hide: true
 		}
 		{
-			x: -2.0d
-			y: -1.5d
-			dependencies: ["6F9F95E6D044341F"]
-			id: "674A84991BA4A79D"
 			tasks: [{
 				id: "50541C97AD09A299"
 				type: "item"
 				item: "techreborn:advanced_machine_frame"
 			}]
+			dependencies: ["6F9F95E6D044341F"]
+			id: "674A84991BA4A79D"
+			y: -1.5d
+			x: -2.0d
 		}
 		{
-			x: -3.0d
-			y: -1.0d
-			dependencies: ["674A84991BA4A79D"]
-			id: "14F107BB285AF6C5"
 			tasks: [{
 				id: "40D9433D8444568B"
 				type: "item"
 				item: "techreborn:industrial_machine_frame"
 			}]
+			dependencies: ["674A84991BA4A79D"]
+			id: "14F107BB285AF6C5"
+			y: -1.0d
+			x: -3.0d
 		}
 		{
-			x: -1.0d
-			y: -2.0d
-			dependencies: ["6F9F95E6D044341F"]
-			id: "244120BFE2DF2741"
 			tasks: [{
 				id: "110AF0945E003457"
 				type: "item"
 				item: "techreborn:basic_machine_casing"
 			}]
+			dependencies: ["6F9F95E6D044341F"]
+			id: "244120BFE2DF2741"
+			y: -2.0d
+			x: -1.0d
 		}
 		{
-			x: -2.0d
-			y: -2.5d
-			dependencies: ["244120BFE2DF2741"]
-			id: "29A782E605168AB0"
 			tasks: [{
 				id: "527E9B4F457A0225"
 				type: "item"
 				item: "techreborn:advanced_machine_casing"
 			}]
+			dependencies: ["244120BFE2DF2741"]
+			id: "29A782E605168AB0"
+			y: -2.5d
+			x: -2.0d
 		}
 		{
-			x: -3.0d
-			y: -2.0d
-			dependencies: ["29A782E605168AB0"]
-			id: "71E1B650B49B2274"
 			tasks: [{
 				id: "5DA46FF438F9137E"
 				type: "item"
 				item: "techreborn:industrial_machine_casing"
 			}]
+			dependencies: ["29A782E605168AB0"]
+			id: "71E1B650B49B2274"
+			y: -2.0d
+			x: -3.0d
 		}
 		{
-			title: "Better Generators"
-			x: 0.0d
-			y: 0.5d
-			dependencies: ["106BE5A97833D6DA"]
-			id: "7FCBBDAE63379B61"
 			tasks: [
 				{
 					id: "379B6291A84D7B78"
@@ -305,13 +301,13 @@
 					item: "techreborn:thermal_generator"
 				}
 			]
+			dependencies: ["106BE5A97833D6DA"]
+			id: "7FCBBDAE63379B61"
+			y: 0.5d
+			x: 0.0d
+			title: "Better Generators"
 		}
 		{
-			title: "First Machines"
-			x: -1.0d
-			y: 1.0d
-			dependencies: ["6F9F95E6D044341F"]
-			id: "263A25C0B02975DF"
 			tasks: [
 				{
 					id: "7D4718FE79A8B4EB"
@@ -334,13 +330,13 @@
 					item: "techreborn:alloy_smelter"
 				}
 			]
+			dependencies: ["6F9F95E6D044341F"]
+			id: "263A25C0B02975DF"
+			y: 1.0d
+			x: -1.0d
+			title: "First Machines"
 		}
 		{
-			title: "Let's get industrial !"
-			x: -2.0d
-			y: 0.5d
-			dependencies: ["263A25C0B02975DF"]
-			id: "6D6B734C366D29AF"
 			tasks: [
 				{
 					id: "00785CCF2A81224F"
@@ -363,174 +359,179 @@
 					item: "techreborn:industrial_electrolyzer"
 				}
 			]
+			dependencies: ["263A25C0B02975DF"]
+			id: "6D6B734C366D29AF"
+			y: 0.5d
+			x: -2.0d
+			title: "Let's get industrial !"
 		}
 		{
-			x: -1.0d
-			y: 2.0d
-			dependencies: ["263A25C0B02975DF"]
-			id: "5DA130F56F0A7FC7"
 			tasks: [{
 				id: "7B6D6E11A42B131E"
 				type: "item"
 				item: "techreborn:recycler"
 			}]
+			dependencies: ["263A25C0B02975DF"]
+			id: "5DA130F56F0A7FC7"
+			y: 2.0d
+			x: -1.0d
 		}
 		{
-			x: -1.0d
-			y: 3.0d
-			dependencies: ["5DA130F56F0A7FC7"]
-			id: "041CE982C0CB4071"
 			tasks: [{
 				id: "482B89A73FAA6E67"
 				type: "item"
 				item: "techreborn:scrap"
 			}]
+			dependencies: ["5DA130F56F0A7FC7"]
+			id: "041CE982C0CB4071"
+			y: 3.0d
+			x: -1.0d
 		}
 		{
-			x: 0.0d
-			y: 2.5d
-			dependencies: ["041CE982C0CB4071"]
-			id: "06FF7A8F4CDC5F6A"
 			tasks: [{
 				id: "663269FB8C1B72AB"
 				type: "item"
 				item: "techreborn:scrap_box"
 			}]
+			dependencies: ["041CE982C0CB4071"]
+			id: "06FF7A8F4CDC5F6A"
+			y: 2.5d
+			x: 0.0d
 		}
 		{
-			x: 1.0d
-			y: 2.0d
-			dependencies: ["06FF7A8F4CDC5F6A"]
-			id: "73E33BA052F68C06"
 			tasks: [{
 				id: "025DB6D335F3ABCF"
 				type: "item"
 				item: "techreborn:scrapboxinator"
 			}]
+			dependencies: ["06FF7A8F4CDC5F6A"]
+			id: "73E33BA052F68C06"
+			y: 2.0d
+			x: 1.0d
 		}
 		{
-			x: 0.0d
-			y: 3.5d
-			dependencies: [
-				"44993D26C0343D18"
-				"041CE982C0CB4071"
-			]
-			id: "00435BCDAA795687"
 			tasks: [{
 				id: "3D4F8801B688AD61"
 				type: "item"
 				item: "techreborn:uu_matter"
 			}]
+			dependencies: [
+				"44993D26C0343D18"
+				"041CE982C0CB4071"
+			]
+			id: "00435BCDAA795687"
+			y: 3.5d
+			x: 0.0d
 		}
 		{
-			x: -2.0d
-			y: 1.5d
-			dependencies: ["263A25C0B02975DF"]
-			id: "200321AF98DCC1C9"
 			tasks: [{
 				id: "2065C4AC24E7BEF5"
 				type: "item"
 				item: "techreborn:chemical_reactor"
 			}]
+			dependencies: ["263A25C0B02975DF"]
+			id: "200321AF98DCC1C9"
+			y: 1.5d
+			x: -2.0d
 		}
 		{
-			x: -3.0d
-			y: 2.0d
-			hide_dependency_lines: true
-			dependencies: ["674A84991BA4A79D"]
-			id: "373BFD6DFA44BBD3"
 			tasks: [{
 				id: "144512213D0EA25B"
 				type: "item"
 				item: "techreborn:assembly_machine"
 			}]
+			dependencies: ["674A84991BA4A79D"]
+			id: "373BFD6DFA44BBD3"
+			hide_dependency_lines: true
+			y: 2.0d
+			x: -3.0d
 		}
 		{
-			x: -2.0d
-			y: 2.5d
-			dependencies: [
-				"200321AF98DCC1C9"
-				"373BFD6DFA44BBD3"
-			]
-			id: "2E452CD2DA080B53"
 			tasks: [{
 				id: "046039A9256FC8F4"
 				type: "item"
 				item: "techreborn:energy_crystal"
 			}]
+			dependencies: [
+				"200321AF98DCC1C9"
+				"373BFD6DFA44BBD3"
+			]
+			id: "2E452CD2DA080B53"
+			y: 2.5d
+			x: -2.0d
 		}
 		{
-			x: -2.0d
-			y: 4.5d
-			dependencies: ["6320017C1BCAFDD4"]
-			id: "44993D26C0343D18"
 			tasks: [{
 				id: "7C2896374AA47B65"
 				type: "item"
 				item: "techreborn:matter_fabricator"
 			}]
+			dependencies: ["6320017C1BCAFDD4"]
+			id: "44993D26C0343D18"
+			y: 4.5d
+			x: -2.0d
 		}
 		{
-			x: -3.0d
-			y: 4.0d
-			dependencies: ["67F11A479ED4CC23"]
-			id: "6320017C1BCAFDD4"
 			tasks: [{
 				id: "664E76B87A1A264C"
 				type: "item"
 				item: "techreborn:lapotronic_orb"
 			}]
+			dependencies: ["67F11A479ED4CC23"]
+			id: "6320017C1BCAFDD4"
+			y: 4.0d
+			x: -3.0d
 		}
 		{
-			x: -4.0d
-			y: 3.5d
-			dependencies: ["2E452CD2DA080B53"]
-			id: "67F11A479ED4CC23"
 			tasks: [{
 				id: "53823E0CC70B29C2"
 				type: "item"
 				item: "techreborn:lapotron_crystal"
 			}]
+			dependencies: ["2E452CD2DA080B53"]
+			id: "67F11A479ED4CC23"
+			y: 3.5d
+			x: -4.0d
 		}
 		{
-			x: -3.0d
-			y: 5.0d
-			dependencies: ["6320017C1BCAFDD4"]
-			id: "77FEE233C05E46CB"
 			tasks: [{
 				id: "2CDBEE46EAE7089E"
 				type: "item"
 				item: "techreborn:lapotronic_orbpack"
 			}]
+			dependencies: ["6320017C1BCAFDD4"]
+			id: "77FEE233C05E46CB"
+			y: 5.0d
+			x: -3.0d
 		}
 		{
-			x: -2.0d
-			y: 3.5d
-			dependencies: ["6320017C1BCAFDD4"]
-			id: "19C2D4326E059B45"
 			tasks: [{
 				id: "510C5E359D8C6057"
 				type: "item"
 				item: "techreborn:dragon_egg_syphon"
 			}]
+			dependencies: ["6320017C1BCAFDD4"]
+			id: "19C2D4326E059B45"
+			y: 3.5d
+			x: -2.0d
 		}
 		{
-			x: -4.0d
-			y: 5.5d
-			dependencies: ["67F11A479ED4CC23"]
-			id: "33FE412B52EE2784"
 			tasks: [{
 				id: "12CAFFFFD0A6C703"
 				type: "item"
 				item: "techreborn:energy_flow_chip"
 			}]
+			dependencies: ["67F11A479ED4CC23"]
+			id: "33FE412B52EE2784"
+			y: 5.5d
+			x: -4.0d
 		}
 		{
-			x: -4.0d
-			y: 7.0d
-			dependencies: ["33FE412B52EE2784"]
 			size: 1.5d
+			dependencies: ["33FE412B52EE2784"]
 			id: "49B0A723B599D62D"
+			y: 7.0d
+			x: -4.0d
 			tasks: [{
 				id: "330103BC34504A7E"
 				type: "item"
@@ -538,54 +539,50 @@
 			}]
 		}
 		{
-			x: -5.5d
-			y: 6.5d
-			dependencies: ["49B0A723B599D62D"]
-			id: "74A1F4F132C0C193"
 			tasks: [{
 				id: "34B16F28DACB9336"
 				type: "item"
 				item: "techreborn:quantum_helmet"
 			}]
+			dependencies: ["49B0A723B599D62D"]
+			id: "74A1F4F132C0C193"
+			y: 6.5d
+			x: -5.5d
 		}
 		{
-			x: -5.5d
-			y: 7.5d
-			dependencies: ["49B0A723B599D62D"]
-			id: "68A1034E3AC960A7"
 			tasks: [{
 				id: "41BC3096A904DA6D"
 				type: "item"
 				item: "techreborn:quantum_chestplate"
 			}]
+			dependencies: ["49B0A723B599D62D"]
+			id: "68A1034E3AC960A7"
+			y: 7.5d
+			x: -5.5d
 		}
 		{
-			x: -2.5d
-			y: 6.5d
-			dependencies: ["49B0A723B599D62D"]
-			id: "6893E4E62C8201E9"
 			tasks: [{
 				id: "730537F91B7ED1DA"
 				type: "item"
 				item: "techreborn:quantum_leggings"
 			}]
+			dependencies: ["49B0A723B599D62D"]
+			id: "6893E4E62C8201E9"
+			y: 6.5d
+			x: -2.5d
 		}
 		{
-			x: -2.5d
-			y: 7.5d
-			dependencies: ["49B0A723B599D62D"]
-			id: "4E5CAA25A13FBE9E"
 			tasks: [{
 				id: "0D75068B2A935C7C"
 				type: "item"
 				item: "techreborn:quantum_boots"
 			}]
+			dependencies: ["49B0A723B599D62D"]
+			id: "4E5CAA25A13FBE9E"
+			y: 7.5d
+			x: -2.5d
 		}
 		{
-			x: -5.0d
-			y: 4.0d
-			dependencies: ["67F11A479ED4CC23"]
-			id: "704E74CD9B17E180"
 			tasks: [{
 				id: "4DFED7E73A0BD2E1"
 				type: "item"
@@ -597,279 +594,282 @@
 					}
 				}
 			}]
+			dependencies: ["67F11A479ED4CC23"]
+			id: "704E74CD9B17E180"
+			y: 4.0d
+			x: -5.0d
 		}
 		{
-			x: 1.0d
-			y: -2.0d
-			dependencies: ["070906D7884D6CB8"]
-			id: "79CA01E9F2756AE8"
 			tasks: [{
 				id: "7E490AC598DC8652"
 				type: "item"
 				item: "techreborn:low_voltage_su"
 			}]
+			dependencies: ["070906D7884D6CB8"]
+			id: "79CA01E9F2756AE8"
+			y: -2.0d
+			x: 1.0d
 		}
 		{
-			x: -1.0d
-			y: 6.0d
-			hide_dependency_lines: true
-			dependencies: ["6F9F95E6D044341F"]
-			id: "76AC42A6F9BADE0E"
 			tasks: [{
 				id: "7C2138632F0A547B"
 				type: "item"
 				item: "techreborn:crude_storage_unit"
 			}]
+			dependencies: ["6F9F95E6D044341F"]
+			id: "76AC42A6F9BADE0E"
+			hide_dependency_lines: true
+			y: 6.0d
+			x: -1.0d
 		}
 		{
-			x: 0.0d
-			y: 5.5d
-			dependencies: ["76AC42A6F9BADE0E"]
-			id: "50C411E79534AFCF"
 			tasks: [{
 				id: "36ACD3A8E64DB78E"
 				type: "item"
 				item: "techreborn:basic_storage_unit"
 			}]
+			dependencies: ["76AC42A6F9BADE0E"]
+			id: "50C411E79534AFCF"
+			y: 5.5d
+			x: 0.0d
 		}
 		{
-			x: 1.0d
-			y: 6.0d
-			dependencies: ["50C411E79534AFCF"]
-			id: "0AE0482CFEB8E570"
 			tasks: [{
 				id: "4F9C19679479E8B0"
 				type: "item"
 				item: "techreborn:advanced_storage_unit"
 			}]
+			dependencies: ["50C411E79534AFCF"]
+			id: "0AE0482CFEB8E570"
+			y: 6.0d
+			x: 1.0d
 		}
 		{
-			x: 2.0d
-			y: 5.5d
-			dependencies: ["0AE0482CFEB8E570"]
-			id: "7F1980F45969B6D3"
 			tasks: [{
 				id: "0D22DDD78C6DA108"
 				type: "item"
 				item: "techreborn:industrial_storage_unit"
 			}]
+			dependencies: ["0AE0482CFEB8E570"]
+			id: "7F1980F45969B6D3"
+			y: 5.5d
+			x: 2.0d
 		}
 		{
-			x: 3.0d
-			y: 6.0d
-			dependencies: ["7F1980F45969B6D3"]
-			id: "1A1E4613B608C098"
 			tasks: [{
 				id: "5E57C8EF5FF6DA5B"
 				type: "item"
 				item: "techreborn:quantum_storage_unit"
 			}]
+			dependencies: ["7F1980F45969B6D3"]
+			id: "1A1E4613B608C098"
+			y: 6.0d
+			x: 3.0d
 		}
 		{
-			x: 0.0d
-			y: 6.5d
-			dependencies: ["36352064E732FA72"]
-			id: "70671EA03CCCCADF"
 			tasks: [{
 				id: "1FA5B2C2354E0E61"
 				type: "item"
 				item: "techreborn:advanced_tank_unit"
 			}]
+			dependencies: ["36352064E732FA72"]
+			id: "70671EA03CCCCADF"
+			y: 6.5d
+			x: 0.0d
 		}
 		{
-			x: -1.0d
-			y: 7.0d
-			hide_dependency_lines: true
-			dependencies: ["6F9F95E6D044341F"]
-			id: "36352064E732FA72"
 			tasks: [{
 				id: "71509B6096A843C9"
 				type: "item"
 				item: "techreborn:basic_tank_unit"
 			}]
+			dependencies: ["6F9F95E6D044341F"]
+			id: "36352064E732FA72"
+			hide_dependency_lines: true
+			y: 7.0d
+			x: -1.0d
 		}
 		{
-			x: 1.0d
-			y: 7.0d
-			dependencies: ["70671EA03CCCCADF"]
-			id: "13B415D59D057D98"
 			tasks: [{
 				id: "1F2049F18DB8002C"
 				type: "item"
 				item: "techreborn:industrial_tank_unit"
 			}]
+			dependencies: ["70671EA03CCCCADF"]
+			id: "13B415D59D057D98"
+			y: 7.0d
+			x: 1.0d
 		}
 		{
-			x: 2.0d
-			y: 6.5d
-			dependencies: ["13B415D59D057D98"]
-			id: "22C010A0CDD144A4"
 			tasks: [{
 				id: "112B4D140669936E"
 				type: "item"
 				item: "techreborn:quantum_tank_unit"
 			}]
+			dependencies: ["13B415D59D057D98"]
+			id: "22C010A0CDD144A4"
+			y: 6.5d
+			x: 2.0d
 		}
 		{
-			x: -4.0d
-			y: 8.5d
-			dependencies: ["49B0A723B599D62D"]
-			id: "662237CA24F99CB6"
 			tasks: [{
 				id: "3A19DBF68B9A1400"
 				type: "item"
 				item: "techreborn:fusion_coil"
 			}]
+			dependencies: ["49B0A723B599D62D"]
+			id: "662237CA24F99CB6"
+			y: 8.5d
+			x: -4.0d
 		}
 		{
-			x: -4.0d
-			y: 9.5d
-			dependencies: ["662237CA24F99CB6"]
-			id: "1E0E4E45C8EEBCCC"
 			tasks: [{
 				id: "56D28B5D698556FA"
 				type: "item"
 				item: "techreborn:fusion_control_computer"
 			}]
+			dependencies: ["662237CA24F99CB6"]
+			id: "1E0E4E45C8EEBCCC"
+			y: 9.5d
+			x: -4.0d
 		}
 		{
-			x: 4.0d
-			y: 1.5d
-			hide_dependency_lines: true
-			dependencies: ["6F9F95E6D044341F"]
-			id: "705C709298C54362"
 			tasks: [{
 				id: "2BF06455D74314B7"
 				type: "item"
 				item: "techreborn:overclocker_upgrade"
 			}]
+			dependencies: ["6F9F95E6D044341F"]
+			id: "705C709298C54362"
+			hide_dependency_lines: true
+			y: 1.5d
+			x: 4.0d
 		}
 		{
-			x: 5.0d
-			y: 2.0d
-			hide_dependency_lines: true
-			dependencies: ["6F9F95E6D044341F"]
-			id: "53998DAEAB2EA60F"
 			tasks: [{
 				id: "07F59E0DD51C0C02"
 				type: "item"
 				item: "techreborn:transformer_upgrade"
 			}]
+			dependencies: ["6F9F95E6D044341F"]
+			id: "53998DAEAB2EA60F"
+			hide_dependency_lines: true
+			y: 2.0d
+			x: 5.0d
 		}
 		{
-			x: 4.0d
-			y: 2.5d
-			hide_dependency_lines: true
-			dependencies: ["6F9F95E6D044341F"]
-			id: "4DF66A8E6967270D"
 			tasks: [{
 				id: "18EDDFB42915924A"
 				type: "item"
 				item: "techreborn:energy_storage_upgrade"
 			}]
+			dependencies: ["6F9F95E6D044341F"]
+			id: "4DF66A8E6967270D"
+			hide_dependency_lines: true
+			y: 2.5d
+			x: 4.0d
 		}
 		{
-			x: 5.0d
-			y: 3.0d
-			hide_dependency_lines: true
-			dependencies: ["6F9F95E6D044341F"]
-			id: "6D3CEE173DE5E2C7"
 			tasks: [{
 				id: "7F9581FB03222B1E"
 				type: "item"
 				item: "techreborn:superconductor_upgrade"
 			}]
+			dependencies: ["6F9F95E6D044341F"]
+			id: "6D3CEE173DE5E2C7"
+			hide_dependency_lines: true
+			y: 3.0d
+			x: 5.0d
 		}
 		{
-			x: 1.0d
-			y: 4.5d
-			hide_dependency_lines: true
-			dependencies: ["6F9F95E6D044341F"]
-			id: "01ADB47236A1DCCE"
 			tasks: [{
 				id: "5C098343ADA8C247"
 				type: "item"
 				item: "techreborn:lv_transformer"
 			}]
+			dependencies: ["6F9F95E6D044341F"]
+			id: "01ADB47236A1DCCE"
+			hide_dependency_lines: true
+			y: 4.5d
+			x: 1.0d
 		}
 		{
-			x: 2.0d
-			y: 4.0d
-			dependencies: ["01ADB47236A1DCCE"]
-			id: "1CEDFCB8B940AAC2"
 			tasks: [{
 				id: "77558CA27100591F"
 				type: "item"
 				item: "techreborn:mv_transformer"
 			}]
+			dependencies: ["01ADB47236A1DCCE"]
+			id: "1CEDFCB8B940AAC2"
+			y: 4.0d
+			x: 2.0d
 		}
 		{
-			x: 3.0d
-			y: 4.5d
-			dependencies: ["1CEDFCB8B940AAC2"]
-			id: "7580B7A97B38BA06"
 			tasks: [{
 				id: "715E92684B396AF6"
 				type: "item"
 				item: "techreborn:hv_transformer"
 			}]
+			dependencies: ["1CEDFCB8B940AAC2"]
+			id: "7580B7A97B38BA06"
+			y: 4.5d
+			x: 3.0d
 		}
 		{
-			x: -3.0d
-			y: 1.0d
-			hide_dependency_lines: true
-			dependencies: ["6F9F95E6D044341F"]
-			id: "4BFCC46CDF75FA49"
 			tasks: [{
 				id: "202887D3A5934125"
 				type: "item"
 				item: "techreborn:auto_crafting_table"
 			}]
+			dependencies: ["6F9F95E6D044341F"]
+			id: "4BFCC46CDF75FA49"
+			hide_dependency_lines: true
+			y: 1.0d
+			x: -3.0d
 		}
 		{
-			x: 3.0d
-			y: 0.0d
-			dependencies: ["305115BA557F938E"]
-			id: "1140AACF2857F303"
 			tasks: [{
 				id: "4115128E7469A293"
 				type: "item"
 				item: "advanced_reborn:ray_solar_panel"
 			}]
+			dependencies: ["305115BA557F938E"]
+			id: "1140AACF2857F303"
+			y: 0.0d
+			x: 3.0d
 		}
 		{
-			x: 4.0d
-			y: 0.0d
-			dependencies: ["1140AACF2857F303"]
-			id: "392DA9FDDDF1BB1A"
 			tasks: [{
 				id: "24F5E6983F0C38D4"
 				type: "item"
 				item: "advanced_reborn:ray_solar_panel_2"
 			}]
+			dependencies: ["1140AACF2857F303"]
+			id: "392DA9FDDDF1BB1A"
+			y: 0.0d
+			x: 4.0d
 		}
 		{
-			x: 5.0d
-			y: 0.0d
-			dependencies: ["392DA9FDDDF1BB1A"]
-			id: "612011861BA36273"
 			tasks: [{
 				id: "76680939819227CA"
 				type: "item"
 				item: "advanced_reborn:ray_solar_panel_3"
 			}]
+			dependencies: ["392DA9FDDDF1BB1A"]
+			id: "612011861BA36273"
+			y: 0.0d
+			x: 5.0d
 		}
 		{
-			x: 6.0d
-			y: 0.0d
-			dependencies: ["612011861BA36273"]
-			id: "6779EC43CC9E80E1"
 			tasks: [{
 				id: "471676EC2ADEF41F"
 				type: "item"
 				item: "advanced_reborn:ray_solar_panel_4"
 			}]
+			dependencies: ["612011861BA36273"]
+			id: "6779EC43CC9E80E1"
+			y: 0.0d
+			x: 6.0d
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/the_beginning.snbt
+++ b/config/ftbquests/quests/chapters/the_beginning.snbt
@@ -1,30 +1,15 @@
 {
-	id: "6C99EC6E1599B728"
-	group: "38633DD49534BFCD"
-	order_index: 0
-	filename: "the_beginning"
-	title: "The Beginning"
-	icon: "fabricaeexnihilo:oak_sieve"
-	default_quest_shape: ""
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "38633DD49534BFCD"
+	id: "6C99EC6E1599B728"
+	filename: "the_beginning"
+	default_quest_shape: ""
+	icon: "fabricaeexnihilo:oak_sieve"
+	title: "The Beginning"
+	order_index: 0
 	quests: [
 		{
-			title: "To get more materials"
-			x: 3.0d
-			y: -5.5d
-			description: [
-				"This is your basic way to get materials, insert mesh, sieve a valid material and get resources, its that simple!"
-				""
-				"Putting multiple sieves side by side acts as a multiblock structure, letting you sieve in bulk, up to 25 Sieves at once! (in a 5x5 square)."
-				""
-				"Later you will be able to use a Deployer or a Click Machine to automate it."
-				"Note that it can be tricky - because fake players can also unequip Meshes from the Sieve, which breaks the whole automation!"
-				""
-				"A Sieve can be water-logged."
-			]
-			dependencies: ["76B1B19B5D3949F5"]
-			min_required_tasks: 1
-			id: "2587A593554DBC4A"
 			tasks: [
 				{
 					id: "78082A8F71778128"
@@ -37,58 +22,64 @@
 					item: "fabricaeexnihilo:rubber_sieve"
 				}
 			]
+			description: [
+				"{the_beginning.sieve.text.1}"
+				""
+				"{the_beginning.sieve.text.2}"
+				""
+				"{the_beginning.sieve.text.3}"
+				""
+				"{the_beginning.sieve.text.4}"
+			]
+			id: "2587A593554DBC4A"
+			x: 3.0d
+			y: -5.5d
+			title: "{the_beginning.sieve.title}"
 			rewards: [{
 				id: "57AA7DEFD0892E4A"
 				type: "item"
 				item: "fabricaeexnihilo:raw_iron_piece"
 				count: 3
 			}]
+			subtitle: "{the_beginning.sieve.subtitle}"
+			dependencies: ["76B1B19B5D3949F5"]
+			min_required_tasks: 1
 		}
 		{
-			title: "Crucial Crucible"
-			x: 9.0d
-			y: -2.5d
-			description: [
-				"Crucible are the tip of the iceberg (or in this case volcano) when it comes to lava production."
-				""
-				"It needs a heat source under it to function."
-				""
-				"Torch, Fire, Lava, and some blocks provide their own level of heat."
-				""
-				"Once heated you can put or pump materials into the crucible(s), some materials provide more lava then others."
-				""
-				"This can potentionally be use as a power free AFK lava generator."
-			]
-			dependencies: ["1A9719BED12BDFC3"]
-			id: "5C106B6E6409EF22"
 			tasks: [{
 				id: "44E83B5E77B733F3"
 				type: "item"
 				item: "fabricaeexnihilo:porcelain_crucible"
 			}]
+			description: [
+				"{the_beginning.crucible.text.1}"
+				""
+				"{the_beginning.crucible.text.2}"
+			]
+			id: "5C106B6E6409EF22"
+			x: 9.0d
+			y: -2.5d
+			title: "{the_beginning.crucible.title}"
 			rewards: [{
 				id: "024BCCEE84F2B0FD"
 				type: "item"
 				item: "fabricaeexnihilo:stone_barrel"
 			}]
+			subtitle: "{the_beginning.crucible.subtitle}"
+			dependencies: ["1A9719BED12BDFC3"]
 		}
 		{
-			title: "This is not even my final form!"
-			x: 9.0d
-			y: -5.5d
-			description: [
-				"The only way to transform dust beyond, is to either sieve into materials, or turn it into clay."
-				""
-				"You could also made it into lava... but compared to cobblestone, dust gives 1/5 the amount of lava. So not a wise choice."
-			]
-			dependencies: ["1A9719BED12BDFC3"]
-			id: "276560C7054D7131"
 			tasks: [{
 				id: "3500358743E5638B"
 				type: "item"
 				item: "fabricaeexnihilo:dust"
 				count: 4L
 			}]
+			description: ["{the_beginning.dust.text.1}"]
+			id: "276560C7054D7131"
+			x: 9.0d
+			y: -5.5d
+			title: "{the_beginning.dust.title}"
 			rewards: [{
 				id: "49A1927E7B45852C"
 				type: "item"
@@ -116,18 +107,20 @@
 					}
 				}
 			}]
+			subtitle: "{the_beginning.dust.subtitle}"
+			dependencies: ["1A9719BED12BDFC3"]
 		}
 		{
-			x: 6.0d
-			y: -4.0d
-			dependencies: ["0BF9B63E286A7C1B"]
-			id: "1B3743770E4CCF42"
 			tasks: [{
 				id: "7765D4065719538A"
 				type: "item"
 				item: "minecraft:gravel"
 				count: 4L
 			}]
+			dependencies: ["0BF9B63E286A7C1B"]
+			id: "1B3743770E4CCF42"
+			y: -4.0d
+			x: 6.0d
 			rewards: [{
 				id: "15B361E7C3BFD1C1"
 				type: "item"
@@ -136,16 +129,16 @@
 			}]
 		}
 		{
-			x: 7.5d
-			y: -4.0d
-			dependencies: ["1B3743770E4CCF42"]
-			id: "508DEEE11F45E4F3"
 			tasks: [{
 				id: "415B428282916C73"
 				type: "item"
 				item: "minecraft:sand"
 				count: 4L
 			}]
+			dependencies: ["1B3743770E4CCF42"]
+			id: "508DEEE11F45E4F3"
+			y: -4.0d
+			x: 7.5d
 			rewards: [{
 				id: "1000EDC63EA5144F"
 				type: "item"
@@ -153,19 +146,6 @@
 			}]
 		}
 		{
-			title: "I am not a crook! Oh wait..."
-			x: 2.0d
-			y: -11.5d
-			description: [
-				"Wooden crooks are a staple to getting silk worms and higher chance for saplings from all trees."
-				""
-				"There are many crooks with varying durability."
-			]
-			dependencies: ["6D9CF1D77D05C2D4"]
-			hide: true
-			dependency_requirement: "one_completed"
-			optional: true
-			id: "458A8414A5189198"
 			tasks: [{
 				id: "217AF1AB5935DE87"
 				type: "item"
@@ -177,6 +157,11 @@
 					}
 				}
 			}]
+			description: [
+				"{the_beginning.tree_island.crook.text.1}"
+				""
+				"{the_beginning.tree_island.crook.text.2}"
+			]
 			rewards: [{
 				id: "04E6F9A92D8612E4"
 				type: "item"
@@ -188,22 +173,17 @@
 					}
 				}
 			}]
+			id: "458A8414A5189198"
+			x: 2.0d
+			y: -11.5d
+			title: "{the_beginning.tree_island.crook.title}"
+			dependency_requirement: "one_completed"
+			subtitle: "{the_beginning.tree_island.crook.subtitle}"
+			dependencies: ["6D9CF1D77D05C2D4"]
+			optional: true
+			hide: true
 		}
 		{
-			title: "Time to Grind"
-			x: 4.5d
-			y: -4.0d
-			description: [
-				"To get the next 3 sieving materials, you have to hammer them."
-				""
-				"Simply place the block down and break them with the hammer."
-				""
-				"REI will show the blocks that can be broken."
-				""
-				"Cobble > Gravel > Sand > Silt -> Dust"
-			]
-			dependencies: ["0B87D8D5CC3AF30D"]
-			id: "0BF9B63E286A7C1B"
 			tasks: [{
 				id: "00FA96B88F642341"
 				type: "item"
@@ -215,45 +195,53 @@
 					}
 				}
 			}]
+			description: ["{the_beginning.stone_hammer.text.1}"]
+			id: "0BF9B63E286A7C1B"
+			x: 4.5d
+			y: -4.0d
+			title: "{the_beginning.stone_hammer.title}"
 			rewards: [{
 				id: "1F9CE2440C50F885"
 				type: "item"
 				item: "minecraft:cobblestone"
 				count: 4
 			}]
+			subtitle: "{the_beginning.stone_hammer.subtitle}"
+			dependencies: ["0B87D8D5CC3AF30D"]
 		}
 		{
-			x: 1.5d
-			y: -5.5d
-			description: [
-				"Meshes have been given an upgrade since we last encountered them, now going up to Netherite!"
-				""
-				"Note that Emerald mesh won't upgrade to Netherite."
-			]
-			dependencies: ["2587A593554DBC4A"]
-			id: "4AA6039937E51455"
 			tasks: [{
 				id: "553618FD48D28A65"
 				type: "item"
 				item: "fabricaeexnihilo:string_mesh"
 			}]
+			description: [
+				"{the_beginning.string_mesh.text.1}"
+				""
+				"{the_beginning.string_mesh.text.2}"
+			]
+			id: "4AA6039937E51455"
+			x: 1.5d
+			y: -5.5d
 			rewards: [{
 				id: "0A384F8C95C0B783"
 				type: "item"
 				item: "fabricaeexnihilo:stone_pebble"
 				count: 15
 			}]
+			subtitle: "{the_beginning.string_mesh.subtitle}"
+			dependencies: ["2587A593554DBC4A"]
 		}
 		{
-			x: 0.0d
-			y: -5.5d
-			dependencies: ["4AA6039937E51455"]
-			id: "1F057C3C6AA5FD22"
 			tasks: [{
 				id: "7AEABEE2664D85EE"
 				type: "item"
 				item: "fabricaeexnihilo:flint_mesh"
 			}]
+			dependencies: ["4AA6039937E51455"]
+			id: "1F057C3C6AA5FD22"
+			y: -5.5d
+			x: 0.0d
 			rewards: [{
 				id: "1EE62537749C587E"
 				type: "item"
@@ -262,15 +250,15 @@
 			}]
 		}
 		{
-			x: -3.0d
-			y: -5.5d
-			dependencies: ["63A774E246F91DB1"]
-			id: "29B095943AD26EA9"
 			tasks: [{
 				id: "55237905F174FAA7"
 				type: "item"
 				item: "fabricaeexnihilo:iron_mesh"
 			}]
+			dependencies: ["63A774E246F91DB1"]
+			id: "29B095943AD26EA9"
+			y: -5.5d
+			x: -3.0d
 			rewards: [{
 				id: "4E10859DBBAC8890"
 				type: "item"
@@ -279,35 +267,35 @@
 			}]
 		}
 		{
-			x: -3.0d
-			y: -4.0d
-			dependencies: [
-				"29B095943AD26EA9"
-				"6B39422421203401"
-			]
-			dependency_requirement: "one_completed"
-			id: "42387D579F777B5E"
 			tasks: [{
 				id: "10A3924D160CC2B2"
 				type: "item"
 				item: "fabricaeexnihilo:diamond_mesh"
 			}]
+			id: "42387D579F777B5E"
+			x: -3.0d
+			y: -4.0d
 			rewards: [{
 				id: "1B8DA21CDFBBA8F1"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: [
+				"29B095943AD26EA9"
+				"6B39422421203401"
+			]
+			dependency_requirement: "one_completed"
 		}
 		{
-			x: 0.0d
-			y: -1.0d
-			dependencies: ["4138CA5A7F768170"]
-			id: "3375606B7B481265"
 			tasks: [{
 				id: "5BD2F4D3D78D3E00"
 				type: "item"
 				item: "fabricaeexnihilo:emerald_mesh"
 			}]
+			dependencies: ["4138CA5A7F768170"]
+			id: "3375606B7B481265"
+			y: -1.0d
+			x: 0.0d
 			rewards: [{
 				id: "6263E09ADF263035"
 				type: "item"
@@ -316,72 +304,56 @@
 			}]
 		}
 		{
-			x: -3.0d
-			y: -2.5d
-			description: [
-				"To get Ancient Debris for Netherite, you can use:"
-				"> Botania's Orechid Ignem,"
-				"> Modern Industrialization's Electric Quarry with Golden Drills,"
-				"or you can plunder chests found in Nether Structures, especially Bastions and Nether \"End Ships\"."
-				""
-				"After you collect a stack of Ancient Debris, you can make an IndRev Mining Rig to provide you with unlimited Ancient Debris!"
-				""
-				"Used to get Uraninite for Powah!. And only for that."
-			]
-			dependencies: ["42387D579F777B5E"]
-			id: "5E9F6228BBC60FFC"
 			tasks: [{
 				id: "692A1A67A3A43BAD"
 				type: "item"
 				item: "fabricaeexnihilo:netherite_mesh"
 			}]
+			description: [
+				"{the_beginning.netherite_mesh.text.1}"
+				""
+				"{the_beginning.netherite_mesh.text.2}"
+			]
+			id: "5E9F6228BBC60FFC"
+			x: -3.0d
+			y: -2.5d
 			rewards: [{
 				id: "594F84A51ADF373C"
 				type: "item"
 				item: "expandedstorage:wood_to_netherite_conversion_kit"
 			}]
+			subtitle: "{the_beginning.netherite_mesh.subtitle}"
+			dependencies: ["42387D579F777B5E"]
 		}
 		{
-			title: "There is an infestation!"
-			x: 2.0d
-			y: -8.5d
-			description: [
-				"Silkworms drop from leaves broken using a crook."
-				""
-				"Can be cooked for food, or used on leaves to infest them."
-				""
-				"Infested leaves will drop strings, but not saplings."
-			]
-			dependencies: ["458A8414A5189198"]
-			hide: true
-			optional: true
-			id: "564263E35EFCAD21"
 			tasks: [{
 				id: "5F37DF3800A01F53"
 				type: "item"
 				item: "fabricaeexnihilo:raw_silkworm"
 			}]
+			description: [
+				"{the_beginning.tree_island.silkworm.text.1}"
+				""
+				"{the_beginning.tree_island.silkworm.text.2}"
+				""
+				"{the_beginning.tree_island.silkworm.text.3}"
+			]
+			id: "564263E35EFCAD21"
+			x: 2.0d
+			y: -8.5d
+			title: "{the_beginning.tree_island.silkworm.title}"
 			rewards: [{
 				id: "681B44C761EB49C5"
 				type: "item"
 				item: "fabricaeexnihilo:cooked_silkworm"
 				count: 8
 			}]
+			subtitle: "{the_beginning.tree_island.silkworm.subtitle}"
+			dependencies: ["458A8414A5189198"]
+			optional: true
+			hide: true
 		}
 		{
-			title: "A Dirt-y idea."
-			icon: "minecraft:mycelium"
-			x: 4.5d
-			y: -5.5d
-			description: [
-				"These seeds are from sieving dirt or sand."
-				""
-				"- Ancient spores will turn dirt to Mycelium"
-				"- Grass seed turns dirt to grass."
-				""
-			]
-			dependencies: ["2587A593554DBC4A"]
-			id: "046D86775F6FF8D3"
 			tasks: [
 				{
 					id: "0ED2CEF487048036"
@@ -404,28 +376,26 @@
 					item: "fabricaeexnihilo:kelp_seeds"
 				}
 			]
+			description: [
+				"{the_beginning.dirt_sieve.text.1}"
+				""
+				"{the_beginning.dirt_sieve.text.2}"
+			]
+			id: "046D86775F6FF8D3"
+			icon: "minecraft:mycelium"
+			x: 4.5d
+			y: -5.5d
+			title: "{the_beginning.dirt_sieve.title}"
 			rewards: [{
 				id: "7B346AC46945E8C5"
 				type: "item"
 				item: "minecraft:beetroot_seeds"
 				count: 4
 			}]
+			subtitle: "{the_beginning.dirt_sieve.subtitle}"
+			dependencies: ["2587A593554DBC4A"]
 		}
 		{
-			title: "All the cobble gens!"
-			icon: "kibe:cobblestone_generator_mk1"
-			x: 10.5d
-			y: -1.0d
-			description: [
-				"There are many cobble generators in this modpack."
-				""
-				"From Vanilla, to Kibe's Cobble Gens."
-				""
-				"Feel free to choose what you like."
-				""
-			]
-			dependencies: ["153C83AD044BF76A"]
-			id: "1D137ABA27562E47"
 			tasks: [
 				{
 					id: "329574D79C45D26F"
@@ -438,24 +408,21 @@
 					item: "kibe:basalt_generator_mk1"
 				}
 			]
+			description: ["{the_beginning.cobblegen.text.1}"]
+			id: "1D137ABA27562E47"
+			icon: "kibe:cobblestone_generator_mk1"
+			x: 10.5d
+			y: -1.0d
+			title: "{the_beginning.cobblegen.title}"
 			rewards: [{
 				id: "50DE23B26B05CB51"
 				type: "item"
 				item: "compress:compressed_cobblestone_3"
 			}]
+			subtitle: "{the_beginning.cobblegen.subtitle}"
+			dependencies: ["153C83AD044BF76A"]
 		}
 		{
-			title: "Strung for Strings"
-			x: 3.0d
-			y: -7.0d
-			description: ["Quite important to make a White bed early, especially with those Phant0ms out there."]
-			min_required_dependencies: 1
-			dependencies: [
-				"564263E35EFCAD21"
-				"5BDA39AF551851EA"
-			]
-			min_required_tasks: 1
-			id: "76B1B19B5D3949F5"
 			tasks: [
 				{
 					id: "061D03A3DC2E464E"
@@ -468,30 +435,40 @@
 					item: "kibe:white_sleeping_bag"
 				}
 			]
+			description: ["{the_beginning.string.text.1}"]
+			min_required_dependencies: 1
+			id: "76B1B19B5D3949F5"
+			x: 3.0d
+			y: -7.0d
+			title: "{the_beginning.string.title}"
 			rewards: [{
 				id: "1A015A83C001FDD1"
 				type: "item"
 				item: "minecraft:string"
 				count: 4
 			}]
+			subtitle: "{the_beginning.string.subtitle}"
+			dependencies: [
+				"564263E35EFCAD21"
+				"5BDA39AF551851EA"
+			]
+			min_required_tasks: 1
 		}
 		{
-			title: "Simply Cobble"
-			x: 3.0d
-			y: -4.0d
-			subtitle: "Sieving for Pebbles!"
-			description: [
-				"Cobblestone, the most basic, and useful block for Skyblock since it's beginning."
-				""
-				"You can put 4 pebbles in the crafting table to get cobblestone or other stones like andesite, diorite, granite and much more."
-			]
-			dependencies: ["2587A593554DBC4A"]
-			id: "0B87D8D5CC3AF30D"
 			tasks: [{
 				id: "387C9E265EF2BFE0"
 				type: "item"
 				item: "minecraft:cobblestone"
 			}]
+			description: [
+				"{the_beginning.cobblestone.text.1}"
+				""
+				"{the_beginning.cobblestone.text.2}"
+			]
+			id: "0B87D8D5CC3AF30D"
+			x: 3.0d
+			y: -4.0d
+			title: "{the_beginning.cobblestone.title}"
 			rewards: [{
 				id: "3E13878CF5AF3F18"
 				type: "item"
@@ -503,20 +480,10 @@
 					}
 				}
 			}]
+			subtitle: "{the_beginning.cobblestone.subtitle}"
+			dependencies: ["2587A593554DBC4A"]
 		}
 		{
-			title: "Barrels of Fun"
-			x: 0.0d
-			y: -13.0d
-			description: [
-				"At first you should insert some organic materials, this will produce dirt."
-				""
-				"Stone Barrels can be used for both hot and cold liquids."
-			]
-			dependencies: ["6D9CF1D77D05C2D4"]
-			hide: true
-			optional: true
-			id: "5E67AA32C8260EFE"
 			tasks: [
 				{
 					id: "3E0D5CE550B290BB"
@@ -562,30 +529,27 @@
 					count: 4L
 				}
 			]
+			description: [
+				"{the_beginning.tree_island.barrel.text.1}"
+				""
+				"{the_beginning.tree_island.barrel.text.2}"
+			]
+			id: "5E67AA32C8260EFE"
+			x: 0.0d
+			y: -13.0d
+			title: "{the_beginning.tree_island.barrel.title}"
 			rewards: [{
 				id: "042B8977BF062957"
 				type: "item"
 				item: "minecraft:oak_sapling"
 				count: 16
 			}]
+			subtitle: "{the_beginning.tree_island.barrel.subtitle}"
+			dependencies: ["6D9CF1D77D05C2D4"]
+			optional: true
+			hide: true
 		}
 		{
-			title: "Heat Sources"
-			icon: {
-				id: "minecraft:flint_and_steel"
-				Count: 1b
-				tag: {
-					Damage: 0
-				}
-			}
-			x: 10.5d
-			y: -2.5d
-			description: [
-				"Heat Sources can be seen from pressing U while hovering your mouse over a crucible."
-				""
-			]
-			dependencies: ["5C106B6E6409EF22"]
-			id: "7F58FDC48A15959F"
 			tasks: [
 				{
 					id: "6BC1EAC25E4E1035"
@@ -604,81 +568,75 @@
 					item: "minecraft:netherrack"
 				}
 			]
+			description: ["{the_beginning.heat_sources.text.1}"]
+			id: "7F58FDC48A15959F"
+			icon: {
+				id: "minecraft:flint_and_steel"
+				Count: 1b
+				tag: {
+					Damage: 0
+				}
+			}
+			x: 10.5d
+			y: -2.5d
+			title: "{the_beginning.heat_sources.title}"
 			rewards: [{
 				id: "73AFD3F476EF15E8"
 				type: "xp"
 				xp: 100
 			}]
+			subtitle: "{the_beginning.heat_sources.subtitle}"
+			dependencies: ["5C106B6E6409EF22"]
 		}
 		{
-			title: "Blocks for Lava?"
-			x: 9.0d
-			y: -1.0d
-			description: [
-				"Lava production not only needs heat, but also needs blocks for production."
-				""
-				"Pressing U while hovering over the crucible in the inventory, will show what it can take."
-				""
-				"Cobblestone is the most common use in the past that produces 1/4 bucket per block of lava."
-				""
-				"But Obsidian and Netherrack makes a whole bucket of lava."
-			]
-			dependencies: ["5C106B6E6409EF22"]
-			id: "153C83AD044BF76A"
 			tasks: [{
 				id: "2E6269CE4D1B1B91"
 				type: "item"
 				item: "minecraft:lava_bucket"
 			}]
+			description: [
+				"{the_beginning.lava.text.1}"
+				""
+				"{the_beginning.lava.text.2}"
+			]
+			id: "153C83AD044BF76A"
+			x: 9.0d
+			y: -1.0d
+			title: "{the_beginning.lava.title}"
 			rewards: [{
 				id: "05A9612A2B359215"
 				type: "xp"
 				xp: 100
 			}]
+			subtitle: "{the_beginning.lava.subtitle}"
+			dependencies: ["5C106B6E6409EF22"]
 		}
 		{
-			title: "Fluid Transformation"
-			x: 6.0d
-			y: -5.5d
-			description: [
-				"Fluid Transformation is required to receive some resources."
-				""
-				"For this quest, I will explain how to get those fluids, as for the next quests, will explain what it can do."
-				""
-				"To get Witch Water, your barrel full of water must be clicked with a Ancient Spore to convert the fluid."
-			]
-			dependencies: ["046D86775F6FF8D3"]
-			id: "2F61617F7194D76A"
 			tasks: [{
 				id: "640D84EDC3A54A91"
 				type: "item"
 				item: "fabricaeexnihilo:witchwater_bucket"
 			}]
+			description: [
+				"{the_beginning.witchwater.text.1}"
+				""
+				"{the_beginning.witchwater.text.2}"
+				""
+				"{the_beginning.witchwater.text.3}"
+			]
+			id: "2F61617F7194D76A"
+			x: 6.0d
+			y: -5.5d
+			title: "{the_beginning.witchwater.title}"
 			rewards: [{
 				id: "017186D7A2FE497E"
 				type: "item"
 				item: "fabricaeexnihilo:mycelium_seeds"
 			}]
+			subtitle: "{the_beginning.witchwater.subtitle}"
+			dependencies: ["046D86775F6FF8D3"]
 		}
 		{
-			title: "Mob Summoning and Changing"
-			icon: "minecraft:wither_skeleton_skull"
-			x: 6.0d
-			y: -7.0d
-			description: [
-				"Mob spawning and changing is a bonus from the Ex Nihilo mod."
-				""
-				"Mobs can be transformed when doused, mainly by witch water:"
-				""
-				" - Villagers -> Witches"
-				" - Creepers -> Charged Creepers"
-				" - Squids -> Ghasts"
-				" - Skeletons -> Wither Skeletons"
-				""
-				"You can also use dolls, to summon mobs from barrels. The dolls required does give you what you need to summon them in their info when you hover your mouse over the item."
-			]
-			dependencies: ["2F61617F7194D76A"]
-			id: "0202FA0848EBB3CC"
 			tasks: [
 				{
 					id: "706CBF8F52B19BA1"
@@ -701,6 +659,20 @@
 					item: "fabricaeexnihilo:doll_enderman"
 				}
 			]
+			description: [
+				"{the_beginning.dolls.text.1}"
+				""
+				"{the_beginning.dolls.text.2}"
+				""
+				"{the_beginning.dolls.text.3}"
+				""
+				"{the_beginning.dolls.text.4}"
+			]
+			id: "0202FA0848EBB3CC"
+			icon: "minecraft:wither_skeleton_skull"
+			x: 6.0d
+			y: -7.0d
+			title: "{the_beginning.dolls.title}"
 			rewards: [
 				{
 					id: "528B65308C4E4E87"
@@ -743,18 +715,20 @@
 					item: "minecraft:gunpowder"
 				}
 			]
+			subtitle: "{the_beginning.dolls.subtitle}"
+			dependencies: ["2F61617F7194D76A"]
 		}
 		{
-			x: 9.0d
-			y: -4.0d
-			dependencies: ["508DEEE11F45E4F3"]
-			id: "1A9719BED12BDFC3"
 			tasks: [{
 				id: "11FB1D860C8E27FF"
 				type: "item"
 				item: "fabricaeexnihilo:silt"
 				count: 4L
 			}]
+			dependencies: ["508DEEE11F45E4F3"]
+			id: "1A9719BED12BDFC3"
+			y: -4.0d
+			x: 9.0d
 			rewards: [{
 				id: "0F97B790FB409BA6"
 				type: "item"
@@ -763,15 +737,15 @@
 			}]
 		}
 		{
-			x: 0.0d
-			y: -4.0d
-			dependencies: ["1F057C3C6AA5FD22"]
-			id: "2F7CB28E05E32B6B"
 			tasks: [{
 				id: "48A60E3716538891"
 				type: "item"
 				item: "fabricaeexnihilo:copper_mesh"
 			}]
+			dependencies: ["1F057C3C6AA5FD22"]
+			id: "2F7CB28E05E32B6B"
+			y: -4.0d
+			x: 0.0d
 			rewards: [{
 				id: "5F2E5E24D5FDE717"
 				type: "item"
@@ -780,15 +754,15 @@
 			}]
 		}
 		{
-			x: 0.0d
-			y: -2.5d
-			dependencies: ["2F7CB28E05E32B6B"]
-			id: "4138CA5A7F768170"
 			tasks: [{
 				id: "5148C22DD7A60C5E"
 				type: "item"
 				item: "fabricaeexnihilo:gold_mesh"
 			}]
+			dependencies: ["2F7CB28E05E32B6B"]
+			id: "4138CA5A7F768170"
+			y: -2.5d
+			x: 0.0d
 			rewards: [
 				{
 					id: "1418E45E0BD850C2"
@@ -803,12 +777,6 @@
 			]
 		}
 		{
-			title: "Salt and Brine"
-			x: 7.5d
-			y: -5.5d
-			subtitle: "Use a bottle on a Sand block."
-			dependencies: ["508DEEE11F45E4F3"]
-			id: "6A8F984980E9BB6B"
 			tasks: [
 				{
 					id: "69D302AF9669B873"
@@ -821,6 +789,10 @@
 					item: "fabricaeexnihilo:brine_bucket"
 				}
 			]
+			id: "6A8F984980E9BB6B"
+			x: 7.5d
+			y: -5.5d
+			title: "{the_beginning.salt_brine.title}"
 			rewards: [
 				{
 					id: "555EC7766EB956CD"
@@ -835,21 +807,10 @@
 					count: 2
 				}
 			]
+			subtitle: "{the_beginning.salt_brine.subtitle}"
+			dependencies: ["508DEEE11F45E4F3"]
 		}
 		{
-			title: "Water... Need water..."
-			x: 0.0d
-			y: -10.0d
-			subtitle: "Here you will get your water!"
-			description: [
-				"Use this to create water from plant materials."
-				""
-				"Saplings or apples would be a good idea."
-			]
-			dependencies: ["6D9CF1D77D05C2D4"]
-			hide: true
-			optional: true
-			id: "500132095BEC908B"
 			tasks: [
 				{
 					id: "2C886BA482CAFA8C"
@@ -902,48 +863,54 @@
 					}
 				}
 			]
+			description: [
+				"{the_beginning.tree_island.water.text.1}"
+				""
+				"{the_beginning.tree_island.water.text.2}"
+			]
+			id: "500132095BEC908B"
+			x: 0.0d
+			y: -10.0d
+			title: "{the_beginning.tree_island.water.title}"
 			rewards: [{
 				id: "1E59BD239846CAE4"
 				type: "item"
 				item: "kibe:water_wooden_bucket"
 			}]
+			subtitle: "{the_beginning.tree_island.water.subtitle}"
+			dependencies: ["6D9CF1D77D05C2D4"]
+			optional: true
+			hide: true
 		}
 		{
-			title: "Fishing and Chill"
+			size: 1.5d
+			id: "6D7B9D15C87A8C57"
 			x: 4.0d
 			y: -11.5d
 			shape: "octagon"
-			dependencies: ["7849BD01ACBFAC3A"]
-			hide: true
-			size: 1.5d
-			optional: true
-			id: "6D7B9D15C87A8C57"
-			tasks: [{
-				id: "2BC3C87D4FB25699"
-				type: "advancement"
-				advancement: "minecraft:husbandry/fishy_business"
-				criterion: ""
-			}]
+			title: "{the_beginning.fishing_island.fishing.title}"
 			rewards: [{
 				id: "3A6C8AA39673CD47"
 				type: "item"
 				item: "minecraft:cooked_cod"
 				count: 4
 			}]
+			dependencies: ["7849BD01ACBFAC3A"]
+			tasks: [{
+				id: "2BC3C87D4FB25699"
+				type: "advancement"
+				advancement: "minecraft:husbandry/fishy_business"
+				criterion: ""
+			}]
+			optional: true
+			hide: true
 		}
 		{
-			title: "Collect Wood"
-			icon: "minecraft:oak_log"
-			x: 0.0d
-			y: -11.5d
-			shape: "octagon"
-			subtitle: "Harvest a tree!"
-			dependencies: ["3AC0329506E80AA4"]
-			hide: true
-			dependency_requirement: "one_completed"
 			size: 1.5d
+			x: 0.0d
+			icon: "minecraft:oak_log"
+			subtitle: "{the_beginning.tree_island.wood.subtitle}"
 			optional: true
-			id: "6D9CF1D77D05C2D4"
 			tasks: [
 				{
 					id: "47F436AB4E34C9D7"
@@ -964,43 +931,55 @@
 					count: 8L
 				}
 			]
+			id: "6D9CF1D77D05C2D4"
+			shape: "octagon"
+			y: -11.5d
+			title: "{the_beginning.tree_island.wood.title}"
 			rewards: [{
 				id: "11D10F5D00323832"
 				type: "item"
 				item: "minecraft:apple"
 				count: 4
 			}]
+			dependencies: ["3AC0329506E80AA4"]
+			dependency_requirement: "one_completed"
+			hide: true
 		}
 		{
-			x: 5.5d
-			y: -10.0d
-			dependencies: ["41EEA2C5F1D6B3E1"]
-			hide: false
-			optional: true
-			id: "07C525ED6A1C8B22"
 			tasks: [{
 				id: "37E3C7894097D2AB"
 				type: "item"
 				item: "blockus:bamboo_planks"
 				count: 16L
 			}]
+			id: "07C525ED6A1C8B22"
+			x: 5.5d
+			y: -10.0d
 			rewards: [{
 				id: "13D9AB456BAE40E2"
 				type: "item"
 				item: "blockus:bamboo_slab"
 				count: 16
 			}]
+			dependencies: ["41EEA2C5F1D6B3E1"]
+			hide: false
+			optional: true
 		}
 		{
+			size: 1.5d
+			id: "41EEA2C5F1D6B3E1"
 			x: 7.0d
 			y: -10.0d
 			shape: "octagon"
-			subtitle: "Spam the sneak key to make your bamboo grow faster."
+			title: "{the_beginning.bamboo_island.bamboo.title}"
+			rewards: [{
+				id: "6EACCC9718873B57"
+				type: "item"
+				item: "minecraft:apple"
+				count: 4
+			}]
+			subtitle: "{the_beginning.bamboo_island.bamboo.subtitle}"
 			dependencies: ["329CC4079DB5DABE"]
-			hide: true
-			size: 1.5d
-			optional: true
-			id: "41EEA2C5F1D6B3E1"
 			tasks: [
 				{
 					id: "71099467AADBD0FC"
@@ -1015,23 +994,25 @@
 					count: 16L
 				}
 			]
-			rewards: [{
-				id: "6EACCC9718873B57"
-				type: "item"
-				item: "minecraft:apple"
-				count: 4
-			}]
+			optional: true
+			hide: true
 		}
 		{
-			title: "What do do with my Andesite?"
+			size: 1.5d
+			id: "725237684B3596F1"
 			icon: "create:andesite_alloy"
 			x: -3.0d
 			y: -8.5d
 			shape: "gear"
-			subtitle: "Andesite and Iron open you the door to the Mechanical Age!"
+			title: "{the_beginning.andesite_alloy.title}"
+			rewards: [{
+				id: "29E611CC13BF7524"
+				type: "item"
+				item: "create:andesite_alloy"
+				count: 4
+			}]
+			subtitle: "{the_beginning.andesite_alloy.subtitle}"
 			dependencies: ["47A493E81814E139"]
-			size: 1.5d
-			id: "725237684B3596F1"
 			tasks: [
 				{
 					id: "185B7F11820BB31E"
@@ -1046,27 +1027,13 @@
 					count: 16L
 				}
 			]
-			rewards: [{
-				id: "29E611CC13BF7524"
-				type: "item"
-				item: "create:andesite_alloy"
-				count: 4
-			}]
 		}
 		{
-			title: "Alloy Forge"
-			icon: "alloy_forgery:prismarine_bricks_forge_controller"
-			x: -3.0d
-			y: -7.0d
-			subtitle: "Expensive but it's your first choice to smelt alloys."
-			description: ["{image:kubejs:textures/item/alloy_forge.png width:144 height:144 align:1}"]
-			dependencies: ["29B095943AD26EA9"]
-			id: "47A493E81814E139"
 			tasks: [
 				{
 					id: "426134A2D5A9FA7B"
 					type: "item"
-					title: "Prismarine or End Stone Forge Controller"
+					title: "{the_beginning.alloy_forge.controller}"
 					item: {
 						id: "itemfilters:or"
 						Count: 1b
@@ -1085,33 +1052,41 @@
 					}
 				}
 				{
-					id: "4E153986EF85E27F"
 					type: "questsadditions:structure"
-					title: "Build a Prismarine Alloy Forge"
-					name: "alloy_forge_s"
-					hasCustomPicture: true
-					layer: true
-					ignoreState: true
+					id: "4E153986EF85E27F"
 					rightclick: true
+					hasCustomPicture: true
+					title: "{the_beginning.alloy_forge.build}"
+					ignoreState: true
+					layer: true
+					name: "alloy_forge_s"
 				}
 			]
+			description: ["{image:kubejs:textures/item/alloy_forge.png width:144 height:144 align:1}"]
+			id: "47A493E81814E139"
+			icon: "alloy_forgery:prismarine_bricks_forge_controller"
+			x: -3.0d
+			y: -7.0d
+			title: "{the_beginning.alloy_forge.title}"
 			rewards: [{
 				id: "756BC280D38C7C77"
 				type: "item"
 				item: "minecraft:prismarine_bricks"
 				count: 4
 			}]
+			subtitle: "{the_beginning.alloy_forge.subtitle}"
+			dependencies: ["29B095943AD26EA9"]
 		}
 		{
-			x: 1.5d
-			y: -1.0d
-			dependencies: ["3375606B7B481265"]
-			id: "783F26A53348A06A"
 			tasks: [{
 				id: "078C8870B269CA1B"
 				type: "item"
 				item: "fabricaeexnihilo:carbon_mesh"
 			}]
+			dependencies: ["3375606B7B481265"]
+			id: "783F26A53348A06A"
+			y: -1.0d
+			x: 1.5d
 			rewards: [{
 				id: "4F5A23FF64DBF006"
 				type: "item"
@@ -1120,22 +1095,20 @@
 			}]
 		}
 		{
-			title: "Barrel Enchanting"
-			x: 6.0d
-			y: -2.5d
-			description: [
-				"Once you have a Enchantment Table, you can try to enchant a Barrel with Thorns."
-				"If you stand on it, it will produce blood while damaging you."
-				"It works with mobs as well."
-			]
-			dependencies: ["5C8FB8F9E44FFE55"]
-			optional: true
-			id: "1A249C63F49FEE11"
 			tasks: [{
 				id: "6D6841B598803A76"
 				type: "item"
 				item: "fabricaeexnihilo:blood_bucket"
 			}]
+			description: [
+				"{the_beginning.blood.text.1}"
+				""
+				"{the_beginning.blood.text.2}"
+			]
+			id: "1A249C63F49FEE11"
+			x: 6.0d
+			y: -2.5d
+			title: "{the_beginning.blood.title}"
 			rewards: [{
 				id: "0CB77E96D48C5F00"
 				type: "item"
@@ -1150,22 +1123,17 @@
 					}
 				}
 			}]
+			subtitle: "{the_beginning.blood.subtitle}"
+			dependencies: ["5C8FB8F9E44FFE55"]
+			optional: true
 		}
 		{
-			title: "In case your Fishing Rod broke"
+			can_repeat: true
+			description: ["{the_beginning.fishing_island.fishing_rod.text.1}"]
+			id: "722E4F3BB0855CE8"
 			x: 4.0d
 			y: -13.0d
-			description: ["This quest is repeatable - meaning that you can always get a new Fishing Rod every 5 XP Levels gained!"]
-			dependencies: ["6D7B9D15C87A8C57"]
-			optional: true
-			can_repeat: true
-			id: "722E4F3BB0855CE8"
-			tasks: [{
-				id: "515A874CDEC88BBC"
-				type: "xp"
-				value: 5L
-				points: false
-			}]
+			title: "{the_beginning.fishing_island.fishing_rod.title}"
 			rewards: [{
 				id: "5F15360BCD7E5FBB"
 				type: "item"
@@ -1178,23 +1146,17 @@
 					}
 				}
 			}]
+			subtitle: "{the_beginning.fishing_island.fishing_rod.subtitle}"
+			dependencies: ["6D7B9D15C87A8C57"]
+			tasks: [{
+				id: "515A874CDEC88BBC"
+				type: "xp"
+				value: 5L
+				points: false
+			}]
+			optional: true
 		}
 		{
-			x: 5.5d
-			y: -13.0d
-			subtitle: "You can strip Bamboo by right clicking with a axe."
-			description: [
-				"Craft one of these to complete this quest."
-				"(TiC tools do not need to be assembled like in the task.)"
-				""
-				"If the quest doesn't complete, throw the item on the ground and pick it up."
-			]
-			dependencies: ["69E4F9F9ED4EB259"]
-			hide: false
-			optional: true
-			min_width: 250
-			min_required_tasks: 1
-			id: "4F5F0B705FCB602F"
 			tasks: [
 				{
 					id: "7C1BB2BF43F96CAC"
@@ -1214,8 +1176,6 @@
 						id: "tconstruct:hand_axe"
 						Count: 1b
 						tag: {
-							tic_multipliers: { }
-							Damage: 0
 							tic_stats: {
 								"tconstruct:attack_damage": 6.0f
 								"tconstruct:harvest_tier": "minecraft:wood"
@@ -1223,6 +1183,8 @@
 								"tconstruct:mining_speed": 2.0f
 								"tconstruct:attack_speed": 0.9f
 							}
+							Damage: 0
+							tic_multipliers: { }
 							tic_materials: [
 								"tconstruct:wood#bamboo"
 								"tconstruct:wood"
@@ -1256,24 +1218,37 @@
 					match_nbt: false
 				}
 			]
+			description: [
+				"{the_beginning.bamboo_island.axe.text.1}"
+				""
+				"{the_beginning.bamboo_island.axe.text.2}"
+			]
+			id: "4F5F0B705FCB602F"
+			x: 5.5d
+			y: -13.0d
 			rewards: [{
 				id: "7387A4FC77792F74"
 				type: "item"
 				item: "minecraft:bamboo"
 				count: 8
 			}]
+			min_width: 250
+			subtitle: "{the_beginning.bamboo_island.axe.subtitle}"
+			dependencies: ["69E4F9F9ED4EB259"]
+			min_required_tasks: 1
+			hide: false
+			optional: true
 		}
 		{
-			x: 9.0d
-			y: 0.5d
-			description: ["This Block Breaker can be used to hammer e.g. cobblestone to gravel."]
-			dependencies: ["153C83AD044BF76A"]
-			id: "3D079061CE0AD33F"
 			tasks: [{
 				id: "2E3581C01BE20963"
 				type: "item"
 				item: "redstonebits:breaker"
 			}]
+			description: ["{the_beginning.breaker.text.1}"]
+			id: "3D079061CE0AD33F"
+			x: 9.0d
+			y: 0.5d
 			rewards: [{
 				id: "7CDBDCBA1A776FD7"
 				type: "item"
@@ -1285,54 +1260,52 @@
 					}
 				}
 			}]
+			dependencies: ["153C83AD044BF76A"]
 		}
 		{
-			title: "Early Automation"
-			x: -1.5d
-			y: -13.0d
-			dependencies: ["5E67AA32C8260EFE"]
-			hide: true
-			optional: true
-			id: "5C5EDCED67B705ED"
 			tasks: [{
 				id: "7934FEB9E0C04811"
 				type: "item"
 				item: "coxinhautilities:wooden_hopper"
 			}]
+			id: "5C5EDCED67B705ED"
+			x: -1.5d
+			y: -13.0d
+			title: "{the_beginning.wooden_hopper.title}"
 			rewards: [{
 				id: "07E02A468549CFA6"
 				type: "item"
 				item: "coxinhautilities:wooden_hopper"
 			}]
+			dependencies: ["5E67AA32C8260EFE"]
+			hide: true
+			optional: true
 		}
 		{
-			title: "I am Grout!"
-			x: 7.5d
-			y: -2.5d
-			subtitle: "Hephaestus is here (Fabric port of TConstruct, BETA)"
-			description: [
-				"Hephaestus - the ancient Greek god of Smithing."
-				""
-				"Feel free to try out Hephaestus, the Tinkers Construct port for Fabric."
-				"Its not fully included in the modpack, so some recipes are currently missing."
-			]
-			dependencies: ["508DEEE11F45E4F3"]
-			id: "5F6BD70DF6342770"
 			tasks: [{
 				id: "7276E4698718F7F0"
 				type: "item"
 				item: "tconstruct:grout"
 			}]
+			description: ["{the_beginning.hephaestus.text.1}"]
+			id: "5F6BD70DF6342770"
+			x: 7.5d
+			y: -2.5d
+			title: "{the_beginning.hephaestus.title}"
 			rewards: [{
 				id: "15CFCF83FDF834E2"
 				type: "item"
 				item: "tconstruct:materials_and_you"
 			}]
+			subtitle: "{the_beginning.hephaestus.subtitle}"
+			dependencies: ["508DEEE11F45E4F3"]
 		}
 		{
-			title: "How to obtain Gold?"
-			x: -4.5d
-			y: -5.5d
+			tasks: [{
+				id: "7E16990520EE91F9"
+				type: "item"
+				item: "minecraft:gold_ingot"
+			}]
 			description: [
 				"The Quest Book will not tell you how to get each material."
 				"Instead, you have to find your own way. By using REI you should be able to find the answers."
@@ -1340,98 +1313,72 @@
 				"Some materials like gold can be obtained in multiple ways."
 				"Gold can be found in the nether, but later you should build a automated gold production with the Create mod."
 			]
-			dependencies: ["29B095943AD26EA9"]
 			id: "2E9E67B123FB86ED"
-			tasks: [{
-				id: "7E16990520EE91F9"
-				type: "item"
-				item: "minecraft:gold_ingot"
-			}]
+			x: -4.5d
+			y: -5.5d
+			title: "How to obtain Gold?"
 			rewards: [{
 				id: "76716B49566C77F1"
 				type: "item"
 				item: "minecraft:gold_nugget"
 				count: 7
 			}]
+			dependencies: ["29B095943AD26EA9"]
 		}
 		{
-			title: "We need to go Deeper!"
-			x: 7.5d
-			y: -1.0d
-			description: ["Other Dimensions like the Nether are not empty. You can discover some structures there."]
-			dependencies: ["153C83AD044BF76A"]
-			id: "3AB25EAB4F16C5A5"
 			tasks: [{
 				id: "5712A76C98E70614"
 				type: "dimension"
 				dimension: "minecraft:the_nether"
 			}]
+			description: ["{the_beginning.nether.text.1}"]
+			id: "3AB25EAB4F16C5A5"
+			x: 7.5d
+			y: -1.0d
+			title: "{the_beginning.nether.title}"
 			rewards: [{
 				id: "054B8B47F8122CAA"
 				type: "item"
 				item: "minecraft:nether_brick"
 				count: 8
 			}]
+			subtitle: "{the_beginning.nether.subtitle}"
+			dependencies: ["153C83AD044BF76A"]
 		}
 		{
-			title: "A Dirt Farm?"
-			icon: "minecraft:dirt"
-			x: 7.5d
-			y: -7.0d
-			description: [
-				"You can use Witchwater to generate infinite Dirt. By using Witchwater and regular Water in the configuration below, it will generate Dirt and sometimes Podzol!"
-				""
-				"{image:kubejs:textures/item/Podzol.png width:150 height:75 align:1}"
-			]
-			dependencies: ["2F61617F7194D76A"]
-			id: "767A2CF2A68BE797"
 			tasks: [{
 				id: "14A86499B880A4F1"
 				type: "checkmark"
 			}]
+			description: [
+				"You can use Witchwater to generate infinite Dirt. By using Witchwater and regular Water in the configuration below, it will generate Dirt and sometimes Podzol!"
+				""
+				"{image:kubejs:textures/item/podzol.png width:150 height:75 align:1}"
+			]
+			icon: "minecraft:dirt"
+			id: "767A2CF2A68BE797"
+			x: 7.5d
+			y: -7.0d
+			title: "A Dirt Farm?"
+			dependencies: ["2F61617F7194D76A"]
 		}
 		{
-			x: 1.5d
-			y: -4.0d
-			subtitle: "Automated Sieving!"
-			description: [
-				"It will automatically sieve items inserted into it."
-				""
-				"Mechanically similar to a Millstone."
-				""
-				"FabricaeExNihilo Meshes won't work here - using Crafting you can switch between FabricaeExNihilo and Create Sifter variants of meshes."
-				""
-				"Please Note: You need some sort of a blacklistable item extraction (like Brass Funnels or Smart Chutes), because without filtering it will extract currently sieved items!"
-				""
-				"A huge advantage of the Sifter is the fact that it will not automatically unequip meshes nor it will spill out items into the world."
-				""
-				"The Sifter can also be Waterlogged to process certain recipes."
-			]
-			dependencies: [
-				"2587A593554DBC4A"
-				"18E391B45D935712"
-			]
-			id: "2EEFE657598AC91C"
 			tasks: [{
 				id: "4BAC6F40786AAF4D"
 				type: "item"
 				item: "createsifter:sifter"
 			}]
+			description: ["{the_beginning.create_sifter.text.1}"]
+			id: "2EEFE657598AC91C"
+			x: 1.5d
+			y: -4.0d
+			subtitle: "{the_beginning.create_sifter.subtitle}"
+			dependencies: [
+				"2587A593554DBC4A"
+				"18E391B45D935712"
+			]
 		}
 		{
-			title: "Spores"
-			x: 1.5d
-			y: -2.5d
-			subtitle: "Bring a part of The Nether to your home island."
-			description: [
-				"Use one of these on the Netherrack Block to turn it into Crimson/Warped Nylium."
-				""
-				"Obtain Crimson or Warped Spores to complete this quest."
-			]
-			dependencies: ["4138CA5A7F768170"]
-			optional: true
-			min_required_tasks: 1
-			id: "43F6C6DF46FFB83F"
 			tasks: [
 				{
 					id: "1FC3AE3301F98620"
@@ -1444,17 +1391,21 @@
 					item: "fabricaeexnihilo:crimson_seeds"
 				}
 			]
+			description: [
+				"{the_beginning.spores.text.1}"
+				""
+				"{the_beginning.spores.text.2}"
+			]
+			id: "43F6C6DF46FFB83F"
+			x: 1.5d
+			y: -2.5d
+			title: "{the_beginning.spores.title}"
+			subtitle: "{the_beginning.spores.subtitle}"
+			dependencies: ["4138CA5A7F768170"]
+			min_required_tasks: 1
+			optional: true
 		}
 		{
-			title: "Nether Fungi"
-			x: 6.0d
-			y: -1.0d
-			subtitle: "You will need these to get Shroomlights."
-			description: ["Obtain one of these items to complete this quest."]
-			dependencies: ["3AB25EAB4F16C5A5"]
-			optional: true
-			min_required_tasks: 1
-			id: "02D7E339C4A7FF1F"
 			tasks: [
 				{
 					id: "77B63079F69D0EAD"
@@ -1477,19 +1428,28 @@
 					item: "minecraft:warped_fungus"
 				}
 			]
+			description: ["{the_beginning.nether_fungi.text.1_nether}"]
+			id: "02D7E339C4A7FF1F"
+			x: 6.0d
+			y: -1.0d
+			title: "{the_beginning.nether_fungi.title}"
+			subtitle: "{the_beginning.nether_fungi.subtitle_nether}"
+			dependencies: ["3AB25EAB4F16C5A5"]
+			min_required_tasks: 1
+			optional: true
 		}
 		{
+			size: 1.5d
+			id: "5CB1E23795D87A85"
+			min_required_dependencies: 1
 			x: 3.0d
 			y: -1.0d
 			shape: "hexagon"
-			subtitle: "You will need this later for Mechanical Age progression."
-			min_required_dependencies: 1
+			subtitle: "{the_beginning.shroomlight.subtitle}"
 			dependencies: [
 				"02D7E339C4A7FF1F"
 				"6DA2C8BFE79F273F"
 			]
-			size: 1.5d
-			id: "5CB1E23795D87A85"
 			tasks: [{
 				id: "3B4531A384C255F6"
 				type: "item"
@@ -1497,19 +1457,6 @@
 			}]
 		}
 		{
-			title: "Nether Fungi"
-			x: 3.0d
-			y: -2.5d
-			subtitle: "Obtain a Nether Fungus!"
-			description: [
-				"You can use Bone Meal on the Netherrack next to a Crimson/Warped Nylium to spread it to that Netherrack block."
-				""
-				"You can apply Bone Meal onto Crimson/Warped Nylium to get various Nether vegetation, including Nether fungi."
-			]
-			dependencies: ["43F6C6DF46FFB83F"]
-			optional: true
-			min_required_tasks: 1
-			id: "6DA2C8BFE79F273F"
 			tasks: [
 				{
 					id: "0D750B031DA6FA88"
@@ -1522,29 +1469,29 @@
 					item: "minecraft:warped_fungus"
 				}
 			]
+			description: ["{the_beginning.nether_fungi.text.1_mesh}"]
+			id: "6DA2C8BFE79F273F"
+			x: 3.0d
+			y: -2.5d
+			title: "{the_beginning.nether_fungi.title}"
+			subtitle: "{the_beginning.nether_fungi.subtitle_mesh}"
+			dependencies: ["43F6C6DF46FFB83F"]
+			min_required_tasks: 1
+			optional: true
 		}
 		{
-			title: "Those pesky arthopods!"
-			x: 4.0d
-			y: -8.5d
-			description: [
-				"You probably feared them at least once."
-				""
-				"Here, you need to kill those pesky Spiders to obtain some String."
-			]
-			min_required_dependencies: 1
-			dependencies: [
-				"357A6C703275C8F9"
-				"07C525ED6A1C8B22"
-			]
-			optional: true
-			id: "5BDA39AF551851EA"
 			tasks: [{
 				id: "76C0785D3ABB197C"
 				type: "kill"
 				entity: "minecraft:spider"
 				value: 5L
 			}]
+			description: ["{the_beginning.spiders.text.1}"]
+			min_required_dependencies: 1
+			id: "5BDA39AF551851EA"
+			x: 4.0d
+			y: -8.5d
+			title: "{the_beginning.spiders.title}"
 			rewards: [{
 				id: "3D9BDF957A41D8BC"
 				type: "item"
@@ -1552,11 +1499,7 @@
 					id: "tconstruct:dagger"
 					Count: 1b
 					tag: {
-						tic_multipliers: {
-							"tconstruct:mining_speed": 0.75f
-							"tconstruct:durability": 0.75f
-							"tconstruct:attack_damage": 0.65f
-						}
+						Damage: 0
 						tic_stats: {
 							"tconstruct:attack_damage": 3.7537498f
 							"tconstruct:harvest_tier": "minecraft:iron"
@@ -1564,7 +1507,11 @@
 							"tconstruct:mining_speed": 4.125f
 							"tconstruct:attack_speed": 2.0f
 						}
-						Damage: 0
+						tic_multipliers: {
+							"tconstruct:attack_damage": 0.65f
+							"tconstruct:mining_speed": 0.75f
+							"tconstruct:durability": 0.75f
+						}
 						tic_upgrades: [
 							{
 								name: "tconstruct:bane_of_sssss"
@@ -1623,14 +1570,14 @@
 					}
 				}
 			}]
+			subtitle: "{the_beginning.spiders.subtitle}"
+			dependencies: [
+				"357A6C703275C8F9"
+				"07C525ED6A1C8B22"
+			]
+			optional: true
 		}
 		{
-			title: "Saplings!"
-			x: 0.0d
-			y: -7.0d
-			subtitle: "Collect them all!"
-			dependencies: ["1F057C3C6AA5FD22"]
-			id: "1C4F6F5E175CD13B"
 			tasks: [
 				{
 					id: "42CA23DFD4C4664F"
@@ -1668,6 +1615,10 @@
 					item: "techreborn:rubber_sapling"
 				}
 			]
+			id: "1C4F6F5E175CD13B"
+			x: 0.0d
+			y: -7.0d
+			title: "{the_beginning.saplings.title}"
 			rewards: [
 				{
 					id: "0211DFB060E55A28"
@@ -1688,15 +1639,10 @@
 					table_id: 13756307348121783L
 				}
 			]
+			subtitle: "{the_beginning.saplings.subtitle}"
+			dependencies: ["1F057C3C6AA5FD22"]
 		}
 		{
-			title: "Driftwood"
-			x: 4.0d
-			y: -10.0d
-			subtitle: "You can sometimes fish up some Oak Logs, Oak Planks and Dirt."
-			dependencies: ["6D7B9D15C87A8C57"]
-			optional: true
-			id: "357A6C703275C8F9"
 			tasks: [
 				{
 					id: "76E38854366C6262"
@@ -1717,6 +1663,10 @@
 					count: 4L
 				}
 			]
+			id: "357A6C703275C8F9"
+			x: 4.0d
+			y: -10.0d
+			title: "{the_beginning.fishing_island.driftwood.title}"
 			rewards: [
 				{
 					id: "65B7ABC3DDA7E2FA"
@@ -1742,27 +1692,16 @@
 					table_id: 13756307348121783L
 				}
 			]
+			subtitle: "{the_beginning.fishing_island.driftwood.subtitle}"
+			dependencies: ["6D7B9D15C87A8C57"]
+			optional: true
 		}
 		{
-			title: "Am I a crook?"
-			x: 1.5d
-			y: -7.0d
-			subtitle: "No Sapling yet?"
-			description: [
-				"By sieving Dirt, you can finally get a Sapling."
-				""
-				"Break leaves using Crooks to get Silkworms. You will also get more saplings than you would get by breaking by hand!"
-			]
-			min_required_dependencies: 2
-			dependencies: [
-				"329CC4079DB5DABE"
-				"7849BD01ACBFAC3A"
-				"1F057C3C6AA5FD22"
-			]
-			hide: true
-			optional: true
 			incompatible: ["3AC0329506E80AA4"]
-			id: "5B5416C89BAB64DC"
+			min_required_dependencies: 2
+			x: 1.5d
+			subtitle: "{the_beginning.crook2.subtitle}"
+			optional: true
 			tasks: [
 				{
 					id: "7EDD8B7A7D8D38AB"
@@ -1782,6 +1721,14 @@
 					count: 16L
 				}
 			]
+			description: [
+				"{the_beginning.crook2.text.1}"
+				""
+				"{the_beginning.crook2.text.2}"
+			]
+			id: "5B5416C89BAB64DC"
+			y: -7.0d
+			title: "{the_beginning.crook2.title}"
 			rewards: [{
 				id: "4A4633315E69BE00"
 				type: "item"
@@ -1793,41 +1740,36 @@
 					}
 				}
 			}]
+			dependencies: [
+				"329CC4079DB5DABE"
+				"7849BD01ACBFAC3A"
+				"1F057C3C6AA5FD22"
+			]
+			hide: true
 		}
 		{
-			title: "Spooky Scary Skeletons"
-			x: 5.5d
-			y: -8.5d
-			subtitle: "You need something harder than elastic bamboo."
-			description: ["You will need some Bones for the Bone Crucible."]
-			dependencies: ["07C525ED6A1C8B22"]
-			optional: true
-			id: "4B15A50AD9828B4C"
 			tasks: [{
 				id: "44D12DEA0F77F01C"
 				type: "kill"
 				entity: "minecraft:skeleton"
 				value: 5L
 			}]
+			description: ["{the_beginning.bamboo_island.skeletons.text.1}"]
+			id: "4B15A50AD9828B4C"
+			x: 5.5d
+			y: -8.5d
+			title: "{the_beginning.bamboo_island.skeletons.title}"
 			rewards: [{
 				id: "3BD7F2658434F743"
 				type: "item"
 				item: "minecraft:bone_block"
 				count: 2
 			}]
+			subtitle: "{the_beginning.bamboo_island.skeletons.subtitle}"
+			dependencies: ["07C525ED6A1C8B22"]
+			optional: true
 		}
 		{
-			x: 8.5d
-			y: -8.5d
-			subtitle: "Suprisingly, Bone Crucible can't hold lava."
-			description: [
-				"But nevertheless, you can use some of your Bamboo Leaves to make water."
-				""
-				"To make a Bone Crucible, Right-Click on a Bone Block with a Bone Knife in hand."
-			]
-			dependencies: ["01041F039FFA6116"]
-			optional: true
-			id: "5502B4F2C6D7AEBD"
 			tasks: [
 				{
 					id: "2E43C772FA202E01"
@@ -1840,22 +1782,24 @@
 					item: "kibe:wooden_bucket"
 				}
 			]
+			description: [
+				"{the_beginning.bamboo_island.water.text.1}"
+				""
+				"{the_beginning.bamboo_island.water.text.2}"
+			]
+			id: "5502B4F2C6D7AEBD"
+			x: 8.5d
+			y: -8.5d
 			rewards: [{
 				id: "04E226EC389B5FD2"
 				type: "item"
 				item: "kibe:water_wooden_bucket"
 			}]
+			subtitle: "{the_beginning.bamboo_island.water.subtitle}"
+			dependencies: ["01041F039FFA6116"]
+			optional: true
 		}
 		{
-			title: "Crafting"
-			x: -1.5d
-			y: -11.5d
-			subtitle: "Necessary to craft 3x3 recipes."
-			description: ["Crafting Stations can hold items inside, and can utilize items from the inventory next to it!"]
-			dependencies: ["6D9CF1D77D05C2D4"]
-			hide: true
-			optional: true
-			id: "36E40D909C6AA3EC"
 			tasks: [
 				{
 					id: "298018EC28C9637C"
@@ -1873,51 +1817,53 @@
 					match_nbt: false
 				}
 			]
+			description: ["{the_beginning.crafting.text.1}"]
+			id: "36E40D909C6AA3EC"
+			x: -1.5d
+			y: -11.5d
+			title: "{the_beginning.crafting.title}"
 			rewards: [{
 				id: "5CABD60033F350EC"
 				type: "item"
 				item: "minecraft:stick"
 				count: 16
 			}]
+			subtitle: "{the_beginning.crafting.subtitle}"
+			dependencies: ["6D9CF1D77D05C2D4"]
+			optional: true
+			hide: true
 		}
 		{
-			x: 4.5d
-			y: -2.5d
-			subtitle: "A barrel made out of solid stone."
-			description: [
-				"This barrel can withstand lava!"
-				""
-				"You will surely find it useful when automating Obsidian or Stone."
-			]
-			dependencies: ["0B87D8D5CC3AF30D"]
-			id: "5C8FB8F9E44FFE55"
 			tasks: [{
 				id: "2A62C3281D7C30BC"
 				type: "item"
 				item: "fabricaeexnihilo:stone_barrel"
 			}]
+			description: [
+				"{the_beginning.stone_barrel.text.1}"
+				""
+				"{the_beginning.stone_barrel.text.2}"
+			]
+			id: "5C8FB8F9E44FFE55"
+			x: 4.5d
+			y: -2.5d
+			subtitle: "{the_beginning.stone_barrel.subtitle}"
+			dependencies: ["0B87D8D5CC3AF30D"]
 		}
 		{
-			x: 7.0d
-			y: -13.0d
-			subtitle: "You will need some Stripped Bamboo for making barrels and sieves."
-			dependencies: ["4F5F0B705FCB602F"]
-			optional: true
-			id: "33881CD4182D25C1"
 			tasks: [{
 				id: "501FAE2B5F222516"
 				type: "item"
 				item: "twigs:stripped_bamboo"
 			}]
+			id: "33881CD4182D25C1"
+			x: 7.0d
+			y: -13.0d
+			subtitle: "{the_beginning.bamboo_island.stripped_bamboo.subtitle}"
+			dependencies: ["4F5F0B705FCB602F"]
+			optional: true
 		}
 		{
-			title: "Tiki Barrel"
-			x: 8.5d
-			y: -13.0d
-			description: ["You farmed so much compost, why not use some to obtain more Dirt?"]
-			dependencies: ["33881CD4182D25C1"]
-			optional: true
-			id: "600ED0945BC3C5F8"
 			tasks: [
 				{
 					id: "6D1DB99457A5A025"
@@ -1931,20 +1877,21 @@
 					count: 4L
 				}
 			]
+			description: ["You farmed so much compost, why not use some to obtain more Dirt?"]
+			id: "600ED0945BC3C5F8"
+			x: 8.5d
+			y: -13.0d
+			title: "Tiki Barrel"
 			rewards: [{
 				id: "53C16FEE15E4ADD2"
 				type: "item"
 				item: "mcwlights:bamboo_tiki_torch"
 				count: 64
 			}]
+			dependencies: ["33881CD4182D25C1"]
+			optional: true
 		}
 		{
-			x: 5.5d
-			y: -11.5d
-			dependencies: ["07C525ED6A1C8B22"]
-			optional: true
-			min_required_tasks: 1
-			id: "69E4F9F9ED4EB259"
 			tasks: [
 				{
 					id: "288F0FE2DA859050"
@@ -1962,42 +1909,41 @@
 					match_nbt: false
 				}
 			]
+			description: ["{the_beginning.crafting.text.1}"]
+			id: "69E4F9F9ED4EB259"
+			x: 5.5d
+			y: -11.5d
+			title: "{the_beginning.crafting.title}"
 			rewards: [{
 				id: "27ECAD6E9F23E1C1"
 				type: "item"
 				item: "minecraft:bamboo"
 				count: 32
 			}]
+			subtitle: "{the_beginning.crafting.subtitle}"
+			dependencies: ["07C525ED6A1C8B22"]
+			min_required_tasks: 1
+			optional: true
 		}
 		{
-			title: "Early Automation"
-			x: 8.5d
-			y: -11.5d
-			dependencies: ["600ED0945BC3C5F8"]
-			optional: true
-			id: "334A9C425F38F44E"
 			tasks: [{
 				id: "54BB666089C59717"
 				type: "item"
 				item: "coxinhautilities:wooden_hopper"
 			}]
+			id: "334A9C425F38F44E"
+			x: 8.5d
+			y: -11.5d
+			title: "{the_beginning.wooden_hopper.title}"
 			rewards: [{
 				id: "0953C826B90897C4"
 				type: "item"
 				item: "coxinhautilities:wooden_hopper"
 			}]
+			dependencies: ["600ED0945BC3C5F8"]
+			optional: true
 		}
 		{
-			x: 7.0d
-			y: -8.5d
-			subtitle: "A carving tool."
-			description: [
-				"The Bone Knife can be used to carve out a Crucible from a Bone Block."
-				""
-				"It can also be used as a rudimentary weapon."
-			]
-			dependencies: ["4B15A50AD9828B4C"]
-			id: "01041F039FFA6116"
 			tasks: [{
 				id: "408868EB051FB2B0"
 				type: "item"
@@ -2009,33 +1955,40 @@
 					}
 				}
 			}]
+			description: [
+				"{the_beginning.bamboo_island.bone_knife.text.1}"
+				""
+				"{the_beginning.bamboo_island.bone_knife.text.2}"
+			]
+			id: "01041F039FFA6116"
+			x: 7.0d
+			y: -8.5d
+			subtitle: "{the_beginning.bamboo_island.bone_knife.subtitle}"
+			dependencies: ["4B15A50AD9828B4C"]
 		}
 		{
-			x: -1.5d
-			y: -5.5d
-			subtitle: "You will need some Nether Quartz for your next mesh."
-			description: [
-				"It can be obtained by sieving Soul Sand through a Flint Mesh."
-				""
-				"But how do you get Soul Sand?"
-				""
-				"The answer is: Witchwater!"
-			]
-			dependencies: ["1F057C3C6AA5FD22"]
-			id: "63A774E246F91DB1"
 			tasks: [{
 				id: "148D892C95260DC2"
 				type: "item"
 				item: "minecraft:quartz"
 				count: 2L
 			}]
+			description: [
+				"{the_beginning.quartz.text.1}"
+				""
+				"{the_beginning.quartz.text.2}"
+			]
+			id: "63A774E246F91DB1"
+			x: -1.5d
+			y: -5.5d
 			rewards: [{
 				id: "56FC12BBC617F56D"
 				type: "item"
 				item: "minecraft:soul_sand"
 				count: 8
 			}]
+			subtitle: "{the_beginning.quartz.subtitle}"
+			dependencies: ["1F057C3C6AA5FD22"]
 		}
 	]
-	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/tools_and_armor.snbt
+++ b/config/ftbquests/quests/chapters/tools_and_armor.snbt
@@ -1,22 +1,15 @@
 {
-	id: "101875ABBA9AC7E6"
-	group: "76C22988F9A7C9CE"
-	order_index: 2
-	filename: "tools_and_armor"
-	title: "Tools and Armor"
-	icon: "minecraft:smithing_table"
-	default_quest_shape: ""
+	quest_links: [ ]
 	default_hide_dependency_lines: false
+	group: "76C22988F9A7C9CE"
+	id: "101875ABBA9AC7E6"
+	filename: "tools_and_armor"
+	default_quest_shape: ""
+	icon: "minecraft:smithing_table"
+	title: "Tools and Armor"
+	order_index: 2
 	quests: [
 		{
-			icon: "xps:block_xp_obelisk"
-			x: 2.0d
-			y: -6.0d
-			subtitle: "Enchanting Efficiency"
-			description: ["If you did not know by now that as you level up you waste more and more experince points when enchanting. So instead of wasting experince why not store it in this handy container!"]
-			dependencies: ["25B6D9950B1CF03C"]
-			hide: true
-			id: "73C866780EE5AD4F"
 			tasks: [
 				{
 					id: "61327AB9EC4286FA"
@@ -29,13 +22,18 @@
 					item: "xps:xp_remover"
 				}
 			]
+			description: ["If you did not know by now that as you level up you waste more and more experince points when enchanting. So instead of wasting experince why not store it in this handy container!"]
+			id: "73C866780EE5AD4F"
+			icon: "xps:block_xp_obelisk"
+			x: 2.0d
+			y: -6.0d
 			rewards: [
 				{
-					id: "13B854E24202DC9B"
 					type: "item"
-					item: "minecraft:experience_bottle"
 					count: 2
+					id: "13B854E24202DC9B"
 					random_bonus: 8
+					item: "minecraft:experience_bottle"
 				}
 				{
 					id: "43C8934A031D887A"
@@ -43,24 +41,27 @@
 					table_id: 13756307348121783L
 				}
 			]
+			subtitle: "Enchanting Efficiency"
+			dependencies: ["25B6D9950B1CF03C"]
+			hide: true
 		}
 		{
-			x: -2.0d
-			y: -6.0d
-			subtitle: "Everlasting Longevity!"
-			description: ["The Dragon anvil works exactly like a normal anvil, but it never breaks, has no level cap, and won't ask you for more than 30 levels of experience."]
-			dependencies: ["25B6D9950B1CF03C"]
-			id: "1C8C22D89ACF248F"
 			tasks: [{
 				id: "4B884C1DFE863714"
 				type: "item"
 				item: "dragonloot:dragon_anvil"
 			}]
+			description: ["The Dragon anvil works exactly like a normal anvil, but it never breaks, has no level cap, and won't ask you for more than 30 levels of experience."]
+			id: "1C8C22D89ACF248F"
+			x: -2.0d
+			y: -6.0d
 			rewards: [{
 				id: "035CB53BF5171058"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Everlasting Longevity!"
+			dependencies: ["25B6D9950B1CF03C"]
 		}
 		{
 			x: 0.0d
@@ -83,13 +84,6 @@
 			}]
 		}
 		{
-			title: "Armory of Dragon"
-			x: -8.5d
-			y: -2.5d
-			subtitle: "Harness the true strength of a dragon."
-			description: ["Scales are dropped by killing the Ender Dragon."]
-			dependencies: ["35F0E2CEEE9D9AD0"]
-			id: "4E2C7A0B42F4588F"
 			tasks: [
 				{
 					id: "1F47057584B43E88"
@@ -136,19 +130,20 @@
 					}
 				}
 			]
+			description: ["Scales are dropped by killing the Ender Dragon."]
+			id: "4E2C7A0B42F4588F"
+			x: -8.5d
+			y: -2.5d
+			title: "Armory of Dragon"
 			rewards: [{
 				id: "69CDBCABE68FDF40"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Harness the true strength of a dragon."
+			dependencies: ["35F0E2CEEE9D9AD0"]
 		}
 		{
-			title: "Manasteel Armory"
-			x: -8.5d
-			y: 2.5d
-			subtitle: "Made out of Iron and Mana."
-			dependencies: ["35F0E2CEEE9D9AD0"]
-			id: "69EF6FE796539675"
 			tasks: [
 				{
 					id: "384F8EE2142E565A"
@@ -195,26 +190,19 @@
 					}
 				}
 			]
+			id: "69EF6FE796539675"
+			x: -8.5d
+			y: 2.5d
+			title: "Manasteel Armory"
 			rewards: [{
 				id: "51556E56CCF7AA44"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Made out of Iron and Mana."
+			dependencies: ["35F0E2CEEE9D9AD0"]
 		}
 		{
-			title: "Elementium Armory"
-			x: -7.0d
-			y: 2.5d
-			subtitle: "Made in the Portal to Alfheim."
-			description: [
-				"If the player is wearing a complete set of Elementium armor, they will gain the Great Fairy's Blessing set bonus:"
-				""
-				"> 10% decrease of the Mana cost on all Mana-using tools and rods,"
-				""
-				"> Pixies spawned by the wearer will inflict a random potion effect for 2 seconds: either Blindness, Wither, Slowness or Weakness."
-			]
-			dependencies: ["35F0E2CEEE9D9AD0"]
-			id: "0A0EE0B8F2CF1840"
 			tasks: [
 				{
 					id: "6443CB4EA4556356"
@@ -261,30 +249,26 @@
 					}
 				}
 			]
+			description: [
+				"If the player is wearing a complete set of Elementium armor, they will gain the Great Fairy's Blessing set bonus:"
+				""
+				"> 10% decrease of the Mana cost on all Mana-using tools and rods,"
+				""
+				"> Pixies spawned by the wearer will inflict a random potion effect for 2 seconds: either Blindness, Wither, Slowness or Weakness."
+			]
+			id: "0A0EE0B8F2CF1840"
+			x: -7.0d
+			y: 2.5d
+			title: "Elementium Armory"
 			rewards: [{
 				id: "01632EDA2F2B9CCD"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Made in the Portal to Alfheim."
+			dependencies: ["35F0E2CEEE9D9AD0"]
 		}
 		{
-			title: "Terrasteel Armory"
-			x: -5.5d
-			y: 2.5d
-			subtitle: "Made via an infusion ritual."
-			description: [
-				"If the player is wearing a complete set of Terrasteel armor, they will gain the Will of the Ancients set bonus:"
-				""
-				"> Passive generation of 1 Mana per tick."
-				""
-				"> 20% decrease of Mana cost on all Mana-using tools and rods."
-				""
-				"> Passive regeneration of 2 health every 4 seconds even if their hunger bar isn't full."
-				""
-				"> Effects of all Wills applied to the worn Terrasteel Helmet."
-			]
-			dependencies: ["35F0E2CEEE9D9AD0"]
-			id: "7E9CEA24C62A5EB5"
 			tasks: [
 				{
 					id: "5AC1B88EE4805986"
@@ -331,26 +315,30 @@
 					}
 				}
 			]
+			description: [
+				"If the player is wearing a complete set of Terrasteel armor, they will gain the Will of the Ancients set bonus:"
+				""
+				"> Passive generation of 1 Mana per tick."
+				""
+				"> 20% decrease of Mana cost on all Mana-using tools and rods."
+				""
+				"> Passive regeneration of 2 health every 4 seconds even if their hunger bar isn't full."
+				""
+				"> Effects of all Wills applied to the worn Terrasteel Helmet."
+			]
+			id: "7E9CEA24C62A5EB5"
+			x: -5.5d
+			y: 2.5d
+			title: "Terrasteel Armory"
 			rewards: [{
 				id: "37CB5420A6EEBFFB"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Made via an infusion ritual."
+			dependencies: ["35F0E2CEEE9D9AD0"]
 		}
 		{
-			title: "Gilded Netherite"
-			x: -7.0d
-			y: -2.5d
-			subtitle: "More durable than the netherite set and has a full set ability."
-			description: [
-				"The Gilded Netherite Armor is the upgraded netherite armor with a gilded netherite fragment."
-				""
-				"If the player wears all four parts of the armor, they'll be able to press default key “v” to activate the armor indicated by a glowing red layer on the armor."
-				""
-				"It will grant fire resistance, less receiving damage and lasts for 1 minute indicated by a small fire resistance symbol above the experience level symbol."
-			]
-			dependencies: ["35F0E2CEEE9D9AD0"]
-			id: "1F084E4BED012340"
 			tasks: [
 				{
 					id: "242FF6C3451B028C"
@@ -397,29 +385,26 @@
 					}
 				}
 			]
+			description: [
+				"The Gilded Netherite Armor is the upgraded netherite armor with a gilded netherite fragment."
+				""
+				"If the player wears all four parts of the armor, they'll be able to press default key “v” to activate the armor indicated by a glowing red layer on the armor."
+				""
+				"It will grant fire resistance, less receiving damage and lasts for 1 minute indicated by a small fire resistance symbol above the experience level symbol."
+			]
+			id: "1F084E4BED012340"
+			x: -7.0d
+			y: -2.5d
+			title: "Gilded Netherite"
 			rewards: [{
 				id: "630E5AD5921851B6"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "More durable than the netherite set and has a full set ability."
+			dependencies: ["35F0E2CEEE9D9AD0"]
 		}
 		{
-			title: "Armory of the Glitch"
-			x: -5.5d
-			y: -2.5d
-			description: [
-				"Barely crafted Glitch Armor pieces are pretty good, but they can be better tho. If you got some extra Pristine Matter you can try using it to upgrade your armor. For this you will need to condense the matter into the armor using a Matter Condenser."
-				""
-				"If you attempt to put a bound Data Model into a piece of armor you will be able to \"inherit\" some effects of the mobs of the category you choose."
-				""
-				"To do that, just get an armor piece in hands and right click, putting a Data Model into the slot."
-				""
-				"The greater the tier of your armor, the greatest the effects you will be gifted with."
-				""
-				"As you use the abilities, the installed Data Models will lose their data, so check regularly if they need recharging."
-			]
-			dependencies: ["35F0E2CEEE9D9AD0"]
-			id: "3D26E1D59C05685A"
 			tasks: [
 				{
 					id: "17A3FB85D4D0BA93"
@@ -458,6 +443,21 @@
 					}
 				}
 			]
+			description: [
+				"Barely crafted Glitch Armor pieces are pretty good, but they can be better tho. If you got some extra Pristine Matter you can try using it to upgrade your armor. For this you will need to condense the matter into the armor using a Matter Condenser."
+				""
+				"If you attempt to put a bound Data Model into a piece of armor you will be able to \"inherit\" some effects of the mobs of the category you choose."
+				""
+				"To do that, just get an armor piece in hands and right click, putting a Data Model into the slot."
+				""
+				"The greater the tier of your armor, the greatest the effects you will be gifted with."
+				""
+				"As you use the abilities, the installed Data Models will lose their data, so check regularly if they need recharging."
+			]
+			id: "3D26E1D59C05685A"
+			x: -5.5d
+			y: -2.5d
+			title: "Armory of the Glitch"
 			rewards: [
 				{
 					id: "3AC2C2A97116746C"
@@ -470,30 +470,9 @@
 					table_id: 13756307348121783L
 				}
 			]
+			dependencies: ["35F0E2CEEE9D9AD0"]
 		}
 		{
-			title: "Quantum Armory"
-			x: -9.5d
-			y: 0.0d
-			subtitle: "Quantum Supremacy!"
-			description: [
-				"The Quantum Helmet will provide you with infinite Water Breathing while in water."
-				""
-				"The Quantum Chestplate enables Creative flight with inertia cancellation."
-				"Also greatly increases mobility while midair."
-				"The Chestplate also gives immunity to fire."
-				""
-				"The Quantum Leggings give you an insane speed boost."
-				""
-				"The Quantum Boots, when paired with the Quantum Chestplate, gives you infinite midair jumps."
-				"They also increase swimming speed."
-				""
-				"Each piece of Quantum Armor will block 20% of damage at the cost of energy (up to 80% for a full set)."
-				""
-				"This blocking is applied before damage reductions due to armor points and Protection enchantments."
-			]
-			dependencies: ["35F0E2CEEE9D9AD0"]
-			id: "44A2231617CD5156"
 			tasks: [
 				{
 					id: "6D0C751FE61EBB13"
@@ -516,24 +495,35 @@
 					item: "techreborn:quantum_boots"
 				}
 			]
+			description: [
+				"The Quantum Helmet will provide you with infinite Water Breathing while in water."
+				""
+				"The Quantum Chestplate enables Creative flight with inertia cancellation."
+				"Also greatly increases mobility while midair."
+				"The Chestplate also gives immunity to fire."
+				""
+				"The Quantum Leggings give you an insane speed boost."
+				""
+				"The Quantum Boots, when paired with the Quantum Chestplate, gives you infinite midair jumps."
+				"They also increase swimming speed."
+				""
+				"Each piece of Quantum Armor will block 20% of damage at the cost of energy (up to 80% for a full set)."
+				""
+				"This blocking is applied before damage reductions due to armor points and Protection enchantments."
+			]
+			id: "44A2231617CD5156"
+			x: -9.5d
+			y: 0.0d
+			title: "Quantum Armory"
 			rewards: [{
 				id: "7EC607B1862772A0"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Quantum Supremacy!"
+			dependencies: ["35F0E2CEEE9D9AD0"]
 		}
 		{
-			title: "Modular Armory"
-			x: -4.5d
-			y: 0.0d
-			subtitle: "Smash modules on it!"
-			description: [
-				"The Modular Armor is, on it's own, not much, but when you install modules, it can become very powerful!"
-				""
-				"Notice that installing modules cost time and some energy!"
-			]
-			dependencies: ["35F0E2CEEE9D9AD0"]
-			id: "415E816A49301DC2"
 			tasks: [
 				{
 					id: "5E654EBB4577464B"
@@ -556,11 +546,22 @@
 					item: "indrev:modular_armor_boots"
 				}
 			]
+			description: [
+				"The Modular Armor is, on it's own, not much, but when you install modules, it can become very powerful!"
+				""
+				"Notice that installing modules cost time and some energy!"
+			]
+			id: "415E816A49301DC2"
+			x: -4.5d
+			y: 0.0d
+			title: "Modular Armory"
 			rewards: [{
 				id: "37391EE292E7F2CE"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Smash modules on it!"
+			dependencies: ["35F0E2CEEE9D9AD0"]
 		}
 		{
 			x: 0.0d
@@ -573,18 +574,6 @@
 			}]
 		}
 		{
-			title: "Basic Tools"
-			x: -0.5d
-			y: 2.0d
-			description: [
-				"Drill could be used as a replacement for Iron Pickaxe and Iron Shovel. It will cost 50 Energy to break one block."
-				""
-				"Chainsaw could be used as a replacement for Iron Axe. It will cost 50 Energy to break one block."
-				""
-				"Rock Cutter is a Diamond like tool with Silk Touch enchantment. It has 10k Energy storage. It uses Energy instead of durability to break a block. It will cost 10 Energy to break one block."
-			]
-			dependencies: ["300FAC6161C1BCDB"]
-			id: "2C428C61C56220CD"
 			tasks: [
 				{
 					id: "54835ABF40DD9BCE"
@@ -602,25 +591,25 @@
 					item: "techreborn:basic_jackhammer"
 				}
 			]
+			description: [
+				"Drill could be used as a replacement for Iron Pickaxe and Iron Shovel. It will cost 50 Energy to break one block."
+				""
+				"Chainsaw could be used as a replacement for Iron Axe. It will cost 50 Energy to break one block."
+				""
+				"Rock Cutter is a Diamond like tool with Silk Touch enchantment. It has 10k Energy storage. It uses Energy instead of durability to break a block. It will cost 10 Energy to break one block."
+			]
+			id: "2C428C61C56220CD"
+			x: -0.5d
+			y: 2.0d
+			title: "Basic Tools"
 			rewards: [{
 				id: "72B780EB3014047A"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["300FAC6161C1BCDB"]
 		}
 		{
-			title: "Advanced Tools"
-			x: 0.5d
-			y: 2.0d
-			description: [
-				"Advanced Drill is an advanced version of Basic Drill and works same as Diamond Pickaxe or Diamond Shovel."
-				""
-				"Advanced Chainsaw is a more advanced chainsaw compare to Basic Chainsaw."
-				""
-				"Advanced Jackhammer is a more advanced version of Basic Jackhammer. Advanced Jackhammer is capable of 3×3 mining when set to active."
-			]
-			dependencies: ["300FAC6161C1BCDB"]
-			id: "5BC9A2F404AD73B7"
 			tasks: [
 				{
 					id: "0C330A4FB95CF932"
@@ -638,25 +627,25 @@
 					item: "techreborn:advanced_jackhammer"
 				}
 			]
+			description: [
+				"Advanced Drill is an advanced version of Basic Drill and works same as Diamond Pickaxe or Diamond Shovel."
+				""
+				"Advanced Chainsaw is a more advanced chainsaw compare to Basic Chainsaw."
+				""
+				"Advanced Jackhammer is a more advanced version of Basic Jackhammer. Advanced Jackhammer is capable of 3×3 mining when set to active."
+			]
+			id: "5BC9A2F404AD73B7"
+			x: 0.5d
+			y: 2.0d
+			title: "Advanced Tools"
 			rewards: [{
 				id: "33DC906472FAE529"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["300FAC6161C1BCDB"]
 		}
 		{
-			title: "Industrial Tools"
-			x: 1.5d
-			y: 2.0d
-			description: [
-				"Industrial Drill is a most powerfull drill. It can do AOE mining in 3×3 area. It has 1.000.000 Energy storage. "
-				""
-				"Industrial Chainsaw is a top tier chainsaw.  It has 1M Energy storage. Chainsaw could be used as a replacement for Diamond Axe and able to chop down whole tree at once. It will cost 150 Energy to break one block."
-				""
-				"Industrial Jackhammer is a top tier JackHammer.  It has 1M energy storage.  Industrial Jackhammer is capable of 3×3 and 5×5 AoE mining when set to active. It will cost 150 energy to break one block."
-			]
-			dependencies: ["300FAC6161C1BCDB"]
-			id: "574F9D5B42852567"
 			tasks: [
 				{
 					id: "6C643470AFDDBCA8"
@@ -674,18 +663,25 @@
 					item: "techreborn:industrial_jackhammer"
 				}
 			]
+			description: [
+				"Industrial Drill is a most powerfull drill. It can do AOE mining in 3×3 area. It has 1.000.000 Energy storage. "
+				""
+				"Industrial Chainsaw is a top tier chainsaw.  It has 1M Energy storage. Chainsaw could be used as a replacement for Diamond Axe and able to chop down whole tree at once. It will cost 150 Energy to break one block."
+				""
+				"Industrial Jackhammer is a top tier JackHammer.  It has 1M energy storage.  Industrial Jackhammer is capable of 3×3 and 5×5 AoE mining when set to active. It will cost 150 energy to break one block."
+			]
+			id: "574F9D5B42852567"
+			x: 1.5d
+			y: 2.0d
+			title: "Industrial Tools"
 			rewards: [{
 				id: "532DEA11B98EE9F0"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["300FAC6161C1BCDB"]
 		}
 		{
-			title: "Mining Drills"
-			x: -1.5d
-			y: 2.0d
-			dependencies: ["300FAC6161C1BCDB"]
-			id: "2206B744E74F22FF"
 			tasks: [
 				{
 					id: "6CE5BD1D97182281"
@@ -708,19 +704,18 @@
 					item: "indrev:mining_drill_mk4"
 				}
 			]
+			id: "2206B744E74F22FF"
+			x: -1.5d
+			y: 2.0d
+			title: "Mining Drills"
 			rewards: [{
 				id: "12F11855EC173355"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["300FAC6161C1BCDB"]
 		}
 		{
-			title: "Jetpacks"
-			x: -3.0d
-			y: 0.5d
-			subtitle: "Past the Statue of Liberty!"
-			dependencies: ["300FAC6161C1BCDB"]
-			id: "331F2D904BCAC94E"
 			tasks: [
 				{
 					id: "135C91EEEB100021"
@@ -758,42 +753,41 @@
 					item: "iron-jetpacks:neutronium_jetpack"
 				}
 			]
+			id: "331F2D904BCAC94E"
+			x: -3.0d
+			y: 0.5d
+			title: "Jetpacks"
 			rewards: [{
 				id: "4C673681B9E22C79"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Past the Statue of Liberty!"
+			dependencies: ["300FAC6161C1BCDB"]
 		}
 		{
-			x: 3.0d
-			y: 0.0d
-			subtitle: "Universal tool that combines Pickaxe, Axe, Shovel, Shears and even Sword in one simple rod."
-			description: [
-				"It's mining level on par with diamond made tools. One mined block will cost 100 Energy and it will use 125 Energy on entity hit."
-				""
-				"Also effective on some \"no tool\" blocks, such as Tech Reborn machines and glass."
-			]
-			dependencies: ["300FAC6161C1BCDB"]
-			id: "6974C60B6461BD04"
 			tasks: [{
 				id: "3188B4D5D16B9220"
 				type: "item"
 				item: "techreborn:omni_tool"
 			}]
+			description: [
+				"It's mining level on par with diamond made tools. One mined block will cost 100 Energy and it will use 125 Energy on entity hit."
+				""
+				"Also effective on some \"no tool\" blocks, such as Tech Reborn machines and glass."
+			]
+			id: "6974C60B6461BD04"
+			x: 3.0d
+			y: 0.0d
 			rewards: [{
 				id: "402352C937118C23"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Universal tool that combines Pickaxe, Axe, Shovel, Shears and even Sword in one simple rod."
+			dependencies: ["300FAC6161C1BCDB"]
 		}
 		{
-			title: "Tools of Dragon"
-			x: -2.0d
-			y: -2.0d
-			subtitle: "Harness the true strength of a dragon."
-			description: ["Scales are dropped by killing the Ender Dragon."]
-			dependencies: ["300FAC6161C1BCDB"]
-			id: "19CD33E3BCCBC283"
 			tasks: [
 				{
 					id: "48BEF1026E46FEFC"
@@ -840,19 +834,20 @@
 					}
 				}
 			]
+			description: ["Scales are dropped by killing the Ender Dragon."]
+			id: "19CD33E3BCCBC283"
+			x: -2.0d
+			y: -2.0d
+			title: "Tools of Dragon"
 			rewards: [{
 				id: "2DE7BD26E36F3A1F"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Harness the true strength of a dragon."
+			dependencies: ["300FAC6161C1BCDB"]
 		}
 		{
-			title: "Gilded Tools"
-			x: -1.0d
-			y: -2.0d
-			subtitle: "Obtain it by bartering with piglins!"
-			dependencies: ["300FAC6161C1BCDB"]
-			id: "048BE9D4C85EC290"
 			tasks: [
 				{
 					id: "2A77CC1F62A3C320"
@@ -899,19 +894,19 @@
 					}
 				}
 			]
+			id: "048BE9D4C85EC290"
+			x: -1.0d
+			y: -2.0d
+			title: "Gilded Tools"
 			rewards: [{
 				id: "220407AB0C3F1D36"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Obtain it by bartering with piglins!"
+			dependencies: ["300FAC6161C1BCDB"]
 		}
 		{
-			title: "Manasteel Tools"
-			x: 0.0d
-			y: -2.0d
-			description: ["They have a special property - they will repair themselves using Mana!"]
-			dependencies: ["300FAC6161C1BCDB"]
-			id: "1812006D3BD67F42"
 			tasks: [
 				{
 					id: "78AE4A2866D42033"
@@ -958,28 +953,19 @@
 					}
 				}
 			]
+			description: ["They have a special property - they will repair themselves using Mana!"]
+			id: "1812006D3BD67F42"
+			x: 0.0d
+			y: -2.0d
+			title: "Manasteel Tools"
 			rewards: [{
 				id: "23BED71423A959F9"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["300FAC6161C1BCDB"]
 		}
 		{
-			title: "Elementium Tools"
-			x: 1.0d
-			y: -2.0d
-			description: [
-				"Elementium Pickaxe voids all common materials (like Stone, Dirt, Netherrack)."
-				""
-				"Elementium Shovel, if breaking a block that can fall, like Sand or Gravel, it will break all of those blocks above."
-				""
-				"Elementium Axe sometimes can behead enemies that this weapon finishes."
-				"Can be enchanted with Looting to increase the chance for a head drop."
-				""
-				"Elementium Hoe will immediately hydrate any tilled soil."
-			]
-			dependencies: ["300FAC6161C1BCDB"]
-			id: "491D1CA466F8BEE7"
 			tasks: [
 				{
 					id: "1B7C87583404D823"
@@ -1026,11 +1012,26 @@
 					}
 				}
 			]
+			description: [
+				"Elementium Pickaxe voids all common materials (like Stone, Dirt, Netherrack)."
+				""
+				"Elementium Shovel, if breaking a block that can fall, like Sand or Gravel, it will break all of those blocks above."
+				""
+				"Elementium Axe sometimes can behead enemies that this weapon finishes."
+				"Can be enchanted with Looting to increase the chance for a head drop."
+				""
+				"Elementium Hoe will immediately hydrate any tilled soil."
+			]
+			id: "491D1CA466F8BEE7"
+			x: 1.0d
+			y: -2.0d
+			title: "Elementium Tools"
 			rewards: [{
 				id: "1431C8A6BA1B44BB"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["300FAC6161C1BCDB"]
 		}
 		{
 			x: 6.5d
@@ -1043,10 +1044,6 @@
 			}]
 		}
 		{
-			x: 4.5d
-			y: -2.5d
-			dependencies: ["5EA2D6174BCFEC05"]
-			id: "43393B11001E56DC"
 			tasks: [{
 				id: "79B14536D0076591"
 				type: "item"
@@ -1058,6 +1055,10 @@
 					}
 				}
 			}]
+			dependencies: ["5EA2D6174BCFEC05"]
+			id: "43393B11001E56DC"
+			y: -2.5d
+			x: 4.5d
 			rewards: [{
 				id: "2C524BDB6795F924"
 				type: "random"
@@ -1065,10 +1066,6 @@
 			}]
 		}
 		{
-			x: 5.5d
-			y: -2.5d
-			dependencies: ["5EA2D6174BCFEC05"]
-			id: "481475646B5351CA"
 			tasks: [{
 				id: "4DF242C8F4DC1856"
 				type: "item"
@@ -1080,6 +1077,10 @@
 					}
 				}
 			}]
+			dependencies: ["5EA2D6174BCFEC05"]
+			id: "481475646B5351CA"
+			y: -2.5d
+			x: 5.5d
 			rewards: [{
 				id: "31A6A3A976141EBE"
 				type: "random"
@@ -1087,10 +1088,6 @@
 			}]
 		}
 		{
-			x: 6.5d
-			y: -2.5d
-			dependencies: ["5EA2D6174BCFEC05"]
-			id: "7CE1E91CE65BEEB1"
 			tasks: [{
 				id: "5C2A939D465B1339"
 				type: "item"
@@ -1102,6 +1099,10 @@
 					}
 				}
 			}]
+			dependencies: ["5EA2D6174BCFEC05"]
+			id: "7CE1E91CE65BEEB1"
+			y: -2.5d
+			x: 6.5d
 			rewards: [{
 				id: "7838C8AA9508DE92"
 				type: "random"
@@ -1109,10 +1110,6 @@
 			}]
 		}
 		{
-			x: 7.5d
-			y: -2.5d
-			dependencies: ["5EA2D6174BCFEC05"]
-			id: "7C5DBA5626CE7D7D"
 			tasks: [{
 				id: "3AFC4119E51084AA"
 				type: "item"
@@ -1124,6 +1121,10 @@
 					}
 				}
 			}]
+			dependencies: ["5EA2D6174BCFEC05"]
+			id: "7C5DBA5626CE7D7D"
+			y: -2.5d
+			x: 7.5d
 			rewards: [{
 				id: "383B0C2426E21B3D"
 				type: "random"
@@ -1131,27 +1132,6 @@
 			}]
 		}
 		{
-			title: "Tools of Terra"
-			x: 2.0d
-			y: -2.0d
-			description: [
-				"The Terra Shatterer can break a lot of blocks at once."
-				""
-				"Activate its AoE breaking mode by Right Clicking with this item in hand."
-				""
-				"Has tiers:"
-				"> D: 1x1, the starting point."
-				"> C: 1x3 tallshot, needs 0.01 pools worth of Mana."
-				"> B: 3x3, needs 1 pool worth of Mana."
-				"> A: 5x5, needs 10 pools worth of Mana."
-				"> S: 7x7, needs 100 pools worth of Mana."
-				"> SS: 9x9, needs 1000 pools worth of Mana."
-				""
-				"The Terra Truncator can chop entire trees in one swoop."
-				"You can crouch in order to not activate the Terra Truncator's ability."
-			]
-			dependencies: ["300FAC6161C1BCDB"]
-			id: "6B2A5C9F8F92975B"
 			tasks: [
 				{
 					id: "0EBC1A262BACB90E"
@@ -1177,19 +1157,34 @@
 					}
 				}
 			]
+			description: [
+				"The Terra Shatterer can break a lot of blocks at once."
+				""
+				"Activate its AoE breaking mode by Right Clicking with this item in hand."
+				""
+				"Has tiers:"
+				"> D: 1x1, the starting point."
+				"> C: 1x3 tallshot, needs 0.01 pools worth of Mana."
+				"> B: 3x3, needs 1 pool worth of Mana."
+				"> A: 5x5, needs 10 pools worth of Mana."
+				"> S: 7x7, needs 100 pools worth of Mana."
+				"> SS: 9x9, needs 1000 pools worth of Mana."
+				""
+				"The Terra Truncator can chop entire trees in one swoop."
+				"You can crouch in order to not activate the Terra Truncator's ability."
+			]
+			id: "6B2A5C9F8F92975B"
+			x: 2.0d
+			y: -2.0d
+			title: "Tools of Terra"
 			rewards: [{
 				id: "505E41D74DE077F8"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			dependencies: ["300FAC6161C1BCDB"]
 		}
 		{
-			x: 8.5d
-			y: -2.5d
-			subtitle: "A Terraria Reference?"
-			description: ["Swinging the Terra Blade in the air will launch a magical projectile, which does 7 damage and counts as a melee attack."]
-			dependencies: ["5EA2D6174BCFEC05"]
-			id: "05F39EED60B5032B"
 			tasks: [{
 				id: "0B6D9A28B4A9B38C"
 				type: "item"
@@ -1201,29 +1196,19 @@
 					}
 				}
 			}]
+			description: ["Swinging the Terra Blade in the air will launch a magical projectile, which does 7 damage and counts as a melee attack."]
+			id: "05F39EED60B5032B"
+			x: 8.5d
+			y: -2.5d
 			rewards: [{
 				id: "0A3FCD23A10F17C6"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A Terraria Reference?"
+			dependencies: ["5EA2D6174BCFEC05"]
 		}
 		{
-			x: 7.0d
-			y: 2.5d
-			subtitle: "An advanced weapon that can be used against hostile mobs, or players."
-			description: [
-				"The Saber requires power to work, every hit done to an entity will cost 150 Energy."
-				""
-				"The nano saber requires being active to work."
-				""
-				"To toggle the active state the user must shift-right click."
-				""
-				"A chat message will appear saying the new mod that the weapon is in."
-				""
-				"While active, it deals 21 damage and has next to no attack cooldown."
-			]
-			dependencies: ["5EA2D6174BCFEC05"]
-			id: "22260C48A683F434"
 			tasks: [{
 				id: "27F4E72D06FE60DD"
 				type: "item"
@@ -1235,27 +1220,29 @@
 					}
 				}
 			}]
+			description: [
+				"The Saber requires power to work, every hit done to an entity will cost 150 Energy."
+				""
+				"The nano saber requires being active to work."
+				""
+				"To toggle the active state the user must shift-right click."
+				""
+				"A chat message will appear saying the new mod that the weapon is in."
+				""
+				"While active, it deals 21 damage and has next to no attack cooldown."
+			]
+			id: "22260C48A683F434"
+			x: 7.0d
+			y: 2.5d
 			rewards: [{
 				id: "4698E1ACD041553F"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "An advanced weapon that can be used against hostile mobs, or players."
+			dependencies: ["5EA2D6174BCFEC05"]
 		}
 		{
-			title: "Charms"
-			x: -3.0d
-			y: -0.5d
-			subtitle: "A practice or expression believed to have magic powers."
-			description: [
-				"The portal charm will allow the wearer to walk through portals instantly."
-				""
-				"The sleep charm allows the wearer to instantly fall asleep in beds. It will also slowly reduce the insomnia counter which will prevent phantoms from spawning and attacking you."
-				""
-				""
-				"All charms can be worn as trinkets."
-			]
-			dependencies: ["300FAC6161C1BCDB"]
-			id: "5FCACC423BE1EB68"
 			tasks: [{
 				id: "06063381E1AB7D20"
 				type: "item"
@@ -1267,19 +1254,27 @@
 					}
 				}
 			}]
+			description: [
+				"The portal charm will allow the wearer to walk through portals instantly."
+				""
+				"The sleep charm allows the wearer to instantly fall asleep in beds. It will also slowly reduce the insomnia counter which will prevent phantoms from spawning and attacking you."
+				""
+				""
+				"All charms can be worn as trinkets."
+			]
+			id: "5FCACC423BE1EB68"
+			x: -3.0d
+			y: -0.5d
+			title: "Charms"
 			rewards: [{
 				id: "62330D49A92DEA59"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "A practice or expression believed to have magic powers."
+			dependencies: ["300FAC6161C1BCDB"]
 		}
 		{
-			x: 5.0d
-			y: 2.5d
-			subtitle: "Chance to spawn a missile falling at the targeted block."
-			description: ["The missile deals 5 damage and has a 25% chance to deal double damage."]
-			dependencies: ["5EA2D6174BCFEC05"]
-			id: "506164F383491B84"
 			tasks: [{
 				id: "3A1ED13E4F0D7093"
 				type: "item"
@@ -1291,23 +1286,19 @@
 					}
 				}
 			}]
+			description: ["The missile deals 5 damage and has a 25% chance to deal double damage."]
+			id: "506164F383491B84"
+			x: 5.0d
+			y: 2.5d
 			rewards: [{
 				id: "5FA8338565973071"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "Chance to spawn a missile falling at the targeted block."
+			dependencies: ["5EA2D6174BCFEC05"]
 		}
 		{
-			x: 6.0d
-			y: 2.5d
-			subtitle: "THUNDERSTRIKE!"
-			description: [
-				"When a creature is attacked with this sword, a weak chain lightning attack will deal 5 points of damage to a random monster in an 8 block radius, then jump to a next target in the same range around the previous one, dealing 1 less point in damage. "
-				""
-				"This is repeated until 4 enemies are damaged."
-			]
-			dependencies: ["5EA2D6174BCFEC05"]
-			id: "3C2FE1723CE04FB0"
 			tasks: [{
 				id: "6A4DB08A4096EF5A"
 				type: "item"
@@ -1319,17 +1310,34 @@
 					}
 				}
 			}]
+			description: [
+				"When a creature is attacked with this sword, a weak chain lightning attack will deal 5 points of damage to a random monster in an 8 block radius, then jump to a next target in the same range around the previous one, dealing 1 less point in damage. "
+				""
+				"This is repeated until 4 enemies are damaged."
+			]
+			id: "3C2FE1723CE04FB0"
+			x: 6.0d
+			y: 2.5d
 			rewards: [{
 				id: "16175E9E9A906CCA"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "THUNDERSTRIKE!"
+			dependencies: ["5EA2D6174BCFEC05"]
 		}
 		{
-			title: "Gate of Babylon"
-			x: 8.0d
-			y: 2.5d
-			subtitle: "From Boomerangs to Yo-yos, and Spears to Broadswords."
+			tasks: [{
+				id: "01910DCC48E5EAC7"
+				type: "item"
+				item: {
+					id: "itemfilters:mod"
+					Count: 1b
+					tag: {
+						value: "gateofbabylon"
+					}
+				}
+			}]
 			description: [
 				"- Dagger"
 				"A small and nimble weapon. It makes up for short reach with a swift attack speed."
@@ -1364,29 +1372,24 @@
 				"- Boomerang"
 				"Your enemy won't see it coming, quite literally. Dance with grace around your foes as your Boomerang destroys them."
 			]
-			dependencies: ["5EA2D6174BCFEC05"]
 			id: "39491A7F275A02BD"
-			tasks: [{
-				id: "01910DCC48E5EAC7"
-				type: "item"
-				item: {
-					id: "itemfilters:mod"
-					Count: 1b
-					tag: {
-						value: "gateofbabylon"
-					}
-				}
-			}]
+			x: 8.0d
+			y: 2.5d
+			title: "Gate of Babylon"
 			rewards: [{
 				id: "256C020D69DB5CF4"
 				type: "random"
 				table_id: 13756307348121783L
 			}]
+			subtitle: "From Boomerangs to Yo-yos, and Spears to Broadswords."
+			dependencies: ["5EA2D6174BCFEC05"]
 		}
 		{
-			x: 0.0d
-			y: -8.0d
-			subtitle: "Level up!"
+			tasks: [{
+				id: "1DDC754E218E7178"
+				type: "item"
+				item: "toolleveling:tool_leveling_table"
+			}]
 			description: [
 				"The Tool Leveling Table can upgrade enchantments using valuable items."
 				""
@@ -1397,22 +1400,18 @@
 				"The full list of item values can be seen by using the command:"
 				"/toolleveling openitemvalues"
 			]
-			dependencies: ["25B6D9950B1CF03C"]
 			id: "1AC1C7EA2DCBD1C5"
-			tasks: [{
-				id: "1DDC754E218E7178"
-				type: "item"
-				item: "toolleveling:tool_leveling_table"
-			}]
+			x: 0.0d
+			y: -8.0d
 			rewards: [
 				{
-					id: "625878870C7CBBBE"
 					type: "command"
-					title: "Open Item Values"
+					player_command: true
+					id: "625878870C7CBBBE"
 					icon: "minecraft:emerald_block"
+					title: "Open Item Values"
 					exclude_from_claim_all: true
 					command: "/toolleveling openitemvalues"
-					player_command: true
 				}
 				{
 					id: "17612A50CFE813B4"
@@ -1421,20 +1420,21 @@
 					table_id: 13756307348121783L
 				}
 			]
+			subtitle: "Level up!"
+			dependencies: ["25B6D9950B1CF03C"]
 		}
 		{
-			x: 0.0d
-			y: -4.0d
-			subtitle: "[Endgame Item]"
-			description: ["Check out the Endgame tab for more info."]
-			dependencies: ["25B6D9950B1CF03C"]
-			id: "1EE7E1FA12789E34"
 			tasks: [{
 				id: "0C45A1E8EE9BCBE8"
 				type: "item"
 				item: "dark-enchanting:dark_enchanter"
 			}]
+			description: ["Check out the Endgame tab for more info."]
+			id: "1EE7E1FA12789E34"
+			x: 0.0d
+			y: -4.0d
+			subtitle: "[Endgame Item]"
+			dependencies: ["25B6D9950B1CF03C"]
 		}
 	]
-	quest_links: [ ]
 }

--- a/kubejs/assets/ftbquests/lang/en_us.json
+++ b/kubejs/assets/ftbquests/lang/en_us.json
@@ -1,0 +1,264 @@
+{
+    "getting_started.welcome.title": "Welcome to Sky FABRICation 3",
+    "getting_started.welcome.subtitle": "A Whole New Void!",
+    "getting_started.welcome.text.1": "Thanks for playing Sky FABRICation 3.",
+    "getting_started.welcome.text.2": "In this version you have the choice how to start the modpack. You will also have to choose your Origin!",
+    "getting_started.welcome.unlock_inventory": "Unlock Inventory",
+    
+    "getting_started.trinkets.title": "Where are my Trinkets Slots?",
+    "getting_started.trinkets.checkmark": "Inventory Upgrade",
+    "getting_started.trinkets.subtitle": "Use the switch in the upper right of your inventory!",
+    "getting_started.trinkets.text.1": "Inventorio was installed to improve the inventory.",
+    "getting_started.trinkets.text.2": "By default you have a tool-belt and 4 off-hand slots.",
+    "getting_started.trinkets.text.3": "You can switch back to the default inventory by using the switch in the upper right.",
+    "getting_started.trinkets.text.4": "Please give feedback in the Discord Server.",
+    
+    "getting_started.recipe.title": "Recipe Wizardry",
+    "getting_started.recipe.checkmark": "I know how to use U and R",
+    "getting_started.recipe.subtitle": "A recipe is a story that ends with a good meal.",
+    "getting_started.recipe.text.1": "How to use an item? Hover over the item in REI and press \"U\" this will show you the uses, pay attention to the tabs.",
+    "getting_started.recipe.text.2": "Dont know how to craft an item? Hover over the item and press \"R\".",
+    "getting_started.recipe.text.3": "Sometimes you have to start out processing a nugget, instead of an ingot or a block.",
+    "getting_started.recipe.text.4": "You may need to look at the recipes for the material's respective nugget or sometimes even powders.",
+    
+    "getting_started.excavate.title": "Excavate",
+    "getting_started.excavate.checkmark": "Excavate",
+    "getting_started.excavate.subtitle": "Ores Be Gone!",
+    "getting_started.excavate.text.1": "Excavate is by default bound to keybind \"Grave\"",
+    "getting_started.excavate.text.2": "You can change this keybind by going into options and change the FTB Ultimine keybinds.",
+    
+    "getting_started.structures.title": "Where are the Structures?",
+    "getting_started.structures.checkmark": "Where are the Structures?",
+    "getting_started.structures.subtitle": "Structures are not disabled!",
+    "getting_started.structures.text.1": "The Overworld is completely empty, you will not find any structures here.",
+    "getting_started.structures.text.2": "The Nether and some dimensions like the Sky Islands Dimension or the End are full of common and rare structures to discover.",
+    "getting_started.structures.text.3": "Take a look at the Adventurer chapter to find out more detailed information.",
+    
+    "getting_started.emergency.title": "In case of Emergency",
+    "getting_started.emergency.checkmark": "In case of Emergency",
+    "getting_started.emergency.subtitle": "Use the §f§n/emergency§r command in case you lost your only sapling/bamboo/fishing rod, depending on chosen island.",
+    
+    "getting_started.start.title": "Where to start?",
+    "getting_started.start.checkmark": "Learning Mods",
+    "getting_started.start.subtitle": "Follow the Progression Guide to continue!",
+    "getting_started.start.text.1": "Mods are split into 5 categories:",
+    "getting_started.start.text.2": "- Progression\n- Technology\n- Magic\n- Utilities\n- Logistics",
+    "getting_started.start.text.3": "Respectively, each chapter will guide you through progression.",
+    "getting_started.start.text.4": "Certain chapters will have tips and tricks on how to ease your adventures with useful trinkets and gadgets.",
+    
+    "getting_started.void.title": "Fall into the Void",
+    "getting_started.void.checkmark": "Fall into the Void",
+    "getting_started.void.subtitle": "If you fall into the void you will be teleported to the top of the world.",
+    
+    "getting_started.crafting.title": "Crafting on the go",
+    "getting_started.crafting.checkmark": "Crafting on the go",
+    "getting_started.crafting.subtitle": "Only 0.0001 BTC",
+    "getting_started.crafting.text.1": "Tired of having to put that crafting table of yours down any time your tool breaks when mining? Look no more!",
+    "getting_started.crafting.text.2": "Make the Crafting Table On A Stick!",
+    "getting_started.crafting.text.3": "There's also one for the following:",
+    "getting_started.crafting.text.4": "- Anvil\n- Cartography\n- Grindstone\n- Loom\n- Smithing\n- Stonecutter",
+    
+    "the_beginning.tree_island.wood.title": "Collect Wood",
+    "the_beginning.tree_island.wood.subtitle": "Harvest a tree!",
+    
+    "the_beginning.tree_island.water.title": "Water... Need water...",
+    "the_beginning.tree_island.water.subtitle": "Here you will get your water!",
+    "the_beginning.tree_island.water.text.1": "Use this to create water from plant materials.",
+    "the_beginning.tree_island.water.text.2": "Saplings or apples would be a good idea.",
+    
+    "the_beginning.tree_island.barrel.title": "Barrels of Fun",
+    "the_beginning.tree_island.barrel.subtitle": "",
+    "the_beginning.tree_island.barrel.text.1": "At first you should insert some organic materials, this will produce dirt.",
+    "the_beginning.tree_island.barrel.text.2": "Because this barrel is made out of planks, it can leak fluids into a block below.",
+    
+    "the_beginning.tree_island.crook.title": "I am not a crook! Oh wait...",
+    "the_beginning.tree_island.crook.subtitle": "",
+    "the_beginning.tree_island.crook.text.1": "Wooden crooks are a staple to getting silk worms and higher chance for saplings from all trees.",
+    "the_beginning.tree_island.crook.text.2": "There are many crooks with varying durability.",
+    
+    "the_beginning.tree_island.silkworm.title": "There is an infestation!",
+    "the_beginning.tree_island.silkworm.subtitle": "",
+    "the_beginning.tree_island.silkworm.text.1": "Silkworms drop from leaves broken using a crook.",
+    "the_beginning.tree_island.silkworm.text.2": "Can be cooked for food, or used on leaves to infest them.",
+    "the_beginning.tree_island.silkworm.text.3": "Infested leaves will drop strings, but not saplings.",
+    
+    "the_beginning.fishing_island.fishing.title": "Fishing and Chill",
+    
+    "the_beginning.fishing_island.driftwood.title": "Driftwood",
+    "the_beginning.fishing_island.driftwood.subtitle": "You can sometimes fish up some Oak Logs, Oak Planks and Dirt.",
+    
+    "the_beginning.fishing_island.fishing_rod.title": "In case your Fishing Rod broke",
+    "the_beginning.fishing_island.fishing_rod.subtitle": "",
+    "the_beginning.fishing_island.fishing_rod.text.1": "This quest is repeatable - meaning that you can always get a new Fishing Rod every 5 XP Levels gained!",
+    
+    "the_beginning.bamboo_island.bamboo.title": "Bamboozled",
+    "the_beginning.bamboo_island.bamboo.subtitle": "",
+    "the_beginning.bamboo_island.bamboo.text.1": "Spam the sneak key to make your bamboo grow faster.",
+    
+    "the_beginning.bamboo_island.axe.subtitle": "You can strip Bamboo by right clicking with a axe.",
+    "the_beginning.bamboo_island.axe.text.1": "Craft one of these to complete this quest.\n(TiC tools do not need to be assembled like in the task.)",
+    "the_beginning.bamboo_island.axe.text.2": "If the quest doesn't complete, throw the item on the ground and pick it up, or move it around in the inventory.",
+    
+    "the_beginning.bamboo_island.stripped_bamboo.subtitle": "You will need some Stripped Bamboo for making barrels and sieves.",
+    
+    "the_beginning.bamboo_island.barrel.title": "Tiki Barrel",
+    "the_beginning.bamboo_island.barrel.subtitle": "",
+    "the_beginning.bamboo_island.barrel.text.1": "You farmed so much compost, why not use some to obtain more Dirt?",
+    
+    "the_beginning.bamboo_island.skeletons.title": "Spooky Scary Skeletons",
+    "the_beginning.bamboo_island.skeletons.subtitle": "You need something harder than elastic bamboo.",
+    "the_beginning.bamboo_island.skeletons.text.1": "You will need some Bones for the Bone Crucible.",
+    
+    "the_beginning.bamboo_island.bone_knife.subtitle": "Peace was never an option.",
+    "the_beginning.bamboo_island.bone_knife.text.1": "The Bone Knife can be used to carve out a Crucible from a Bone Block.",
+    "the_beginning.bamboo_island.bone_knife.text.2": "It can also be used as a rudimentary weapon.",
+    
+    "the_beginning.bamboo_island.water.subtitle": "Suprisingly, Bone Crucible can't hold lava.",
+    "the_beginning.bamboo_island.water.text.1": "But nevertheless, you can use some of your Bamboo Leaves to make water.",
+    "the_beginning.bamboo_island.water.text.2": "To make a Bone Crucible, Right-Click on a Bone Block with a Bone Knife in hand.",
+    
+    "the_beginning.wooden_hopper.title": "Early Automation",
+    
+    "the_beginning.crafting.title": "Crafting",
+    "the_beginning.crafting.subtitle": "Necessary to craft 3x3 recipes.",
+    "the_beginning.crafting.text.1": "Crafting Stations can hold items inside, and can utilize items from the inventory next to it!",
+    
+    "the_beginning.spiders.title": "Those pesky arthopods!",
+    "the_beginning.spiders.subtitle": "",
+    "the_beginning.spiders.text.1": "You probably feared them at least once.\n\nHere, you need to kill those pesky Spiders to obtain some String.",
+    
+    "the_beginning.string.title": "Strung for Strings",
+    "the_beginning.string.subtitle": "",
+    "the_beginning.string.text.1": "Quite important to make a White bed early, especially with those Phant0ms out there.",
+    
+    "the_beginning.sieve.title": "To get more materials",
+    "the_beginning.sieve.subtitle": "",
+    "the_beginning.sieve.text.1": "This is your basic way to get materials, insert mesh, sieve a valid material and get resources, its that simple!",
+    "the_beginning.sieve.text.2": "Putting multiple sieves side by side acts as a multiblock structure, letting you sieve in bulk, up to 25 Sieves at once! (in a 5x5 square).",
+    "the_beginning.sieve.text.3": "Later you will be able to use a Deployer or a Click Machine to automate it.\nNote that it can be tricky - because fake players can also unequip Meshes from the Sieve, which breaks the whole automation!",
+    "the_beginning.sieve.text.4": "A Sieve can be water-logged.",
+    
+    "the_beginning.dirt_sieve.title": "A Dirt-y idea.",
+    "the_beginning.dirt_sieve.subtitle": "",
+    "the_beginning.dirt_sieve.text.1": "These seeds can be obtained by sieving dirt or sand.",
+    "the_beginning.dirt_sieve.text.2": "Ancient Spores will turn Dirt to Mycelium.\nGrass Seed will turn Dirt to a Grass Block.",
+    
+    "the_beginning.witchwater.title": "Fluid Transformation",
+    "the_beginning.witchwater.subtitle": "",
+    "the_beginning.witchwater.text.1": "Fluid Transformation is required to receive some resources.",
+    "the_beginning.witchwater.text.2": "This quest will explain how to get those fluids. Later quests will explain what they can do.",
+    "the_beginning.witchwater.text.3": "To get Witchwater, you can do one of the following:\n- Right-Click a barrel full of water with some Ancient Spores in hand - instant transformation,\n- Insert water into a barrel placed above Mycelium - this will slowly transform water into Witchwater.",
+    
+    "the_beginning.dolls.title": "Summoning and Transforming mobs",
+    "the_beginning.dolls.subtitle": "",
+    "the_beginning.dolls.text.1": "Summoning and Transforming mobs is a feature of FabricaeExNihilo!",
+    "the_beginning.dolls.text.2": "Using Witchwater, you can transform mobs into scarier, stonger variants:",
+    "the_beginning.dolls.text.3": "- Villagers -> Witches,\n- Creepers -> Charged Creepers,\n- Squids -> Ghasts,\n- Skeletons -> Wither Skeletons.",
+    "the_beginning.dolls.text.4": "You can also use dolls to summon mobs using barrels.\nYou can see the required fluid in the barrel in the \"Alchemy\" section in REI - just right-click the doll in REI or press \"U\" while hovering over it!",
+    
+    "the_beginning.dirt_farm.title": "A Dirt Farm?",
+    "the_beginning.dirt_farm.subtitle": "",
+    "the_beginning.dirt_farm.text.1": "You can use Witchwater to generate infinite Dirt.\nBy using Witchwater and regular Water in the configuration below, it will generate Dirt and sometimes Podzol!",
+    
+    "the_beginning.create_sifter.subtitle": "Automated Sieving!",
+    "the_beginning.create_sifter.text.1": "It will automatically sieve items inserted into it.\n\nMechanically similar to a Millstone.\n\nFabricaeExNihilo Meshes won't work here - using Crafting you can switch between FabricaeExNihilo and Create Sifter variants of meshes.\n\nPlease Note: You need some sort of a blacklistable item extraction (like Brass Funnels or Smart Chutes), because without filtering it will extract currently sieved items!\n\nA huge advantage of the Sifter is the fact that it will not automatically unequip meshes nor it will spill out items into the world.\n\nThe Sifter can also be Waterlogged to process certain recipes.",
+    
+    "the_beginning.cobblestone.title": "Simply Cobble",
+    "the_beginning.cobblestone.subtitle": "Sieving for Pebbles!",
+    "the_beginning.cobblestone.text.1": "Cobblestone, the most basic, and useful block for Skyblock since it's beginning.",
+    "the_beginning.cobblestone.text.2": "You can put 4 pebbles in the crafting table to get cobblestone or other stones like andesite, diorite, granite and much more.",
+    
+    "the_beginning.stone_barrel.subtitle": "A barrel made out of solid stone.",
+    "the_beginning.stone_barrel.text.1": "This barrel can withstand lava!",
+    "the_beginning.stone_barrel.text.2": "You will surely find it useful when automating Obsidian or Stone.",
+    
+    "the_beginning.blood.title": "Barrel Enchanting",
+    "the_beginning.blood.subtitle": "",
+    "the_beginning.blood.text.1": "Once you get your hands on an Enchantment Table, you can try to enchant a Barrel with Thorns.",
+    "the_beginning.blood.text.2": "If you stand on it, it will produce blood while damaging you.\nIt works with mobs as well.",
+    
+    "the_beginning.stone_hammer.title": "Time to Grind",
+    "the_beginning.stone_hammer.subtitle": "",
+    "the_beginning.stone_hammer.text.1": "To get the next 3 sieving materials, you have to hammer them.\n\nSimply place the block down and break them with the hammer.\n\nREI will show the blocks that can be broken.\n\nCobble > Gravel > Sand > Silt > Dust",
+    
+    "the_beginning.salt_brine.title": "Time to Grind",
+    "the_beginning.salt_brine.subtitle": "Use a bottle on a Sand block to get Salt.",
+    
+    "the_beginning.dust.title": "This is not even my final form!",
+    "the_beginning.dust.subtitle": "",
+    "the_beginning.dust.text.1": "The only way to transform dust beyond, is to either sieve into materials, or turn it into clay.\n\nYou could also made it into lava... but compared to cobblestone, dust gives 1/5 the amount of lava. So not a wise choice.",
+    
+    "the_beginning.crucible.title": "Crucial Crucible",
+    "the_beginning.crucible.subtitle": "",
+    "the_beginning.crucible.text.1": "Crucible are the tip of the iceberg (or in this case volcano) when it comes to lava production.\n\nIt needs a heat source under it to function.\n\nTorch, Fire, Lava, and some blocks provide their own level of heat.",
+    "the_beginning.crucible.text.2": "Once heated you can put or pump materials into the crucible(s), some materials provide more lava then others.\n\nThis can potentionally be use as a power free AFK lava generator.",
+    
+    "the_beginning.heat_sources.title": "Heat Sources",
+    "the_beginning.heat_sources.subtitle": "",
+    "the_beginning.heat_sources.text.1": "Heat Sources can be seen from pressing U while hovering your mouse over a crucible.",
+    
+    "the_beginning.lava.title": "Blocks for Lava?",
+    "the_beginning.lava.subtitle": "",
+    "the_beginning.lava.text.1": "Lava production not only needs heat, but also needs blocks for production.\n\nPressing U while hovering over the crucible in the inventory, will show what it can take.",
+    "the_beginning.lava.text.2": "Cobblestone is the most common use in the past that produces 1/4 bucket per block of lava.\n\nBut Obsidian and Netherrack makes a whole bucket of lava.",
+    
+    "the_beginning.breaker.text.1": "This Block Breaker can be used to hammer e.g. cobblestone to gravel.",
+    
+    "the_beginning.cobblegen.title": "All the cobble gens!",
+    "the_beginning.cobblegen.subtitle": "",
+    "the_beginning.cobblegen.text.1": "There are many cobble generators in this modpack.\n\nFrom Vanilla, to Kibe's Cobble Gens.\n\nFeel free to choose what you like.",
+    
+    "the_beginning.nether.title": "We need to go deeper!",
+    "the_beginning.nether.subtitle": "",
+    "the_beginning.nether.text.1": "Other Dimensions like the Nether are not empty. You can discover some structures there.",
+    
+    "the_beginning.nether_fungi.title": "Nether Fungi",
+    "the_beginning.nether_fungi.subtitle_nether": "You will need these to get Shroomlights.",
+    "the_beginning.nether_fungi.subtitle_mesh": "Obtain a Nether Fungus!",
+    "the_beginning.nether_fungi.text.1_nether": "Obtain one of these items to complete this quest.",
+    "the_beginning.nether_fungi.text.1_mesh": "You can use Bone Meal on the Netherrack next to a Crimson/Warped Nylium to spread it to that Netherrack block.\n\nYou can apply Bone Meal onto Crimson/Warped Nylium to get various Nether vegetation, including Nether fungi.",
+    
+    "the_beginning.hephaestus.title": "I am Grout!",
+    "the_beginning.hephaestus.subtitle": "Hephaestus is here (Fabric port of TConstruct, BETA)",
+    "the_beginning.hephaestus.text.1": "Hephaestus - the ancient Greek god of Smithing.\n\nFeel free to try out Hephaestus, the Tinkers Construct port for Fabric.\nIts not fully included in the modpack, so some recipes are currently missing.",
+    
+    "the_beginning.saplings.title": "Saplings!",
+    "the_beginning.saplings.subtitle": "Collect them all!",
+    
+    "the_beginning.crook2.title": "Am I a crook?",
+    "the_beginning.crook2.subtitle": "No Sapling yet?",
+    "the_beginning.crook2.text.1": "By sieving Dirt, you can finally get a Sapling.",
+    "the_beginning.crook2.text.2": "Break leaves using Crooks to get Silkworms. You will also get more saplings than you would get by breaking by hand!",
+    
+    "the_beginning.string_mesh.subtitle": "",
+    "the_beginning.string_mesh.text.1": "Meshes have been given an upgrade since we last encountered them, now going up to Netherite!",
+    "the_beginning.string_mesh.text.2": "Note that Emerald mesh won't upgrade to Netherite.",
+    
+    "the_beginning.quartz.subtitle": "You will need some Nether Quartz for your next mesh.",
+    "the_beginning.quartz.text.1": "It can be obtained by sieving Soul Sand through a Flint Mesh.",
+    "the_beginning.quartz.text.2": "But how do you get Soul Sand?\n\nThe answer is: Witchwater!",
+    
+    "the_beginning.netherite_mesh.subtitle": "",
+    "the_beginning.netherite_mesh.text.1": "To get Ancient Debris for Netherite, you can use:\n> Botania's Orechid Ignem,\n> Modern Industrialization's Electric Quarry with Golden Drills,\nor you can plunder chests found in Nether Structures, especially Bastions and Nether \"End Ships\".",
+    "the_beginning.netherite_mesh.text.2": "After you collect a stack of Ancient Debris, you can make an IndRev Mining Rig to provide you with unlimited Ancient Debris!\n\nUsed to get Uraninite for Powah!. And only for that.",
+    
+    "the_beginning.gold.title": "How to obtain Gold?",
+    "the_beginning.gold.subtitle": "",
+    "the_beginning.gold.text.1": "The Quest Book will not tell you how to get each material.\nInstead, you have to find your own way. By using REI you should be able to find the answers.",
+    "the_beginning.gold.text.2": "Some materials like gold can be obtained in multiple ways.\nGold can be found in the Nether, but later you should build a automated gold production with the Create mod.",
+    
+    "the_beginning.alloy_forge.title": "Alloy Forge",
+    "the_beginning.alloy_forge.subtitle": "Expensive, but it's your first choice to smelt alloys.",
+    "the_beginning.alloy_forge.controller": "Prismarine or End Stone Forge Controller",
+    "the_beginning.alloy_forge.build": "Build a Prismarine Alloy Forge",
+    
+    "the_beginning.andesite_alloy.title": "What do I do with my Andesite?",
+    "the_beginning.andesite_alloy.subtitle": "Andesite and Iron open you the door to the Mechanical Age!",
+    
+    "the_beginning.shroomlight.subtitle": "You will need this later for Mechanical Age progression.",
+    
+    "the_beginning.spores.title": "Spores",
+    "the_beginning.spores.subtitle": "Bring a part of The Nether to your home island.",
+    "the_beginning.spores.text.1": "Use one of these on the Netherrack Block to turn it into Crimson/Warped Nylium.",
+    "the_beginning.spores.text.2": "Obtain Crimson or Warped Spores to complete this quest."
+}

--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -168,8 +168,16 @@ onEvent('item.tooltip', tooltip => {
 	})
 
     const toContain = [
-		"Looting", "Luck"
-	] 
+		Text.translate("enchantment.minecraft.looting").getString(),
+		Text.translate("modifier.tconstruct.luck.1").getString(),
+		Text.translate("modifier.tconstruct.luck.2").getString(),
+		Text.translate("modifier.tconstruct.luck.3").getString()
+	]
+
+	if (Text.translate("enchantment.minecraft.looting").getString() != Text.translate("modifier.tconstruct.looting").getString()) {
+		toContain.push(Text.translate("modifier.tconstruct.looting").getString())
+	}
+	
 	onEvent('item.tooltip', event => {
 		event.addAdvanced(/^tconstruct:.*/, (stack, a, text) => {
 			let del_indexes = [];
@@ -180,7 +188,7 @@ onEvent('item.tooltip', tooltip => {
 				toContain.forEach(e => {
 					if(k.contains(e)) {
 						matches++;
-						if (e == "Looting") {del_indexes.push(i);}
+						if (e == Text.translate("enchantment.minecraft.looting").getString() || e == Text.translate("modifier.tconstruct.looting").getString()) {del_indexes.push(i);}
 				}
 				});
 			}

--- a/kubejs/server_scripts/first_login.js
+++ b/kubejs/server_scripts/first_login.js
@@ -9,6 +9,7 @@ var firstJoinMessage = "Welcome to Sky FABRICation 3, open the Quest-Book and cl
 
 onEvent('player.logged_in', event => {
   console.log("login script started ...");
+  event.player.runCommandSilent('kubejs reload client_scripts')
   if (!event.player.getTags().contains('first_login'))
   {
   	// Add the gamestage


### PR DESCRIPTION
This PR will bring support for translating quests!

At a time of writing this, Getting Started and The Beginning are fully un-localized and use placeholders instead.

Translations are present in `minecraft/kubejs/assets/ftbquests/lang/<your language>.json`.

Some guidelines:
Translations are in the form of `<chapter>.<quest>.<fragment>`, where `<fragment>` is either `<title>`, `<subtitle>`, `<text.N>` for quest descriptions or something different depending on needs.

To use a translation in quests, set the text of title/subtitle/description in FTB Quests to `{<chapter>.<quest>.<fragment>}`.

For example - the title of the Welcome text in Getting Started chapter has `{getting_started.welcome.title}` as a title, and this is also present in the lang file.

If a language does not have a translation string, it will fall back to en_US, then to unlocalized.

Some quests have the title automatically grabbed from the item name, for this you need to write a translation for a mod the item comes from.


